### PR TITLE
Add typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,50 @@
+// Type definitions for jss.
+export type RuleType = { [rule: string]: any } | Object;
+export type RulesType = { [name: string]: RuleType } | Object;
+export type Plugin = (rules: RulesType) => void;
+
+export interface StyleSheetOptions {
+  media?: string;
+  meta?: string;
+  named?: boolean;
+  link?: boolean;
+  element?: HTMLStyleElement;
+}
+
+export interface SetupOptions {
+  generateClassName?: (stylesStr: string, rule: Rule) => string;
+  plugins?: Array<Plugin>;
+}
+
+export interface Rule {
+  applyTo(element: HTMLElement): void;
+  prop(name: string, value?: string): string;
+  toJSON(): string;
+}
+
+export interface StyleSheet {
+  classes: any;
+  attach(): void;
+  detach(): void;
+  toString(): string;
+  options: StyleSheetOptions;
+  addRule(selector: string, rule: RuleType, options?: StyleSheetOptions): Rule;
+  addRule(rule: RuleType, options?: StyleSheetOptions): Rule;
+}
+
+export interface Registry {
+  registry:  Array<StyleSheet>;
+  toString(): string;
+}
+
+export class Jss {
+  setup(options: SetupOptions): void;
+  use(...plugin: Array<Plugin>): void;
+  createStyleSheet(rules?: RulesType, options?: StyleSheetOptions): StyleSheet;
+  createRule(selector: string, rule: RuleType): Rule;
+  createRule(rule: RuleType): Rule;
+  sheets: Registry;
+}
+
+export function create(options?: SetupOptions): Jss;
+export default create();


### PR DESCRIPTION
I'm using `jss` with `typescript`, it would be great to have the `typescript` definitions right in the repository.

I made the definitions from the api docs and briefly compared with the actual implementation for mistakes. Can someone double check this? I am especially unsure about the type of `element` in `StyleSheetOptions`.

I placed this file directly in the root folder where it will be automatically picked up by typescript. Alternatively we can put it in `src` and [add the path](http://www.typescriptlang.org/docs/handbook/typings-for-npm-packages.html) to the `package.json` file. I wasn't sure if I have to tweak the build scripts for this.