### PR TITLE
Fix typo in dom renderer

### DIFF
--- a/src/backends/DomRenderer.js
+++ b/src/backends/DomRenderer.js
@@ -70,7 +70,7 @@ export default class DomRenderer {
    */
   attach() {
     // In the case the element node is external and it is already in the DOM.
-    if (this.element.parendNode) return
+    if (this.element.parentNode) return
     this.head.appendChild(this.element)
   }
 


### PR DESCRIPTION
`jss` would definitely benefit from a better test suite, would help avoid little things like this typo 👍 

If we end up using `jss` I can certainly help with that!