### PR TITLE
Add DOM priority feature via index option

### DIFF
--- a/docs/js-api.md
+++ b/docs/js-api.md
@@ -71,6 +71,7 @@ Options:
 - `named` true by default - keys are names, selectors will be generated, if false - keys are global selectors.
 - `link` link jss `Rule` instances with DOM `CSSRule` instances so that styles, can be modified dynamically, false by default because it has some performance cost.
 - `element` style element, will create one by default
+- `index` 0 by default - determines DOM rendering order, higher number = higher specificity (inserted after)
 
 
 ```javascript

--- a/docs/js-api.md
+++ b/docs/js-api.md
@@ -6,6 +6,7 @@
 1. [Create regular style sheet with global selectors.](#create-regular-style-sheet-with-global-selectors)
 1. [Attach style sheet.](#attach-style-sheet)
 1. [Detach style sheet.](#detach-style-sheet)
+1. [Attach style sheets in a specific order.](#attach-style-sheets-in-a-specific-order)
 1. [Add a rule to an existing style sheet.](#add-a-rule-to-an-existing-style-sheet)
 1. [Delete a rule from an existing style sheet.](#delete-a-rule-from-an-existing-style-sheet)
 1. [Add a rule dynamically with a generated class name.](#add-a-rule-dynamically-with-a-generated-class-name)
@@ -142,6 +143,20 @@ Insert style sheet into the render tree. You need to call it in order to make yo
 `sheet.detach()`
 
 Detaching unused style sheets will speedup every DOM node insertion and manipulation as the browser will have to do less lookups for css rules potentially to be applied to the element.
+
+### Attach style sheets in a specific order.
+
+Sheet 1 has a higher index (priority), and as such will come **after** sheet 2 in the resulting DOM.
+
+```javascript
+const sheet1 = jss.createStyleSheet({}, {index: 5, meta: 'sheet-1'}).attach()
+const sheet2 = jss.createStyleSheet({}, {index: 1, meta: 'sheet-2'}).attach()
+```
+
+```html
+<style type="text/css" data-meta="sheet-2"></style>
+<style type="text/css" data-meta="sheet-1"></style>
+```
 
 ### Add a rule to an existing style sheet.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -44,6 +44,19 @@ sheet.attach()
 sheet.toString()
 ```
 
+## Specify DOM insertion point
+
+You can instruct `jss` to render your stylesheets starting at a specific point in the DOM by placing a comment node anywhere in the `head` of the document.
+
+This can be useful if you have another dependency that needs to come before or after the `jss` style sheets for cascading specificity purposes.
+
+```html
+<head>
+    <title>JSS</title>
+    <!-- jss -->
+</head>
+```
+
 ## CLI
 
 For more information see [CLI](https://github.com/cssinjs/jss-cli).

--- a/src/SheetsRegistry.js
+++ b/src/SheetsRegistry.js
@@ -17,7 +17,7 @@ export default class SheetsRegistry {
   add(sheet) {
     const {registry} = this
 
-    if (!registry.length || typeof sheet.options.index !== 'number') {
+    if (!registry.length) {
       registry.push(sheet)
       return
     }
@@ -30,6 +30,7 @@ export default class SheetsRegistry {
       }
     }
 
+    // Higher priority than any sheets in registry, so push on the end
     registry.push(sheet)
   }
 

--- a/src/SheetsRegistry.js
+++ b/src/SheetsRegistry.js
@@ -15,7 +15,21 @@ export default class SheetsRegistry {
    * @api public
    */
   add(sheet) {
-    this.registry.push(sheet)
+    const {registry} = this
+
+    if (registry.length && sheet.options.index) {
+      for (let i = 0; i < registry.length; i++) {
+        const registration = registry[i]
+        if (
+          !registration.options.index ||
+          registration.options.index < sheet.options.index
+        ) continue
+        registry.splice(i, 0, sheet)
+        return
+      }
+    }
+
+    registry.push(sheet)
   }
 
   /**

--- a/src/SheetsRegistry.js
+++ b/src/SheetsRegistry.js
@@ -17,13 +17,14 @@ export default class SheetsRegistry {
   add(sheet) {
     const {registry} = this
 
-    if (registry.length && sheet.options.index) {
-      for (let i = 0; i < registry.length; i++) {
-        const registration = registry[i]
-        if (
-          !registration.options.index ||
-          registration.options.index < sheet.options.index
-        ) continue
+    if (!registry.length || typeof sheet.options.index !== 'number') {
+      registry.push(sheet)
+      return
+    }
+
+    for (let i = 0; i < registry.length; i++) {
+      const {options} = registry[i]
+      if (options.index > sheet.options.index) {
         registry.splice(i, 0, sheet)
         return
       }

--- a/src/SheetsRegistry.js
+++ b/src/SheetsRegistry.js
@@ -16,22 +16,20 @@ export default class SheetsRegistry {
    */
   add(sheet) {
     const {registry} = this
+    const {index} = sheet.options
 
-    if (!registry.length) {
+    if (!registry.length || index >= registry[registry.length - 1].options.index) {
       registry.push(sheet)
       return
     }
 
     for (let i = 0; i < registry.length; i++) {
       const {options} = registry[i]
-      if (options.index > sheet.options.index) {
+      if (options.index > index) {
         registry.splice(i, 0, sheet)
         return
       }
     }
-
-    // Higher priority than any sheets in registry, so push on the end
-    registry.push(sheet)
   }
 
   /**

--- a/src/StyleSheet.js
+++ b/src/StyleSheet.js
@@ -24,6 +24,7 @@ export default class StyleSheet {
   constructor(rules, options) {
     this.options = {...options}
     if (this.options.named == null) this.options.named = true
+    if (typeof this.options.index !== 'number') this.options.index = 0
     // Rules registry for access by .getRule() method.
     // It contains the same rule registered by name and by class name.
     this.rules = Object.create(null)

--- a/src/backends/DomRenderer.js
+++ b/src/backends/DomRenderer.js
@@ -85,8 +85,8 @@ export default class DomRenderer {
           const sheet = registry[i]
           if (
             !sheet.attached ||
-            !sheet.options.index ||
-            sheet.options.index < index
+            typeof sheet.options.index !== 'number' ||
+            sheet.options.index <= index
           ) continue
           anchorEl = sheet.renderer.element
           break
@@ -96,9 +96,9 @@ export default class DomRenderer {
       // Otherwise insert after the last attached
       if (!anchorEl) {
         for (let i = registry.length - 1; i >= 0; i--) {
-          const registrySheet = registry[i]
-          if (registrySheet.attached) {
-            anchorEl = registrySheet.renderer.element.nextElementSibling
+          const sheet = registry[i]
+          if (sheet.attached) {
+            anchorEl = sheet.renderer.element.nextElementSibling
             break
           }
         }
@@ -107,9 +107,9 @@ export default class DomRenderer {
 
     if (!anchorEl) {
       // Try find a comment placeholder if registry is empty
-      for (let i = 0; i < document.head.childNodes.length; i++) {
-        const el = document.head.childNodes[i]
-        if (el.nodeType === 8 && el.nodeValue === 'jss') {
+      for (let i = 0; i < this.head.childNodes.length; i++) {
+        const el = this.head.childNodes[i]
+        if (el.nodeValue === 'jss') {
           anchorEl = el
           break
         }

--- a/src/backends/DomRenderer.js
+++ b/src/backends/DomRenderer.js
@@ -18,6 +18,7 @@ export default class DomRenderer {
     this.head = document.head || document.getElementsByTagName('head')[0]
     this.element = element || document.createElement('style')
     this.element.type = 'text/css'
+    this.element.setAttribute('data-jss', '')
     if (media) this.element.setAttribute('media', media)
     if (meta) this.element.setAttribute('data-meta', meta)
   }
@@ -71,7 +72,51 @@ export default class DomRenderer {
   attach() {
     // In the case the element node is external and it is already in the DOM.
     if (this.element.parentNode) return
-    this.head.appendChild(this.element)
+
+    let anchorEl = null
+
+    const {index, jss} = this.options
+    const {registry} = jss.sheets
+
+    if (registry.length > 1) {
+      // Try to insert by index if set
+      if (typeof index === 'number') {
+        for (let i = 0; i < registry.length; i++) {
+          const sheet = registry[i]
+          if (
+            !sheet.attached ||
+            !sheet.options.index ||
+            sheet.options.index < index
+          ) continue
+          anchorEl = sheet.renderer.element
+          break
+        }
+      }
+
+      // Otherwise insert after the last attached
+      if (!anchorEl) {
+        for (let i = registry.length - 1; i >= 0; i--) {
+          const registrySheet = registry[i]
+          if (registrySheet.attached) {
+            anchorEl = registrySheet.renderer.element.nextElementSibling
+            break
+          }
+        }
+      }
+    }
+
+    if (!anchorEl) {
+      // Try find a comment placeholder if registry is empty
+      for (let i = 0; i < document.head.childNodes.length; i++) {
+        const el = document.head.childNodes[i]
+        if (el.nodeType === 8 && el.nodeValue === 'jss') {
+          anchorEl = el
+          break
+        }
+      }
+    }
+
+    this.head.insertBefore(this.element, anchorEl)
   }
 
   /**

--- a/tests/functional/priority.js
+++ b/tests/functional/priority.js
@@ -2,7 +2,7 @@ import expect from 'expect.js'
 import {create} from 'jss'
 import {reset} from '../utils'
 
-describe('Integration: dom priority', () => {
+describe('Functional: dom priority', () => {
   function createDummySheets() {
     for (let i = 0; i < 2; i++) {
       const dummySheet = document.createElement('style')
@@ -147,6 +147,64 @@ describe('Integration: dom priority', () => {
       expect(styleElements[5].getAttribute('data-meta')).to.be('sheet4')
 
       expect(styleElements[6].getAttribute('data-test-dummy')).to.be('dummy2')
+    })
+  })
+
+  describe('with zero and negative indices', () => {
+    let jss
+
+    beforeEach(() => {
+      jss = create()
+    })
+    afterEach(() => {
+      reset(jss)
+    })
+
+    it('should insert sheets in the correct order', () => {
+      jss.createStyleSheet({}, {meta: 'sheet1', index: 0}).attach()
+      jss.createStyleSheet({}, {meta: 'sheet2', index: -5}).attach()
+      jss.createStyleSheet({}, {meta: 'sheet3', index: -999}).attach()
+      jss.createStyleSheet({}, {meta: 'sheet4', index: 3}).attach()
+      jss.createStyleSheet({}, {meta: 'sheet5', index: 312}).attach()
+
+      const styleElements = document.head.getElementsByTagName('style')
+
+      expect(styleElements.length).to.be(5)
+
+      expect(styleElements[0].getAttribute('data-meta')).to.be('sheet3')
+      expect(styleElements[1].getAttribute('data-meta')).to.be('sheet2')
+      expect(styleElements[2].getAttribute('data-meta')).to.be('sheet1')
+      expect(styleElements[3].getAttribute('data-meta')).to.be('sheet4')
+      expect(styleElements[4].getAttribute('data-meta')).to.be('sheet5')
+    })
+  })
+
+  describe('with multiple sheets using the same index', () => {
+    let jss
+
+    beforeEach(() => {
+      jss = create()
+    })
+    afterEach(() => {
+      reset(jss)
+    })
+
+    it('should insert sheets with the same index after existing', () => {
+      jss.createStyleSheet({}, {meta: 'sheet1', index: 50}).attach()
+      jss.createStyleSheet({}, {meta: 'sheet2', index: 40}).attach()
+      jss.createStyleSheet({}, {meta: 'sheet3', index: 40}).attach()
+      jss.createStyleSheet({}, {meta: 'sheet4', index: 20}).attach()
+      jss.createStyleSheet({}, {meta: 'sheet5', index: 40}).attach()
+
+      const styleElements = document.head.getElementsByTagName('style')
+
+      expect(styleElements.length).to.be(5)
+
+      expect(styleElements[0].getAttribute('data-meta')).to.be('sheet4')
+      expect(styleElements[1].getAttribute('data-meta')).to.be('sheet2')
+      expect(styleElements[2].getAttribute('data-meta')).to.be('sheet3')
+      expect(styleElements[3].getAttribute('data-meta')).to.be('sheet5')
+      expect(styleElements[4].getAttribute('data-meta')).to.be('sheet1')
     })
   })
 })

--- a/tests/functional/sheet.js
+++ b/tests/functional/sheet.js
@@ -130,6 +130,21 @@ describe('Functional: sheet', () => {
     })
   })
 
+  describe('Option: {index}', () => {
+    it('should be 0 by default', () => {
+      const sheet = jss.createStyleSheet({})
+      expect(sheet.options.index).to.be(0)
+    })
+
+    it('should be set by the options argument', () => {
+      [-50, 0, 50, 9999].forEach((n) => {
+        const sheet2 = jss.createStyleSheet({}, { index: n })
+        expect(sheet2.options.index).to.be(n)
+      });
+    })
+  })
+
+
   describe('.addRule() to an unnamed sheet', () => {
     let sheet
     let rule

--- a/tests/functional/sheet.js
+++ b/tests/functional/sheet.js
@@ -138,9 +138,9 @@ describe('Functional: sheet', () => {
 
     it('should be set by the options argument', () => {
       [-50, 0, 50, 9999].forEach((n) => {
-        const sheet2 = jss.createStyleSheet({}, { index: n })
+        const sheet2 = jss.createStyleSheet({}, {index: n})
         expect(sheet2.options.index).to.be(n)
-      });
+      })
     })
   })
 

--- a/tests/integration/priority.js
+++ b/tests/integration/priority.js
@@ -1,0 +1,152 @@
+import expect from 'expect.js'
+import {create} from 'jss'
+import {reset} from '../utils'
+
+describe('Integration: dom priority', () => {
+  function createDummySheets() {
+    for (let i = 0; i < 2; i++) {
+      const dummySheet = document.createElement('style')
+      dummySheet.type = 'text/css'
+      dummySheet.setAttribute('data-test-dummy', `dummy${i + 1}`)
+      document.head.appendChild(dummySheet)
+    }
+  }
+
+  function removeDummySheets() {
+    const dummySheets = document.head.querySelectorAll('[data-test-dummy]')
+    for (let i = 0; i < dummySheets.length; i++) {
+      document.head.removeChild(dummySheets[i])
+    }
+  }
+
+  describe('without a comment node', () => {
+    let jss
+
+    beforeEach(() => {
+      createDummySheets()
+      jss = create()
+    })
+    afterEach(() => {
+      removeDummySheets()
+      reset(jss)
+    })
+
+    it('should append sheets to the end of the document head after other stylesheets', () => {
+      jss.createStyleSheet({}, {meta: 'sheet1', index: 50}).attach()
+      jss.createStyleSheet({}, {meta: 'sheet2', index: 1}).attach()
+      jss.createStyleSheet({}, {meta: 'sheet3', index: 40}).attach()
+      jss.createStyleSheet({}, {meta: 'sheet4', index: 75}).attach()
+      jss.createStyleSheet({}, {meta: 'sheet5', index: 35}).attach()
+
+      const styleElements = document.head.getElementsByTagName('style')
+
+      expect(styleElements.length).to.be(7)
+
+      expect(styleElements[0].getAttribute('data-test-dummy')).to.be('dummy1')
+      expect(styleElements[1].getAttribute('data-test-dummy')).to.be('dummy2')
+
+      expect(styleElements[2].getAttribute('data-meta')).to.be('sheet2')
+      expect(styleElements[3].getAttribute('data-meta')).to.be('sheet5')
+      expect(styleElements[4].getAttribute('data-meta')).to.be('sheet3')
+      expect(styleElements[5].getAttribute('data-meta')).to.be('sheet1')
+      expect(styleElements[6].getAttribute('data-meta')).to.be('sheet4')
+    })
+  })
+
+  describe('with a comment node', () => {
+    let jss
+    let comment
+
+    beforeEach(() => {
+      createDummySheets()
+      jss = create()
+    })
+    afterEach(() => {
+      removeDummySheets()
+      if (comment) {
+        document.head.removeChild(comment)
+      }
+      reset(jss)
+    })
+
+    it('should insert sheets before other stylesheets', () => {
+      comment = document.createComment('jss')
+
+      document.head.insertBefore(
+        comment,
+        document.head.querySelector('style')
+      )
+
+      jss.createStyleSheet({}, {meta: 'sheet1', index: 50}).attach()
+      jss.createStyleSheet({}, {meta: 'sheet2', index: 1}).attach()
+      jss.createStyleSheet({}, {meta: 'sheet3', index: 40}).attach()
+      jss.createStyleSheet({}, {meta: 'sheet4', index: 75}).attach()
+      jss.createStyleSheet({}, {meta: 'sheet5', index: 35}).attach()
+
+      const styleElements = document.head.getElementsByTagName('style')
+
+      expect(styleElements.length).to.be(7)
+
+      expect(styleElements[0].getAttribute('data-meta')).to.be('sheet2')
+      expect(styleElements[1].getAttribute('data-meta')).to.be('sheet5')
+      expect(styleElements[2].getAttribute('data-meta')).to.be('sheet3')
+      expect(styleElements[3].getAttribute('data-meta')).to.be('sheet1')
+      expect(styleElements[4].getAttribute('data-meta')).to.be('sheet4')
+
+      expect(styleElements[5].getAttribute('data-test-dummy')).to.be('dummy1')
+      expect(styleElements[6].getAttribute('data-test-dummy')).to.be('dummy2')
+    })
+
+    it('should insert sheets after other stylesheets', () => {
+      comment = document.createComment('jss')
+      document.head.appendChild(comment)
+
+      jss.createStyleSheet({}, {meta: 'sheet1', index: 50}).attach()
+      jss.createStyleSheet({}, {meta: 'sheet2', index: 1}).attach()
+      jss.createStyleSheet({}, {meta: 'sheet3', index: 40}).attach()
+      jss.createStyleSheet({}, {meta: 'sheet4', index: 75}).attach()
+      jss.createStyleSheet({}, {meta: 'sheet5', index: 35}).attach()
+
+      const styleElements = document.head.getElementsByTagName('style')
+
+      expect(styleElements.length).to.be(7)
+
+      expect(styleElements[0].getAttribute('data-test-dummy')).to.be('dummy1')
+      expect(styleElements[1].getAttribute('data-test-dummy')).to.be('dummy2')
+
+      expect(styleElements[2].getAttribute('data-meta')).to.be('sheet2')
+      expect(styleElements[3].getAttribute('data-meta')).to.be('sheet5')
+      expect(styleElements[4].getAttribute('data-meta')).to.be('sheet3')
+      expect(styleElements[5].getAttribute('data-meta')).to.be('sheet1')
+      expect(styleElements[6].getAttribute('data-meta')).to.be('sheet4')
+    })
+
+    it('should insert sheets between other stylesheets', () => {
+      comment = document.createComment('jss')
+      document.head.insertBefore(
+        comment,
+        document.head.querySelectorAll('style')[1]
+      )
+
+      jss.createStyleSheet({}, {meta: 'sheet1', index: 50}).attach()
+      jss.createStyleSheet({}, {meta: 'sheet2', index: 1}).attach()
+      jss.createStyleSheet({}, {meta: 'sheet3', index: 40}).attach()
+      jss.createStyleSheet({}, {meta: 'sheet4', index: 75}).attach()
+      jss.createStyleSheet({}, {meta: 'sheet5', index: 35}).attach()
+
+      const styleElements = document.head.getElementsByTagName('style')
+
+      expect(styleElements.length).to.be(7)
+
+      expect(styleElements[0].getAttribute('data-test-dummy')).to.be('dummy1')
+
+      expect(styleElements[1].getAttribute('data-meta')).to.be('sheet2')
+      expect(styleElements[2].getAttribute('data-meta')).to.be('sheet5')
+      expect(styleElements[3].getAttribute('data-meta')).to.be('sheet3')
+      expect(styleElements[4].getAttribute('data-meta')).to.be('sheet1')
+      expect(styleElements[5].getAttribute('data-meta')).to.be('sheet4')
+
+      expect(styleElements[6].getAttribute('data-test-dummy')).to.be('dummy2')
+    })
+  })
+})

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -40,12 +40,7 @@ export function computeStyle(className) {
 
 export function reset(jssInstance = jss) {
   jssInstance.plugins.registry = []
-
-  const numSheets = jssInstance.sheets.registry.length
-
-  for (let i = 0; i < numSheets; i++) {
-    jssInstance.removeStyleSheet(jssInstance.sheets.registry[0])
-  }
+  jssInstance.sheets.registry.slice(0).forEach(jssInstance.removeStyleSheet, jssInstance)
 }
 
 // Mock the hash function.

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -38,9 +38,14 @@ export function computeStyle(className) {
   return styleCopy
 }
 
-export function reset() {
-  jss.plugins.registry = []
-  jss.sheets.registry.forEach(jss.removeStyleSheet, jss)
+export function reset(jssInstance = jss) {
+  jssInstance.plugins.registry = []
+
+  const numSheets = jssInstance.sheets.registry.length
+
+  for (let i = 0; i < numSheets; i++) {
+    jssInstance.removeStyleSheet(jssInstance.sheets.registry[0])
+  }
 }
 
 // Mock the hash function.


### PR DESCRIPTION
ref #290

@kof Once you have 👍 the implementation I will document the feature.

Please review and let me know anything you'd like to see changed.

When using the priority/index feature there's some extra array iteration when adding and attaching sheets. One could use a binary search but I don't think it would make a real difference with the length of the registry array in typical usage.

This should give you a good handle on the usage -> output: https://github.com/nathanmarks/jss/blob/priority/tests/integration/priority.js