### PR TITLE
fix addRule insertion order from plugins, fix @media insertion

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "expect.js": "^0.3.1",
     "json-loader": "^0.5.4",
     "jss-nested": "2.x",
+    "jss-extend": "2.x",
     "karma": "^1.1.1",
     "karma-benchmark": "^0.6.0",
     "karma-benchmark-reporter": "^0.1.1",

--- a/src/backends/DomRenderer.js
+++ b/src/backends/DomRenderer.js
@@ -149,7 +149,10 @@ export default class DomRenderer {
     const {sheet} = this.element
     const {cssRules} = sheet
     const index = cssRules.length
-    sheet.insertRule(rule.toString(), index)
+    const css = rule.toString()
+    if (rule.type === 'regular') sheet.insertRule(css, index)
+    // IE `.insertRule()` can't handle @media queries.
+    else this.element.appendChild(document.createTextNode(css))
     return cssRules[index]
   }
 

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -13,12 +13,18 @@ export function getStyle() {
 }
 
 export function getCss(style) {
-  // IE8 returns css from innerHTML even when inserted using addRule.
-  return style.innerHTML.trim() ||
+  // IE doesn't provide correct rules list when at-rules have been added
+  // by using `.addRule()` api.
+  // Others do not update .innerHTML result when `.addRule()` was used.
+  // We use what we can get.
+  return removeWhitespace(style.innerHTML) ||
     getRules(style)
-      .map(rule => rule.cssText)
+      .map(rule => removeWhitespace(rule.cssText))
       .join('')
-      .trim()
+}
+
+export function removeWhitespace(str) {
+  return str.replace(/\s/g, '')
 }
 
 export function computeStyle(className) {


### PR DESCRIPTION
Fixes #318

When sheet is attached and deployed and `.addRule`:
- is used from a plugin, order is not preserved
- at-rules are not inserted using `insertRule` api in IE