### PR TITLE
Add sheet meta value to className generation

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -8,8 +8,16 @@ import createHash from 'murmurhash-js/murmurhash3_gc'
  * @return {String}
  */
 export function generateClassName(str, rule) {
+  const {name, options: {sheet}} = rule
   const hash = createHash(str)
-  return rule.name ? `${rule.name}-${hash}` : hash
+
+  let className = name ? `${name}-${hash}` : hash
+
+  if (sheet && sheet.options.meta) {
+    className = `${sheet.options.meta}_${className}`
+  }
+
+  return className
 }
 
 /**

--- a/tests/integration/sheet.js
+++ b/tests/integration/sheet.js
@@ -40,6 +40,16 @@ describe('Integration: sheet', () => {
       })
       expect(sheet.classes.a).to.be('a-id')
     })
+
+    it('should create rule classNames using the rule name', () => {
+      const sheet = jss.createStyleSheet({bar: {}})
+      expect(sheet.classes.bar).to.be('bar-id')
+    })
+
+    it('should create rule classNames using the rule name and meta value', () => {
+      const sheet = jss.createStyleSheet({bar: {}}, {meta: 'foo'})
+      expect(sheet.classes.bar).to.be('foo_bar-id')
+    })
   })
 
   describe('sheet.getRule()', () => {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -49,5 +49,16 @@ export function reset(jssInstance = jss) {
 
 // Mock the hash function.
 jss.setup({
-  generateClassName: (str, rule) => (rule.name ? `${rule.name}-id` : 'id')
+  generateClassName: (str, rule) => {
+    const {name, options: {sheet}} = rule
+    const hash = 'id'
+
+    let className = name ? `${name}-${hash}` : hash
+
+    if (sheet && sheet.options.meta) {
+      className = `${sheet.options.meta}_${className}`
+    }
+
+    return className
+  }
 })


### PR DESCRIPTION
Resolves #349. Also helps somewhat resolve #347.

**What?**
This PR introduces a chang that prefixes classNames with the sheet meta value (if provided). This provides better readability of classNames in the DOM for debugging purposes in libraries such as `react-jss` and `jss-theme-reactor` that use the `meta` property for component names. It also goes some way towards solving #347 by providing a mechanism to namespace selectors other than by a hash of their style declaration (which can be duplicated across sheets, along with the rule name).

**How?**
`generateClassName` checks if the sheet has a meta value set. If it does, it prepends it to the className separated by a `_`.

I added a couple of tests and updated the test util `generateClassName` stub.

Check this test out for an example: https://github.com/cssinjs/jss/compare/master...nathanmarks:meta-classname-prefix?expand=1#diff-f5956f248a2c73190de0534eeb61390bR49

