### PR TITLE
Add sheet meta value to className hash

### DIFF
--- a/src/plugins/RegularRule.js
+++ b/src/plugins/RegularRule.js
@@ -41,7 +41,7 @@ export default class RegularRule {
     this.originalStyle = style
     this.className = ''
     if (options.className) this.className = options.className
-    else if (generateClassName) this.className = generateClassName(styleStr, this)
+    else if (generateClassName) this.className = generateClassName(styleStr, this, options.sheet)
     this.selectorText = options.selector || `.${this.className}`
     if (sheet) this.renderer = sheet.renderer
     else if (Renderer) this.renderer = new Renderer()

--- a/src/utils/generateClassName.js
+++ b/src/utils/generateClassName.js
@@ -1,12 +1,16 @@
 /* @flow */
 import createHash from 'murmurhash-js/murmurhash3_gc'
+import type StyleSheet from '../StyleSheet'
 import type {Rule} from '../types'
 
 /**
  * Generates a class name using murmurhash.
  */
-export default function generateClassName(str: string, rule: Rule): string {
+export default function generateClassName(str: string, rule: Rule, sheet?: StyleSheet): string {
+  if (sheet && sheet.options.meta) str += sheet.options.meta
+
   const hash = createHash(str)
+
   // There is no name if `jss.createRule(style)` was used.
   return rule.name ? `${rule.name}-${hash}` : hash
 }

--- a/tests/integration/sheet.js
+++ b/tests/integration/sheet.js
@@ -1,4 +1,5 @@
 import expect from 'expect.js'
+import createHash from 'murmurhash-js/murmurhash3_gc'
 import {create} from '../../src'
 import RegularRule from '../../src/plugins/RegularRule'
 import {generateClassName} from '../utils'
@@ -39,6 +40,23 @@ describe('Integration: sheet', () => {
         }
       })
       expect(sheet.classes.a).to.be('a-id')
+    })
+
+    it('should create rule classNames using the rule name and a hash of styles', () => {
+      const jssInstance = create()
+      const styles = {bar: {color: 'red'}}
+      const sheet = jssInstance.createStyleSheet(styles)
+      const expectedHash = createHash(JSON.stringify(styles.bar))
+      expect(sheet.classes.bar).to.be(`bar-${expectedHash}`)
+    })
+
+    it('should create rule classNames using the rule name and a hash of styles + the meta option', () => {
+      const jssInstance = create()
+      const styles = {bar: {color: 'red'}}
+      const meta = 'foo'
+      const sheet = jssInstance.createStyleSheet(styles, {meta})
+      const expectedHash = createHash(JSON.stringify(styles.bar) + meta)
+      expect(sheet.classes.bar).to.be(`bar-${expectedHash}`)
     })
   })
 


### PR DESCRIPTION
Follow up to #350 .

From #374 
>  it is possible that 2 equal rules exist in 2 different sheets rendered at different times. Class name generation uses rules style object at the moment.

Addresses this by including the sheet meta (if provided) in the string that gets hashed.

@kof 