### PR TITLE
Use files field in package.json instead of .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-src
-benchmark
-tmp
-tests
-.env
-coverage

--- a/package.json
+++ b/package.json
@@ -107,6 +107,10 @@
     "murmurhash-js": "1.0.0",
     "warning": "3.0.0"
   },
+  "files": [
+    "dist",
+    "lib"
+  ],
   "lint-staged": {
     "./src ./tests ./benchmark ./*.js": [
       "eslint",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
   },
   "files": [
     "dist",
-    "lib"
+    "lib",
+    "flow-typed"
   ],
   "lint-staged": {
     "./src ./tests ./benchmark ./*.js": [


### PR DESCRIPTION
That’s what you publish to npm now:

![image 2017-02-03 at 7 32 54 pm](https://cloud.githubusercontent.com/assets/70067/22603719/c7c8b292-ea48-11e6-904d-b6c7f3693baa.png)

Most of this files aren‘t necessary. I’m not sure about flow files though.