### PR TITLE
Renamed method call from '.hexString()' to the new '.hex()'.

### DIFF
--- a/docs/json-api.md
+++ b/docs/json-api.md
@@ -315,7 +315,7 @@ import color from 'color'
 
 const styles = {
   button: {
-    color: color('blue').darken(0.3).hexString()
+    color: color('blue').darken(0.3).hex()
   }
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ const styles = {
   ctaButton: {
     extend: 'button',
     '&:hover': {
-      background: color('blue').darken(0.3).hexString()
+      background: color('blue').darken(0.3).hex()
     }
   },
   '@media (min-width: 1024px)': {


### PR DESCRIPTION
Just a small modification on the docs. As of https://github.com/Qix-/color/pull/96 the method for converting to a hex string is now just `.hex()`. 
