### PR TITLE
Fixes for the SSR classname counter reset bug.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ lib
 dist
 .env
 coverage
+.idea

--- a/src/Jss.js
+++ b/src/Jss.js
@@ -45,9 +45,19 @@ export default class Jss {
    * Create a Style Sheet.
    */
   createStyleSheet(styles: Object, options: StyleSheetOptions): StyleSheet {
+    let generateClassName
+    if (options
+      && options.sheetsRegistryContext
+      && this.options.generateClassName === generateClassNameDefault) {
+      generateClassName = options.sheetsRegistryContext.generateClassName
+    }
+    else {
+      generateClassName = this.options.generateClassName
+    }
+
     const sheet = new StyleSheet(styles, {
       jss: (this: Jss),
-      generateClassName: this.options.generateClassName,
+      generateClassName,
       insertionPoint: this.options.insertionPoint,
       ...options
     })

--- a/src/SheetsRegistry.js
+++ b/src/SheetsRegistry.js
@@ -1,5 +1,6 @@
 /* @flow */
-import type {ToCssOptions} from './types'
+import {createGenerateClassName} from './utils/generateClassName'
+import type {ToCssOptions, SheetsRegistryContext} from './types'
 import type StyleSheet from './StyleSheet'
 
 /**
@@ -7,6 +8,13 @@ import type StyleSheet from './StyleSheet'
  */
 export default class SheetsRegistry {
   registry: Array<StyleSheet> = []
+  context: SheetsRegistryContext
+
+  constructor() {
+    this.context = {
+      generateClassName: createGenerateClassName()
+    }
+  }
 
   /**
    * Register a Style Sheet.
@@ -52,5 +60,13 @@ export default class SheetsRegistry {
       .filter(sheet => sheet.attached)
       .map(sheet => sheet.toString(options))
       .join('\n')
+  }
+
+  /**
+   * Get the class name generator, if there
+   * is one.
+   */
+  getContext(): SheetsRegistryContext {
+    return this.context
   }
 }

--- a/src/types.js
+++ b/src/types.js
@@ -56,6 +56,10 @@ export type Plugin = {
   onChangeValue?: (value: string, prop: string, rule: Rule) => string
 }
 
+export type SheetsRegistryContext = {
+  generateClassName: generateClassName
+}
+
 export type JssOptions = {
   generateClassName?: generateClassName,
   plugins?: Array<Plugin>,
@@ -86,6 +90,7 @@ export type StyleSheetOptions = {
   virtual?: boolean,
   Renderer?: Function,
   generateClassName?: generateClassName,
+  sheetsRegistryContext?: SheetsRegistryContext,
   jss: Jss
 }
 

--- a/src/utils/generateClassName.js
+++ b/src/utils/generateClassName.js
@@ -1,17 +1,21 @@
 /* @flow */
-import type {Rule} from '../types'
+import type {Rule, generateClassName} from '../types'
 
 const globalRef = typeof window === 'undefined' ? global : window
 const namespace = '__JSS_VERSION_COUNTER__'
 if (globalRef[namespace] == null) globalRef[namespace] = 0
 // In case we have more than one JSS version.
 const jssCounter = globalRef[namespace]++
-let ruleCounter = 0
 
-/**
- * Generates unique class names.
- */
-export default (rule: Rule): string => (
-  // There is no rule name if `jss.createRule(style)` was used.
-  `${rule.name || 'jss'}-${jssCounter}-${ruleCounter++}`
-)
+export const createGenerateClassName = () : generateClassName => {
+  let ruleCounter = 0
+  /**
+   * Generates unique class names.
+   */
+  return (rule: Rule): string => (
+    // There is no rule name if `jss.createRule(style)` was used.
+    `${rule.name || 'jss'}-${jssCounter}-${ruleCounter++}`
+  )
+}
+
+export default createGenerateClassName()

--- a/tests/integration/sheetsRegistry.js
+++ b/tests/integration/sheetsRegistry.js
@@ -109,4 +109,21 @@ describe('Integration: sheetsRegistry', () => {
       )
     })
   })
+
+  describe('.getClassNameGenerator', () => {
+    it('should return a generator', () => {
+      const registry = new SheetsRegistry()
+      expect(registry.getContext().generateClassName).to.not.be(undefined)
+    })
+
+    it('should return different generators from two instances', () => {
+      const registry1 = new SheetsRegistry()
+      const registry2 = new SheetsRegistry()
+      const generator1 = registry1.getContext().generateClassName
+      const generator2 = registry2.getContext().generateClassName
+      expect(typeof generator1).to.be('function')
+      expect(typeof generator2).to.be('function')
+      expect(generator1).to.not.be(generator2)
+    })
+  })
 })


### PR DESCRIPTION
There is a bug in `jss` where one of the counters used to generate classnames does not reset to `0` with each SSR request. For the bug to be completely fixed, a commit to `react-jss` is also needed. The following  changes were made:
* `generateClassName` was modified to have a factory function, `createGenerateClassName`, exported as a named export , that creates an independent instance of the classname generator.
* The `default export` from `generateClassName` now simply calls the factory function.
* The SheetsRegistry `constructor` now takes an optional `options` object. There are currently two new options:
  * `resetClassNameCounter: boolean`: if set to true, each new instance of `SheetsRegistry` will have its own instance of the built-in `generateClassName` function.
  * `generateClassName: generateClassName`: if supplied, sets the option to the supplied generation algorithm.

The end result is that, if you do:
```
const registry = new SheetsRegistry()
```
then there should be no changes to existing behavior. But if you do:
```
const registry = new SheetsRegistry({resetClassNameCounter: true})
```
Then the registry will have an independent copy of the generator that begins at 0.