### PR TITLE
Fix createStyleSheet type definitions error

### DIFF
--- a/src/Jss.js
+++ b/src/Jss.js
@@ -9,7 +9,7 @@ import findRenderer from './utils/findRenderer'
 import type {
   Rule,
   RuleOptions,
-  StyleSheetOptions,
+  StyleSheetFactoryOptions,
   Plugin,
   JssOptions,
   JssStyle
@@ -44,7 +44,7 @@ export default class Jss {
   /**
    * Create a Style Sheet.
    */
-  createStyleSheet(styles: Object, options: StyleSheetOptions): StyleSheet {
+  createStyleSheet(styles: Object, options: StyleSheetFactoryOptions = {}): StyleSheet {
     const sheet = new StyleSheet(styles, {
       jss: (this: Jss),
       generateClassName: this.options.generateClassName,

--- a/src/types.js
+++ b/src/types.js
@@ -89,6 +89,19 @@ export type StyleSheetOptions = {
   jss: Jss
 }
 
+export type StyleSheetFactoryOptions = {
+  media?: string,
+  meta?: string,
+  index?: number,
+  insertionPoint?: string,
+  link?: boolean,
+  element?: HTMLStyleElement,
+  virtual?: boolean,
+  Renderer?: Function,
+  generateClassName?: generateClassName,
+  jss?: Jss
+}
+
 export type InternalStyleSheetOptions = {
   media?: string,
   meta?: string,


### PR DESCRIPTION
#495 If `options` is optional, it must have the default value. In our case it is empty object. But the empty object is incompatible with `StyleSheetOptions` since `StyleSheetOptions` has a required parameter `jss`. But since the `StyleSheet` constructor still comes with an object with this parameter, we do not need to make it required in the `createStyleSheet` options. To solve the problem, I created `StyleSheetFactoryOptions` type.