### PR TITLE
Support insertion points within body tag

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -47,17 +47,29 @@ sheet.toString()
 
 ## Specify DOM insertion point
 
-You can instruct `jss` to render your stylesheets starting at a specific point in the DOM by placing a comment node anywhere in the `head` of the document.
+You can instruct `jss` to render your stylesheets starting at a specific point in the DOM by placing a comment node anywhere in the `head` or `body` of the document.
 
 This can be useful if you have another dependency that needs to come before or after the `jss` Style Sheets for cascading specificity purposes.
+
+**Note:** the comment node must be an immediate descendant of either the `head` or `body` tag.
 
 You can specify an `insertionPoint` during [jss.setup()](https://github.com/cssinjs/jss/blob/master/docs/js-api.md#setup-jss-instance) and [jss.createStyleSheeet()](https://github.com/cssinjs/jss/blob/master/docs/js-api.md#create-style-sheet).
 
 ```html
 <head>
-    <title>JSS</title>
+    <title>JSS in head</title>
     <!-- jss -->
 </head>
+```
+
+Here's another example, with the insertion point moved to the top of the `body`: 
+```html
+<head>
+    <title>JSS in body</title>
+</head>
+<body>
+  <!-- jss -->
+</body>
 ```
 
 ## CLI

--- a/tests/functional/priority.js
+++ b/tests/functional/priority.js
@@ -167,6 +167,38 @@ describe('Functional: dom priority', () => {
     })
   })
 
+  describe('custom insertion point in the body', () => {
+    let jss1
+    let jss2
+    let comment1
+    let comment2
+
+    beforeEach(() => {
+      jss1 = create()
+      jss2 = create({
+        insertionPoint: 'jss2'
+      })
+      comment1 = document.body.appendChild(document.createComment('jss'))
+      comment2 = document.body.appendChild(document.createComment('jss2'))
+    })
+
+    afterEach(() => {
+      document.body.removeChild(comment1)
+      document.body.removeChild(comment2)
+    })
+
+    it('should insert sheets in the correct order', () => {
+      jss2.createStyleSheet({}, {meta: 'sheet2'}).attach()
+      jss1.createStyleSheet({}, {meta: 'sheet1'}).attach()
+
+      const styleElements = document.body.getElementsByTagName('style')
+
+      expect(styleElements.length).to.be(2)
+      expect(styleElements[0].getAttribute('data-meta')).to.be('sheet1')
+      expect(styleElements[1].getAttribute('data-meta')).to.be('sheet2')
+    })
+  })
+
   describe('preserve attachment order with no index, but with registry', () => {
     let jss
 


### PR DESCRIPTION
I need more insertion point control than just the current "anywhere in the `head`" functionality of JSS offered. Hence, this PR:

- Adds support for insertion point comments (i.e. `<!-- jss -->`) as immediate descendants in the `body` of the document
- Adds a test to verify stylesheet insertion order when using this capability
- Minorly expands the "Specify DOM insertion point" documentation to describe the new capability

There are no test regressions, and the one added test currently passes.