### PR TITLE
Support simplified template literals

### DIFF
--- a/docs/json-api.md
+++ b/docs/json-api.md
@@ -16,7 +16,7 @@ const styles = {
 Compiles to:
 
 ```css
-.button-jss-0 {
+.button-0-0 {
   color: red;
   font-size: 12px;
 }
@@ -69,11 +69,11 @@ const styles = {
 Compiles to:
 
 ```css
-.button-jss-0 {
+.button-0-0 {
   width: 100px;
 }
 @media (min-width: 1024px): {
-  .button-jss-0 {
+  .button-0-0 {
     width: 200px;
   }
 }
@@ -141,7 +141,7 @@ const styles = {
 Compiles to:
 
 ```css
-.container--jss-0-0 {
+.container-0-0 {
   background: red;
   background: linear-gradient(to right, red 0%, green 100%);
 }
@@ -245,7 +245,7 @@ const styles = {
 Compiles to:
 
 ```css
-.button-12345 {
+.button-0-1 {
   border: 1px solid red, 1px solid blue;
 }
 ```
@@ -266,7 +266,7 @@ const styles = {
 Compiles to:
 
 ```css
-.button-12345 {
+.button-0-1 {
   border: 1px solid red, 1px solid blue;
 }
 ```
@@ -283,7 +283,7 @@ const styles = {
 Compiles to:
 
 ```css
-.button-12345 {
+.button-0-1 {
   margin: 5px 10px;
 }
 ```
@@ -313,7 +313,7 @@ const styles = {
 Compiles to:
 
 ```css
-.button-jss-0-1:after {
+.button-0-1:after {
   content: "JSS"
 }
 ```
@@ -335,8 +335,27 @@ const styles = {
 Compiles to:
 
 ```css
-.button-jss-0-1 {
+.button-0-1 {
   color: '#0000B3'
+}
+```
+
+## Alternative syntax using string templates
+
+You can use a template string literal or a regular string to declare the props and values.
+This notation is only supported for style declarations, nested rules, media queries, keyframes and others still have to be objects.
+
+```javascript
+const styles = {
+  button: `
+    color: red;
+    margin: 20px 40px;
+  `,
+  '@media print': {
+    button: `
+      color: black;
+    `
+  }
 }
 ```
 

--- a/src/Jss.js
+++ b/src/Jss.js
@@ -2,6 +2,7 @@
 import StyleSheet from './StyleSheet'
 import PluginsRegistry from './PluginsRegistry'
 import rulesPlugins from './plugins/rules'
+import stringStylePlugin from './plugins/stringStyle'
 import sheets from './sheets'
 import createGenerateClassNameDefault from './utils/createGenerateClassName'
 import createRule from './utils/createRule'
@@ -31,7 +32,7 @@ export default class Jss {
 
   constructor(options?: JssOptions) {
     // eslint-disable-next-line prefer-spread
-    this.use.apply(this, rulesPlugins)
+    this.use.apply(this, rulesPlugins.concat(stringStylePlugin))
     this.setup(options)
   }
 

--- a/src/plugins/stringStyle.js
+++ b/src/plugins/stringStyle.js
@@ -1,0 +1,32 @@
+/* @flow */
+import createRule from '../utils/createRule'
+import type {JssStyle, RuleOptions, Rule} from '../types'
+
+const nlOrSemi = /\n|;/
+
+// This is a very optimistic and simplified implementation.
+// It is not intended to implement a full CSS parser here.
+const toStyle = (cssText) => {
+  const style = {}
+  const split = cssText.trim().split(nlOrSemi)
+  for (let i = 0; i < split.length; i++) {
+    const item = split[i]
+    if (!item) continue
+    const colonIndex = item.indexOf(':')
+    // Missing colon, must by a syntax error.
+    // TODO warn.
+    if (colonIndex === -1) continue
+    const prop = item.substr(0, colonIndex).trim()
+    const value = item.substr(colonIndex + 1).trim()
+    style[prop] = value
+  }
+  return style
+}
+
+const onCreateRule = (key: string, cssText: string|JssStyle, options: RuleOptions): Rule|null => {
+  if (typeof cssText !== 'string') return null
+  const style = toStyle(cssText)
+  return createRule(key, style, options)
+}
+
+export default {onCreateRule}

--- a/tests/integration/sheet.js
+++ b/tests/integration/sheet.js
@@ -351,4 +351,63 @@ describe('Integration: sheet', () => {
       expect(sheet.toString()).to.be('')
     })
   })
+
+  describe('template literals', () => {
+    it('should convert a simple template literal', () => {
+      const sheet = jss.createStyleSheet({
+        a: `
+          color: red;
+        `
+      })
+      expect(sheet.toString()).to.be(stripIndent`
+        .a-id {
+          color: red;
+        }
+      `)
+    })
+
+    it('should parse multiple props/values', () => {
+      const sheet = jss.createStyleSheet({
+        a: `
+          color: red;
+          float: left;
+        `
+      })
+      expect(sheet.toString()).to.be(stripIndent`
+        .a-id {
+          color: red;
+          float: left;
+        }
+      `)
+    })
+
+    it('should parse without semicolons', () => {
+      const sheet = jss.createStyleSheet({
+        a: `
+          color: red
+          float: left
+        `
+      })
+      expect(sheet.toString()).to.be(stripIndent`
+        .a-id {
+          color: red;
+          float: left;
+        }
+      `)
+    })
+
+    it('should parse without line breaks', () => {
+      const sheet = jss.createStyleSheet({
+        a: `
+          color: red; float: left;
+        `
+      })
+      expect(sheet.toString()).to.be(stripIndent`
+        .a-id {
+          color: red;
+          float: left;
+        }
+      `)
+    })
+  })
 })


### PR DESCRIPTION
The goal here is not to provide a full CSS parser. It supports only a StyleRule and only the style declaration as a string. It does basic tolerance support like omitting semicolons or newlines and trimming spaces though.

There are 2 motivations behind it:
1. Give user lower case, dashes and values without quotes syntax, they know from styled-components
2. Provide a handy tool for copy paste from dev tools.