### PR TITLE
Add size-limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "mocha": "^3.2.0",
     "pre-commit": "^1.1.3",
     "rimraf": "^2.5.4",
+    "size-limit": "^0.2.0",
     "webpack": "^2.3.3"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "webpack": "^2.3.3"
   },
   "scripts": {
-    "all": "npm run lint && npm run flow && npm run test && npm run build",
+    "all": "npm run lint && npm run flow && npm run test && npm run build && npm run size",
     "build": "npm run clean && npm run build:lib && npm run build:max && npm run build:min && npm run build:tests",
     "build:lib": "babel src --out-dir lib && npm run flow:copy-src",
     "build:max": "cross-env NODE_ENV=development webpack src/index.js dist/jss.js",
@@ -100,7 +100,8 @@
     "test:watch": "cross-env NODE_ENV=test karma start",
     "posttest": "[ -z \"$TRAVIS\" ] || codecov",
     "codecov": "codecov",
-    "bench": "cross-env BENCHMARK=true karma start --single-run"
+    "bench": "cross-env BENCHMARK=true karma start --single-run",
+    "size": "size-limit 5.6KB dist/jss.js"
   },
   "dependencies": {
     "is-in-browser": "^1.0.2",


### PR DESCRIPTION
[size-limit](https://github.com/ai/size-limit) is a tool to show how many kilobytes your JS library increases the user bundle. You can set size budget and size-limit will prevent JavaScript libraries bloat on Travis CI.

I already use it in Logux and PostCSS and it helps me a lot. For instance, I reduce Logux Client size 2x because I found some unexpected huge dependencies.

@kof BTW, I was excited that JSS size is just 5.5 KB.