### PR TITLE
Fixed warning in sheets manager

### DIFF
--- a/src/SheetsManager.js
+++ b/src/SheetsManager.js
@@ -44,7 +44,7 @@ export default class SheetsManager {
     const index = this.keys.indexOf(key)
     if (index === -1) {
       // eslint-ignore-next-line no-console
-      warn('SheetsManager: can\'t find sheet to unmanage')
+      warn(false, 'SheetsManager: can\'t find sheet to unmanage')
       return
     }
     if (this.refs[index] > 0) {


### PR DESCRIPTION
The warn function had a missing argument and didn't output the passed in the message but instead threw an error because it was missing an argument

It would throw [this](https://github.com/BerkeleyTrue/warning/blob/master/warning.js#L31)