### PR TITLE
Fix flow issue in DomRenderer

### DIFF
--- a/src/renderers/DomRenderer.js
+++ b/src/renderers/DomRenderer.js
@@ -125,7 +125,7 @@ function findCommentNode(text: string): Comment|null {
   for (let i = 0; i < head.childNodes.length; i++) {
     const node = head.childNodes[i]
     if (node.nodeType === 8 && node.nodeValue.trim() === text) {
-      return node
+      return ((node:any):Comment)
     }
   }
   return null


### PR DESCRIPTION
Flow 0.54.1 reports an error in DomRenderer.js.flow:

```
Error: node_modules/jss/lib/renderers/DomRenderer.js.flow:128
128:       return node
                  ^^^^ Node. This type is incompatible with
123: function findCommentNode(text: string): Comment|null {
                                             ^^^^^^^^^^^^ union: Comment | null
  Member 1:
  123: function findCommentNode(text: string): Comment|null {
                                               ^^^^^^^ Comment
  Error:
  128:       return node
                    ^^^^ Node. This type is incompatible with
  123: function findCommentNode(text: string): Comment|null {
                                               ^^^^^^^ Comment
  Member 2:
  123: function findCommentNode(text: string): Comment|null {
                                                       ^^^^ null
  Error:
  128:       return node
                    ^^^^ Node. This type is incompatible with
  123: function findCommentNode(text: string): Comment|null {
                                                       ^^^^ null


Found 1 error
error Command failed with exit code 2.
```

The PR fixes this with an explicit downcast from Node to Comment.
