### PR TITLE
fix: constructor-function declaration should have return type `void`

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -21,7 +21,7 @@ export type generateClassName = (rule: Rule, sheet?: StyleSheet) => string
 export type JssStyle = Object
 
 export interface Renderer {
-  constructor(sheet?: StyleSheet): Renderer;
+  constructor(sheet?: StyleSheet): void;
   setStyle(cssRule: HTMLElement|CSSStyleRule, prop: string, value: string): boolean;
   getStyle(cssRule: HTMLElement|CSSStyleRule, prop: string): string;
   setSelector(cssRule: CSSStyleRule, selectorText: string): boolean;


### PR DESCRIPTION
Environment:
node 7.10.1
jss 8.1.0
flow-bin: 0.55.0

In `types.js`, interface `Renderer` declares a constructor function with return type `Renderer`. However, constructor functions should have return type `void` as far as I know. Otherwise I get a bunch of flow issues:

```
Error: node_modules/jss/lib/types.js.flow:25
 25:   constructor(sheet?: StyleSheet): Renderer;
                                        ^^^^^^^^ property `attach` of Renderer. Property not found in possibly undefined value
205:   constructor(sheet?: StyleSheet) {
                                      ^ undefined. See: node_modules/jss/lib/renderers/DomRenderer.js.flow:205

Error: node_modules/jss/lib/types.js.flow:25
 25:   constructor(sheet?: StyleSheet): Renderer;
                                        ^^^^^^^^ property `attach` of Renderer. Property not found in possibly undefined value
  7: export default class VirtualRenderer {
                          ^^^^^^^^^^^^^^^ undefined. See: node_modules/jss/lib/renderers/VirtualRenderer.js.flow:7

Error: node_modules/jss/lib/types.js.flow:25
 25:   constructor(sheet?: StyleSheet): Renderer;
                                        ^^^^^^^^ property `constructor` of Renderer. Property not found in possibly undefined value
205:   constructor(sheet?: StyleSheet) {
                                      ^ undefined. See: node_modules/jss/lib/renderers/DomRenderer.js.flow:205

Error: node_modules/jss/lib/types.js.flow:25
 25:   constructor(sheet?: StyleSheet): Renderer;
                                        ^^^^^^^^ property `constructor` of Renderer. Property not found in possibly undefined value
  7: export default class VirtualRenderer {
                          ^^^^^^^^^^^^^^^ undefined. See: node_modules/jss/lib/renderers/VirtualRenderer.js.flow:7

Error: node_modules/jss/lib/types.js.flow:25
 25:   constructor(sheet?: StyleSheet): Renderer;
                                        ^^^^^^^^ property `deleteRule` of Renderer. Property not found in possibly undefined value
205:   constructor(sheet?: StyleSheet) {
                                      ^ undefined. See: node_modules/jss/lib/renderers/DomRenderer.js.flow:205

Error: node_modules/jss/lib/types.js.flow:25
 25:   constructor(sheet?: StyleSheet): Renderer;
                                        ^^^^^^^^ property `deleteRule` of Renderer. Property not found in possibly undefined value
  7: export default class VirtualRenderer {
                          ^^^^^^^^^^^^^^^ undefined. See: node_modules/jss/lib/renderers/VirtualRenderer.js.flow:7

Error: node_modules/jss/lib/types.js.flow:25
 25:   constructor(sheet?: StyleSheet): Renderer;
                                        ^^^^^^^^ property `deploy` of Renderer. Property not found in possibly undefined value
205:   constructor(sheet?: StyleSheet) {
                                      ^ undefined. See: node_modules/jss/lib/renderers/DomRenderer.js.flow:205

Error: node_modules/jss/lib/types.js.flow:25
 25:   constructor(sheet?: StyleSheet): Renderer;
                                        ^^^^^^^^ property `deploy` of Renderer. Property not found in possibly undefined value
  7: export default class VirtualRenderer {
                          ^^^^^^^^^^^^^^^ undefined. See: node_modules/jss/lib/renderers/VirtualRenderer.js.flow:7

Error: node_modules/jss/lib/types.js.flow:25
 25:   constructor(sheet?: StyleSheet): Renderer;
                                        ^^^^^^^^ property `detach` of Renderer. Property not found in possibly undefined value
205:   constructor(sheet?: StyleSheet) {
                                      ^ undefined. See: node_modules/jss/lib/renderers/DomRenderer.js.flow:205

Error: node_modules/jss/lib/types.js.flow:25
 25:   constructor(sheet?: StyleSheet): Renderer;
                                        ^^^^^^^^ property `detach` of Renderer. Property not found in possibly undefined value
  7: export default class VirtualRenderer {
                          ^^^^^^^^^^^^^^^ undefined. See: node_modules/jss/lib/renderers/VirtualRenderer.js.flow:7

Error: node_modules/jss/lib/types.js.flow:25
 25:   constructor(sheet?: StyleSheet): Renderer;
                                        ^^^^^^^^ property `getRules` of Renderer. Property not found in possibly undefined value
205:   constructor(sheet?: StyleSheet) {
                                      ^ undefined. See: node_modules/jss/lib/renderers/DomRenderer.js.flow:205

Error: node_modules/jss/lib/types.js.flow:25
 25:   constructor(sheet?: StyleSheet): Renderer;
                                        ^^^^^^^^ property `getRules` of Renderer. Property not found in possibly undefined value
  7: export default class VirtualRenderer {
                          ^^^^^^^^^^^^^^^ undefined. See: node_modules/jss/lib/renderers/VirtualRenderer.js.flow:7

Error: node_modules/jss/lib/types.js.flow:25
 25:   constructor(sheet?: StyleSheet): Renderer;
                                        ^^^^^^^^ property `getSelector` of Renderer. Property not found in possibly undefined value
205:   constructor(sheet?: StyleSheet) {
                                      ^ undefined. See: node_modules/jss/lib/renderers/DomRenderer.js.flow:205

Error: node_modules/jss/lib/types.js.flow:25
 25:   constructor(sheet?: StyleSheet): Renderer;
                                        ^^^^^^^^ property `getSelector` of Renderer. Property not found in possibly undefined value
  7: export default class VirtualRenderer {
                          ^^^^^^^^^^^^^^^ undefined. See: node_modules/jss/lib/renderers/VirtualRenderer.js.flow:7

Error: node_modules/jss/lib/types.js.flow:25
 25:   constructor(sheet?: StyleSheet): Renderer;
                                        ^^^^^^^^ property `getStyle` of Renderer. Property not found in possibly undefined value
205:   constructor(sheet?: StyleSheet) {
                                      ^ undefined. See: node_modules/jss/lib/renderers/DomRenderer.js.flow:205

Error: node_modules/jss/lib/types.js.flow:25
 25:   constructor(sheet?: StyleSheet): Renderer;
                                        ^^^^^^^^ property `getStyle` of Renderer. Property not found in possibly undefined value
  7: export default class VirtualRenderer {
                          ^^^^^^^^^^^^^^^ undefined. See: node_modules/jss/lib/renderers/VirtualRenderer.js.flow:7

Error: node_modules/jss/lib/types.js.flow:25
 25:   constructor(sheet?: StyleSheet): Renderer;
                                        ^^^^^^^^ property `insertRule` of Renderer. Property not found in possibly undefined value
205:   constructor(sheet?: StyleSheet) {
                                      ^ undefined. See: node_modules/jss/lib/renderers/DomRenderer.js.flow:205

Error: node_modules/jss/lib/types.js.flow:25
 25:   constructor(sheet?: StyleSheet): Renderer;
                                        ^^^^^^^^ property `insertRule` of Renderer. Property not found in possibly undefined value
  7: export default class VirtualRenderer {
                          ^^^^^^^^^^^^^^^ undefined. See: node_modules/jss/lib/renderers/VirtualRenderer.js.flow:7

Error: node_modules/jss/lib/types.js.flow:25
 25:   constructor(sheet?: StyleSheet): Renderer;
                                        ^^^^^^^^ property `setSelector` of Renderer. Property not found in possibly undefined value
205:   constructor(sheet?: StyleSheet) {
                                      ^ undefined. See: node_modules/jss/lib/renderers/DomRenderer.js.flow:205

Error: node_modules/jss/lib/types.js.flow:25
 25:   constructor(sheet?: StyleSheet): Renderer;
                                        ^^^^^^^^ property `setSelector` of Renderer. Property not found in possibly undefined value
  7: export default class VirtualRenderer {
                          ^^^^^^^^^^^^^^^ undefined. See: node_modules/jss/lib/renderers/VirtualRenderer.js.flow:7

Error: node_modules/jss/lib/types.js.flow:25
 25:   constructor(sheet?: StyleSheet): Renderer;
                                        ^^^^^^^^ property `setStyle` of Renderer. Property not found in possibly undefined value
205:   constructor(sheet?: StyleSheet) {
                                      ^ undefined. See: node_modules/jss/lib/renderers/DomRenderer.js.flow:205

Error: node_modules/jss/lib/types.js.flow:25
 25:   constructor(sheet?: StyleSheet): Renderer;
                                        ^^^^^^^^ property `setStyle` of Renderer. Property not found in possibly undefined value
  7: export default class VirtualRenderer {
                          ^^^^^^^^^^^^^^^ undefined. See: node_modules/jss/lib/renderers/VirtualRenderer.js.flow:7
```