### PR TITLE
WIP add support for Observable rules

### DIFF
--- a/src/plugins/observables.js
+++ b/src/plugins/observables.js
@@ -8,11 +8,11 @@ export default {
   onCreateRule(name: string, decl: JssStyle, options: RuleOptions): Rule | null {
     if (isObservable(decl)) {
       // Cast `decl` to `Observable`, since it passed the type guard
-      const props$ = (decl: Observable<{[string]: string}>);
+      const props$ = (decl: Observable<{[string]: string}>)
 
       // We know `rule` is a `StyleRule`, and the other types don't have a
       // `prop` method, so we must explicitly cast to `StyleRule`
-      const rule = ((createRule(name, {}, options): any): StyleRule);
+      const rule = ((createRule(name, {}, options): any): StyleRule)
 
       // `stream.subscribe()` returns a subscription, which should be explicitly
       // unsubscribed from when we know this sheet is no longer needed, but I
@@ -25,13 +25,13 @@ export default {
             // The typing here is gross because `Object.entries` is typed as
             // `[string, mixed]`, even though `props` is `{[string]: string}`
             ([key, value]) => rule.prop(key, ((value: any): string))
-          );
+          )
         }
-      );
+      )
 
-      return rule;
+      return rule
     } else {
-      return null;
+      return null
     }
   },
 

--- a/src/plugins/observables.js
+++ b/src/plugins/observables.js
@@ -1,9 +1,26 @@
 /* @flow */
 import isObservable from 'is-observable'
 import StyleRule from '../rules/StyleRule'
-import type {Rule} from '../types'
+import createRule from '../utils/createRule'
+import type {Observable, Rule, RuleOptions, JssStyle} from '../types'
 
 export default {
+  onCreateRule(name: string, decl: JssStyle | Observable<{[string]: string}>, options: RuleOptions) {
+    if (isObservable(decl)) {
+      const rule = createRule(name, {}, options);
+
+      decl.subscribe(
+        (currentProps) => {
+          Object.entries(currentProps).forEach(
+            ([key, value]) => rule.prop(key, value)
+          );
+        }
+      );
+
+      return rule;
+    }
+  },
+
   onProcessRule(rule: Rule) {
     if (!(rule instanceof StyleRule)) return
     const {style} = rule

--- a/src/plugins/observables.js
+++ b/src/plugins/observables.js
@@ -5,19 +5,33 @@ import createRule from '../utils/createRule'
 import type {Observable, Rule, RuleOptions, JssStyle} from '../types'
 
 export default {
-  onCreateRule(name: string, decl: JssStyle | Observable<{[string]: string}>, options: RuleOptions) {
+  onCreateRule(name: string, decl: JssStyle, options: RuleOptions): Rule | null {
     if (isObservable(decl)) {
-      const rule = createRule(name, {}, options);
+      // Cast `decl` to `Observable`, since it passed the type guard
+      const props$ = (decl: Observable<{[string]: string}>);
 
-      decl.subscribe(
-        (currentProps) => {
-          Object.entries(currentProps).forEach(
-            ([key, value]) => rule.prop(key, value)
+      // We know `rule` is a `StyleRule`, and the other types don't have a
+      // `prop` method, so we must explicitly cast to `StyleRule`
+      const rule = ((createRule(name, {}, options): any): StyleRule);
+
+      // `stream.subscribe()` returns a subscription, which should be explicitly
+      // unsubscribed from when we know this sheet is no longer needed, but I
+      // don't see any hooks to do that in the plugin API.  The Observable props
+      // implementation doesn't store its subscription either, so this is a TODO
+      // for both.
+      props$.subscribe(
+        (props) => {
+          Object.entries(props).forEach(
+            // The typing here is gross because `Object.entries` is typed as
+            // `[string, mixed]`, even though `props` is `{[string]: string}`
+            ([key, value]) => rule.prop(key, ((value: any): string))
           );
         }
       );
 
       return rule;
+    } else {
+      return null;
     }
   },
 

--- a/src/plugins/observables.js
+++ b/src/plugins/observables.js
@@ -6,33 +6,31 @@ import type {Observable, Rule, RuleOptions, JssStyle} from '../types'
 
 export default {
   onCreateRule(name: string, decl: JssStyle, options: RuleOptions): Rule | null {
-    if (isObservable(decl)) {
-      // Cast `decl` to `Observable`, since it passed the type guard
-      const props$ = (decl: Observable<{[string]: string}>)
+    if (!isObservable(decl)) return null
 
-      // We know `rule` is a `StyleRule`, and the other types don't have a
-      // `prop` method, so we must explicitly cast to `StyleRule`
-      const rule = ((createRule(name, {}, options): any): StyleRule)
+    // Cast `decl` to `Observable`, since it passed the type guard
+    const props$ = (decl: Observable<{[string]: string}>)
 
-      // `stream.subscribe()` returns a subscription, which should be explicitly
-      // unsubscribed from when we know this sheet is no longer needed, but I
-      // don't see any hooks to do that in the plugin API.  The Observable props
-      // implementation doesn't store its subscription either, so this is a TODO
-      // for both.
-      props$.subscribe(
-        (props) => {
-          Object.entries(props).forEach(
-            // The typing here is gross because `Object.entries` is typed as
-            // `[string, mixed]`, even though `props` is `{[string]: string}`
-            ([key, value]) => rule.prop(key, ((value: any): string))
-          )
-        }
-      )
+    // We know `rule` is a `StyleRule`, and the other types don't have a
+    // `prop` method, so we must explicitly cast to `StyleRule`
+    const rule = ((createRule(name, {}, options): any): StyleRule)
 
-      return rule
-    } else {
-      return null
-    }
+    // `stream.subscribe()` returns a subscription, which should be explicitly
+    // unsubscribed from when we know this sheet is no longer needed, but I
+    // don't see any hooks to do that in the plugin API.  The Observable props
+    // implementation doesn't store its subscription either, so this is a TODO
+    // for both.
+    props$.subscribe(
+      (props) => {
+        Object.entries(props).forEach(
+          // The typing here is gross because `Object.entries` is typed as
+          // `[string, mixed]`, even though `props` is `{[string]: string}`
+          ([key, value]) => rule.prop(key, ((value: any): string))
+        )
+      }
+    )
+
+    return rule
   },
 
   onProcessRule(rule: Rule) {

--- a/src/plugins/observables.js
+++ b/src/plugins/observables.js
@@ -22,11 +22,10 @@ export default {
     // for both.
     props$.subscribe(
       (props) => {
-        Object.entries(props).forEach(
-          // The typing here is gross because `Object.entries` is typed as
-          // `[string, mixed]`, even though `props` is `{[string]: string}`
-          ([key, value]) => rule.prop(key, ((value: any): string))
-        )
+        for (const key in props) {
+          const value = props[key]
+          rule.prop(key, value)
+        }
       }
     )
 

--- a/src/types.js
+++ b/src/types.js
@@ -138,3 +138,23 @@ export type InternalStyleSheetOptions = {
   parent: ConditionalRule|KeyframesRule|StyleSheet,
   classes: Object
 }
+
+
+// These types are imported from indefinite-observable.  They should probably
+// be moved to flow-typed.
+
+export type Observable<T> = {
+  subscribe(observerOrNext: ObserverOrNext<T>): Subscription,
+}
+
+export type Observer<T> = {
+  next: NextChannel<T>,
+}
+
+export type NextChannel<T> = (value: T) => void;
+export type ObserverOrNext<T> = Observer<T> | NextChannel<T>;
+
+export type Unsubscribe = () => void;
+export type Subscription = {
+  unsubscribe: Unsubscribe,
+};

--- a/src/utils/cloneStyle.js
+++ b/src/utils/cloneStyle.js
@@ -14,6 +14,10 @@ export default function cloneStyle(style: JssStyle): JssStyle {
   // Support array for FontFaceRule.
   if (isArray(style)) return style.map(cloneStyle)
 
+  // Support Observable styles.  Observables are immutable, so we don't need to
+  // copy them.
+  if (isObservable(style)) return style
+
   const newStyle = {}
   for (const name in style) {
     const value = style[name]

--- a/tests/functional/observables.js
+++ b/tests/functional/observables.js
@@ -9,7 +9,50 @@ import {
 
 const settings = {createGenerateClassName}
 
-describe('Functional: Observable', () => {
+describe('Functional: Observable rules', () => {
+  let jss
+
+  beforeEach(() => {
+    jss = create(settings)
+  })
+
+  describe('Observables', () => {
+    let sheet
+    let observer
+
+    beforeEach(() => {
+      sheet = jss.createStyleSheet({
+        div: new Observable((obs) => {
+          observer = obs
+        }),
+      }, {link: true}).attach()
+    })
+
+    it('should subscribe the observer', () => {
+      expect(observer).to.be.an(Object)
+    })
+
+    it('should update the value 1', () => {
+      observer.next({ opacity: '0', height: '5px' })
+
+      const result = computeStyle(sheet.classes.div)
+
+      expect(result.opacity).to.be('0')
+      expect(result.height).to.be('5px')
+    })
+
+    it('should update the value 2', () => {
+      observer.next({ opacity: '1', height: '10px' })
+
+      const result = computeStyle(sheet.classes.div)
+
+      expect(result.opacity).to.be('1')
+      expect(result.height).to.be('10px')
+    })
+  })
+})
+
+describe('Functional: Observable props', () => {
   let jss
 
   beforeEach(() => {


### PR DESCRIPTION
I've started writing a plugin that adds support for Observable rules (#607).  Right now, I'm seeing this warning:

```
Rule is not linked. Missing sheet option "link: true".
```

Even though `{ link: true }` is clearly specified in the tests.