### PR TITLE
Support current symbol-observable & synchronous observable rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "is-in-browser": "^1.1.3",
-    "is-observable": "^0.2.0",
+    "symbol-observable": "^1.0.4",
     "warning": "^3.0.0"
   },
   "files": [

--- a/src/plugins/observables.js
+++ b/src/plugins/observables.js
@@ -1,7 +1,7 @@
 /* @flow */
-import isObservable from 'is-observable'
 import StyleRule from '../rules/StyleRule'
 import createRule from '../utils/createRule'
+import isObservable from '../utils/isObservable'
 import type {Observable, Rule, RuleOptions, JssStyle} from '../types'
 
 export default {

--- a/src/rules/StyleRule.js
+++ b/src/rules/StyleRule.js
@@ -63,11 +63,11 @@ export default class StyleRule implements BaseRule {
    * Get or set a style property.
    */
   prop(name: string, nextValue?: string): StyleRule|string {
-    // The result of a dynamic value is prefixed with $ and is not innumerable in
+    // The result of a dynamic value is prefixed with $ and is not enumerable in
     // order to be ignored by all plugins or during stringification.
     const $name = isDynamic(this.style[name]) ? `$${name}` : name
 
-    // Its a setter.
+    // It's a setter.
     if (nextValue != null) {
       // Don't do anything if the value has not changed.
       if (this.style[$name] !== nextValue) {

--- a/src/utils/cloneStyle.js
+++ b/src/utils/cloneStyle.js
@@ -1,4 +1,4 @@
-import isObservable from 'is-observable'
+import isObservable from './isObservable'
 import type {JssStyle} from '../types'
 
 const {isArray} = Array

--- a/src/utils/isDynamic.js
+++ b/src/utils/isDynamic.js
@@ -1,3 +1,3 @@
-import isObservable from 'is-observable'
+import isObservable from './isObservable'
 
 export default value => typeof value === 'function' || isObservable(value)

--- a/src/utils/isObservable.js
+++ b/src/utils/isObservable.js
@@ -1,0 +1,4 @@
+import $$observable from 'symbol-observable'
+
+export default value => value && value[$$observable] && value === value[$$observable]()
+

--- a/tests/functional/observables.js
+++ b/tests/functional/observables.js
@@ -25,14 +25,14 @@ describe('Functional: Observable rules', () => {
         div: new Observable((obs) => {
           observer = obs
         }),
-      }, {link: true}).attach()
+      }).attach().link()
     })
 
     it('should subscribe the observer', () => {
       expect(observer).to.be.an(Object)
     })
 
-    it('should update the value 1', () => {
+    it('should update the value', () => {
       observer.next({opacity: '0', height: '5px'})
 
       const result = computeStyle(sheet.classes.div)
@@ -41,13 +41,81 @@ describe('Functional: Observable rules', () => {
       expect(result.height).to.be('5px')
     })
 
-    it('should update the value 2', () => {
+    it('should update the value when it receives a new emission', () => {
+      observer.next({opacity: '0', height: '5px'})
       observer.next({opacity: '1', height: '10px'})
 
       const result = computeStyle(sheet.classes.div)
 
       expect(result.opacity).to.be('1')
       expect(result.height).to.be('10px')
+    })
+
+    it('should work with multiple rules', () => {
+      let divObs
+      let buttonObs
+
+      sheet = jss.createStyleSheet({
+        div: new Observable((obs) => {
+          divObs = obs
+        }),
+        button: new Observable((obs) => {
+          buttonObs = obs
+        })
+      }).attach().link()
+
+      divObs.next({ display: 'flex' })
+      buttonObs.next({ height: '3px' })
+
+      expect(computeStyle(sheet.classes.div).display).to.be('flex')
+      expect(computeStyle(sheet.classes.button).height).to.be('3px')
+    })
+
+    it('should work with mixed sheets', () => {
+      let divObs
+      let buttonObs
+
+      sheet = jss.createStyleSheet({
+        div: new Observable((obs) => {
+          divObs = obs
+        }),
+        button: new Observable((obs) => {
+          buttonObs = obs
+        }),
+        a: {
+          opacity: '0',
+        }
+      }).attach().link()
+
+      divObs.next({ display: 'flex' })
+      buttonObs.next({ height: '3px' })
+
+      expect(computeStyle(sheet.classes.div).display).to.be('flex')
+      expect(computeStyle(sheet.classes.button).height).to.be('3px')
+      expect(computeStyle(sheet.classes.a).opacity).to.be('0')
+    })
+
+    it('should accept synchronous values', () => {
+      sheet = jss.createStyleSheet({
+        div: new Observable((obs) => {
+          obs.next({ display: 'flex' })
+        })
+      }).attach().link()
+
+      expect(computeStyle(sheet.classes.div).display).to.be('flex')
+    })
+
+    it('should update synchronous values when it receives a new emission', () => {
+      sheet = jss.createStyleSheet({
+        div: new Observable((obs) => {
+          obs.next({ display: 'flex' })
+          observer = obs
+        })
+      }).attach().link()
+
+      observer.next({ display: 'inline-flex' })
+
+      expect(computeStyle(sheet.classes.div).display).to.be('inline-flex')
     })
   })
 })
@@ -70,7 +138,7 @@ describe('Functional: Observable props', () => {
             observer = obs
           })
         }
-      }, {link: true}).attach()
+      }).attach().link()
     })
 
     it('should subscribe the observer', () => {


### PR DESCRIPTION
I tried using `jss@9.1` to add the `JSSDemo` back to `material-motion`.  I encountered two problems:

1. `link: true` doesn't seem to work if there is more than one observable rule in a style sheet.
2. `isObservable` is always failing, because it depends on an obsolete version of `symbol-observable`.

I added a (currently failing) test for 1) and fixed 2).  Feel free to take this PR over to fix 1). 😄 