### PR TITLE
Update createGenerateClassName.js

### DIFF
--- a/src/utils/createGenerateClassName.js
+++ b/src/utils/createGenerateClassName.js
@@ -13,7 +13,7 @@ const maxRules = 1e10
 
 const env = process.env.NODE_ENV
 
-const CSS = (window.CSS: any)
+const CSS = (globalRef.CSS: any)
 
 const escape = (str) => {
   if (!CSS || !CSS.escape) {


### PR DESCRIPTION
> ReferenceError: window is not defined
    at Object.<anonymous> (/Users/oliviertassinari/material-ui-next/node_modules/jss/lib/utils/createGenerateClassName.js:27:17)