### PR TITLE
Fix added nested rules order

### DIFF
--- a/src/StyleSheet.js
+++ b/src/StyleSheet.js
@@ -89,7 +89,7 @@ export default class StyleSheet {
       if (!this.deployed) return rule
       // Don't insert rule directly if there is no stringified version yet.
       // It will be inserted all together when .attach is called.
-      if (queue) queue.push(rule)
+      if (queue) queue.unshift(rule)
       else {
         this.insertRule(rule)
         if (this.queue) {

--- a/tests/integration/plugins.js
+++ b/tests/integration/plugins.js
@@ -1,9 +1,14 @@
 import expect from 'expect.js'
 import {stripIndent} from 'common-tags'
+import jssNested from 'jss-nested'
 import {create} from '../../src'
 import StyleSheet from '../../src/StyleSheet'
-import {createGenerateClassName} from '../utils'
 import PluginsRegistry from '../../src/PluginsRegistry'
+import {
+  createGenerateClassName,
+  getCssFromSheet,
+  removeWhitespace
+} from '../utils'
 
 describe('Integration: plugins', () => {
   let jss
@@ -414,6 +419,31 @@ describe('Integration: plugins', () => {
           color: green;
         }
       `)
+    })
+  })
+
+  describe('jss-nested', () => {
+    let sheet
+
+    beforeEach(() => {
+      jss.use(jssNested())
+
+      sheet = jss.createStyleSheet({}, {
+        link: true,
+      }).attach()
+
+      sheet.addRule('b', {color: 'green'})
+      sheet.addRule('a', {
+        '&:hover': {
+          '& $b': {
+            color: 'red',
+          },
+        },
+      })
+    })
+
+    it('should save the added nested rules order', () => {
+      expect(getCssFromSheet(sheet)).to.be(removeWhitespace(sheet.toString()))
     })
   })
 })


### PR DESCRIPTION
Fix an issue from https://github.com/cssinjs/styled-jss/pull/59

The problem is when we add rules by `.addRules`, it has some issues with nested rules order.

```js
const Div = styled('div')({
  padding: 15,
  '&:hover': {
    '& $button': {
      color: ({primary}) => (primary ? 'red' : 'green'),
    },
  },
})

const Button = styled('button')({
  composes: '$button',
})

const App = (props: {primary?: boolean}) => (
  <div>
    <Div primary={props.primary}>
      <Button>Button</Button>
    </Div>
  </div>
)

expect(getCss(sheet)).toBe(removeWhitespace(sheet.toString()))
```

![image](https://user-images.githubusercontent.com/11135392/34281417-9c5e39ae-e6cf-11e7-8e83-9b4f11b55b57.png)
