### PR TITLE
fix link to work with global rule

### DIFF
--- a/src/RuleList.js
+++ b/src/RuleList.js
@@ -155,7 +155,9 @@ export default class RuleList {
       const cssRule = cssRules[i]
       let key = this.options.sheet.renderer.getKey(cssRule)
       if (map[key]) key = map[key]
-      const rule = this.map[key]
+
+      const mappedGlobal: any = this.map['@global']
+      const rule = mappedGlobal ? mappedGlobal.rules.map[key] || this.map[key] : this.map[key]
       if (rule) linkRule(rule, cssRule)
     }
   }


### PR DESCRIPTION
Related to #664 

As I was also trying to get it work I fixed this.
This works for me and all tests pass, but please check if this causes any side effects.

May be this should be moved to the jss-global plugin ? ( I am not sure about it), I had to use the 'any' type as the actual type of the rule is 'GlobalContainerRule' which is part of jss-global. Let me know if I should improve this PR or you can adapt it. 
