### PR TITLE
UMD distribution fixes

### DIFF
--- a/packages/jss-plugin-syntax-compose/.size-snapshot.json
+++ b/packages/jss-plugin-syntax-compose/.size-snapshot.json
@@ -5,8 +5,8 @@
     "gzipped": 849
   },
   "dist/jss-plugin-syntax-compose.min.js": {
-    "bundled": 5530,
-    "minified": 1560,
-    "gzipped": 849
+    "bundled": 5529,
+    "minified": 1048,
+    "gzipped": 579
   }
 }

--- a/packages/jss-plugin-syntax-extend/.size-snapshot.json
+++ b/packages/jss-plugin-syntax-extend/.size-snapshot.json
@@ -5,8 +5,8 @@
     "gzipped": 1079
   },
   "dist/jss-plugin-syntax-extend.min.js": {
-    "bundled": 7534,
-    "minified": 2270,
-    "gzipped": 1079
+    "bundled": 7533,
+    "minified": 1758,
+    "gzipped": 818
   }
 }

--- a/packages/jss-plugin-syntax-global/.size-snapshot.json
+++ b/packages/jss-plugin-syntax-global/.size-snapshot.json
@@ -1,12 +1,12 @@
 {
   "dist/jss-plugin-syntax-global.js": {
-    "bundled": 51878,
-    "minified": 20896,
-    "gzipped": 5228
+    "bundled": 5667,
+    "minified": 2354,
+    "gzipped": 1014
   },
   "dist/jss-plugin-syntax-global.min.js": {
-    "bundled": 51878,
-    "minified": 20896,
-    "gzipped": 5228
+    "bundled": 5667,
+    "minified": 2354,
+    "gzipped": 1014
   }
 }

--- a/packages/jss-plugin-syntax-nested/.size-snapshot.json
+++ b/packages/jss-plugin-syntax-nested/.size-snapshot.json
@@ -5,8 +5,8 @@
     "gzipped": 1120
   },
   "dist/jss-plugin-syntax-nested.min.js": {
-    "bundled": 7426,
-    "minified": 2112,
-    "gzipped": 1120
+    "bundled": 7425,
+    "minified": 1600,
+    "gzipped": 862
   }
 }

--- a/packages/jss-plugin-syntax-nested/package-lock.json
+++ b/packages/jss-plugin-syntax-nested/package-lock.json
@@ -7,14 +7,6 @@
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
-		"jss-extend": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/jss-extend/-/jss-extend-6.2.0.tgz",
-			"integrity": "sha512-YszrmcB6o9HOsKPszK7NeDBNNjVyiW864jfoiHoMlgMIg2qlxKw70axZHqgczXHDcoyi/0/ikP1XaHDPRvYtEA==",
-			"requires": {
-				"warning": "3.0.0"
-			}
-		},
 		"loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",

--- a/packages/jss-plugin-syntax-rule-value-function/.size-snapshot.json
+++ b/packages/jss-plugin-syntax-rule-value-function/.size-snapshot.json
@@ -1,12 +1,12 @@
 {
   "dist/jss-plugin-syntax-rule-value-function.js": {
-    "bundled": 48457,
-    "minified": 19343,
-    "gzipped": 4994
+    "bundled": 2116,
+    "minified": 827,
+    "gzipped": 472
   },
   "dist/jss-plugin-syntax-rule-value-function.min.js": {
-    "bundled": 48457,
-    "minified": 19343,
-    "gzipped": 4994
+    "bundled": 2116,
+    "minified": 827,
+    "gzipped": 472
   }
 }

--- a/packages/jss-plugin-syntax-rule-value-function/src/index.js
+++ b/packages/jss-plugin-syntax-rule-value-function/src/index.js
@@ -1,8 +1,7 @@
 /* @flow */
-import {RuleList} from 'jss'
+import {RuleList, createRule} from 'jss'
 import type StyleRule from 'jss/src/rules/StyleRule'
 import type {Rule, JssStyle, RuleOptions} from 'jss/src/types'
-import createRule from 'jss/lib/utils/createRule'
 
 // A symbol replacement.
 let now = Date.now()

--- a/packages/jss-plugin-syntax-rule-value-observable/.size-snapshot.json
+++ b/packages/jss-plugin-syntax-rule-value-observable/.size-snapshot.json
@@ -1,12 +1,12 @@
 {
   "dist/jss-plugin-syntax-rule-value-observable.js": {
-    "bundled": 18075,
-    "minified": 5692,
-    "gzipped": 2083
+    "bundled": 3483,
+    "minified": 1102,
+    "gzipped": 530
   },
   "dist/jss-plugin-syntax-rule-value-observable.min.js": {
-    "bundled": 18075,
-    "minified": 5692,
-    "gzipped": 2083
+    "bundled": 3483,
+    "minified": 1102,
+    "gzipped": 530
   }
 }

--- a/packages/jss-plugin-syntax-rule-value-observable/src/index.js
+++ b/packages/jss-plugin-syntax-rule-value-observable/src/index.js
@@ -1,8 +1,8 @@
 /* @flow */
 import $$observable from 'symbol-observable'
+import {createRule} from 'jss'
 import type StyleRule from 'jss/src/rules/StyleRule'
-import createRule from 'jss/lib/utils/createRule'
-import type {Rule, RuleOptions, JssStyle} from '../../jss/src/types'
+import type {Rule, RuleOptions, JssStyle} from 'jss/src/types'
 import type {Observable} from './types'
 
 const isObservable = value => value && value[$$observable] && value === value[$$observable]()

--- a/packages/jss-plugin-syntax-template/.size-snapshot.json
+++ b/packages/jss-plugin-syntax-template/.size-snapshot.json
@@ -5,8 +5,8 @@
     "gzipped": 757
   },
   "dist/jss-plugin-syntax-template.min.js": {
-    "bundled": 4432,
-    "minified": 1338,
-    "gzipped": 757
+    "bundled": 4431,
+    "minified": 826,
+    "gzipped": 480
   }
 }

--- a/packages/jss-plugin-vendor-prefixer/.size-snapshot.json
+++ b/packages/jss-plugin-vendor-prefixer/.size-snapshot.json
@@ -1,12 +1,12 @@
 {
   "dist/jss-plugin-vendor-prefixer.js": {
-    "bundled": 73662,
-    "minified": 28029,
-    "gzipped": 6918
+    "bundled": 28046,
+    "minified": 9807,
+    "gzipped": 2725
   },
   "dist/jss-plugin-vendor-prefixer.min.js": {
-    "bundled": 73662,
-    "minified": 28029,
-    "gzipped": 6918
+    "bundled": 28046,
+    "minified": 9807,
+    "gzipped": 2725
   }
 }

--- a/packages/jss-preset-default/.size-snapshot.json
+++ b/packages/jss-preset-default/.size-snapshot.json
@@ -1,12 +1,12 @@
 {
   "dist/jss-preset-default.js": {
-    "bundled": 99929,
-    "minified": 37495,
-    "gzipped": 8895
+    "bundled": 54432,
+    "minified": 19378,
+    "gzipped": 5386
   },
   "dist/jss-preset-default.min.js": {
-    "bundled": 99929,
-    "minified": 37495,
-    "gzipped": 8895
+    "bundled": 54429,
+    "minified": 17846,
+    "gzipped": 5132
   }
 }

--- a/packages/jss/.size-snapshot.json
+++ b/packages/jss/.size-snapshot.json
@@ -1,12 +1,12 @@
 {
   "dist/jss.js": {
-    "bundled": 75403,
-    "minified": 21122,
-    "gzipped": 6196
+    "bundled": 75448,
+    "minified": 21137,
+    "gzipped": 6202
   },
   "dist/jss.min.js": {
-    "bundled": 75403,
-    "minified": 21122,
-    "gzipped": 6196
+    "bundled": 75445,
+    "minified": 20529,
+    "gzipped": 5891
   }
 }

--- a/packages/jss/package-lock.json
+++ b/packages/jss/package-lock.json
@@ -7,14 +7,6 @@
 			"resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
 			"integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
 		},
-		"is-observable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
-			"integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
-			"requires": {
-				"symbol-observable": "1.2.0"
-			}
-		},
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",

--- a/packages/jss/src/index.js
+++ b/packages/jss/src/index.js
@@ -20,6 +20,11 @@ export {default as getDynamicStyles} from './utils/getDynamicStyles'
 export {default as toCssValue} from './utils/toCssValue'
 
 /**
+ * Create a rule instance.
+ */
+export {default as createRule} from './utils/createRule'
+
+/**
  * SheetsRegistry for SSR.
  */
 export {default as SheetsRegistry} from './SheetsRegistry'


### PR DESCRIPTION
In this diff I refactored rollup config in favor of composition
instead of mixins.

- made createRule part of a public api; this allows to get rid from
interals usage in plugins
- peer dependencies are global in umd; this reduces plugins
size significantly
- changed development back to production mode in umd.min