### PR TITLE
Added typing to the cache plugin

### DIFF
--- a/packages/jss-plugin-cache/src/index.js
+++ b/packages/jss-plugin-cache/src/index.js
@@ -1,3 +1,6 @@
+// @flow
+import type {Plugin} from 'jss'
+
 /**
  * Tiny WeakMap like cache using arrays.
  * Required because we have frozen style objects in dev, which are not extensible,
@@ -20,7 +23,7 @@ class Cache {
   }
 }
 
-export default function cachePlugin() {
+export default function cachePlugin(): Plugin {
   const cache = new Cache()
 
   function onCreateRule(name, decl, {parent}) {

--- a/packages/jss/src/types/jss.js
+++ b/packages/jss/src/types/jss.js
@@ -66,6 +66,7 @@ export type RuleOptions = {
   selector?: string,
   sheet?: StyleSheet,
   index?: number,
+  parent?: ConditionalRule | KeyframesRule | StyleSheet,
   classes: Classes,
   jss: Jss,
   generateClassName: generateClassName,


### PR DESCRIPTION
@kof could it be that the `RuleOptions` is missing the `parent` property because we are accessing it in the plugin. That's also why the CI is failing.