### PR TITLE
Added typing to the isolate plugin

### DIFF
--- a/packages/jss-plugin-isolate/.size-snapshot.json
+++ b/packages/jss-plugin-isolate/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/jss-plugin-isolate.js": {
-    "bundled": 15176,
-    "minified": 9975,
-    "gzipped": 2837
+    "bundled": 15308,
+    "minified": 9980,
+    "gzipped": 2839
   },
   "dist/jss-plugin-isolate.min.js": {
-    "bundled": 15176,
-    "minified": 9975,
-    "gzipped": 2837
+    "bundled": 15308,
+    "minified": 9980,
+    "gzipped": 2839
   },
   "dist/jss-plugin-isolate.cjs.js": {
-    "bundled": 4991,
-    "minified": 2420,
-    "gzipped": 996
+    "bundled": 5127,
+    "minified": 2401,
+    "gzipped": 990
   },
   "dist/jss-plugin-isolate.esm.js": {
-    "bundled": 4753,
-    "minified": 2233,
-    "gzipped": 938,
+    "bundled": 4889,
+    "minified": 2214,
+    "gzipped": 933,
     "treeshaked": {
       "rollup": {
         "code": 56,

--- a/packages/jss-plugin-isolate/src/index.js
+++ b/packages/jss-plugin-isolate/src/index.js
@@ -39,15 +39,10 @@ const getStyle = (option = 'inherited') => {
   return inheritedInitials
 }
 
-const ignoreParents = {
-  keyframes: true,
-  conditional: true
-}
-
 const shouldIsolate = (rule: StyleRule, sheet, options) => {
   const {parent} = rule.options
 
-  if (parent && typeof parent.type === 'string' && ignoreParents[parent.type]) {
+  if (parent && (parent.type === 'keyframes' || parent.type === 'conditional')) {
     return false
   }
 

--- a/packages/jss-plugin-isolate/src/index.js
+++ b/packages/jss-plugin-isolate/src/index.js
@@ -47,7 +47,7 @@ const ignoreParents = {
 const shouldIsolate = (rule: StyleRule, sheet, options) => {
   const {parent} = rule.options
 
-  if (parent && ignoreParents[parent.type]) {
+  if (parent && typeof parent.type === 'string' && ignoreParents[parent.type]) {
     return false
   }
 

--- a/packages/jss-plugin-isolate/src/index.js
+++ b/packages/jss-plugin-isolate/src/index.js
@@ -1,5 +1,13 @@
+// @flow
 import inheritedInitials from 'css-initials/inherited'
 import allInitials from 'css-initials/all'
+import type {Plugin} from 'jss'
+import type StyleRule from 'jss/src/rules/StyleRule'
+
+type Options = {
+  isolate?: boolean | string,
+  reset?: 'all' | 'inherited' | Object | ['all' | 'inherited', Object]
+}
 
 const resetSheetOptions = {
   meta: 'jss-isolate',
@@ -37,7 +45,7 @@ const ignoreParents = {
   conditional: true
 }
 
-const shouldIsolate = (rule, sheet, options) => {
+const shouldIsolate = (rule: StyleRule, sheet, options) => {
   const {parent} = rule.options
 
   if (parent && ignoreParents[parent.type]) {
@@ -45,6 +53,7 @@ const shouldIsolate = (rule, sheet, options) => {
   }
 
   let isolate = options.isolate == null ? true : options.isolate
+  // $FlowFixMe: isolate is only added as an option by this plugin which means we can't type it in jss
   if (sheet.options.isolate != null) isolate = sheet.options.isolate
   if (rule.style.isolate != null) {
     isolate = rule.style.isolate
@@ -77,11 +86,11 @@ const createDebounced = (fn, delay = 3) => {
   }
 }
 
-export default function jssIsolate(options = {}) {
+export default function jssIsolate(options: Options = {}): Plugin {
   let setSelectorDone = false
   const selectors = []
   let resetSheet
-  let resetRule
+  let resetRule: StyleRule
 
   const setSelector = () => {
     resetRule.selector = selectors.join(',\n')
@@ -92,17 +101,20 @@ export default function jssIsolate(options = {}) {
   function onProcessRule(rule, sheet) {
     if (!sheet || sheet === resetSheet || rule.type !== 'style') return
 
+    // Type it as a StyleRule
+    rule = ((rule: any): StyleRule)
+
     if (!shouldIsolate(rule, sheet, options)) return
 
     // Create a reset Style Sheet once and use it for all rules.
     if (!resetRule) {
-      resetSheet = rule.options.jss.createStyleSheet(null, resetSheetOptions)
-      resetRule = resetSheet.addRule('reset', getStyle(options.reset))
+      resetSheet = rule.options.jss.createStyleSheet({}, resetSheetOptions)
+      resetRule = ((resetSheet.addRule('reset', getStyle(options.reset)): any): StyleRule)
       resetSheet.attach()
     }
 
     // Add reset rule class name to the classes map of users Style Sheet.
-    const {selector} = rule
+    const {selector} = (rule: StyleRule)
     if (selectors.indexOf(selector) === -1) {
       selectors.push(selector)
       setSelectorDone = setSelectorDebounced()

--- a/packages/jss-plugin-isolate/src/index.js
+++ b/packages/jss-plugin-isolate/src/index.js
@@ -1,8 +1,7 @@
 // @flow
 import inheritedInitials from 'css-initials/inherited'
 import allInitials from 'css-initials/all'
-import type {Plugin} from 'jss'
-import type StyleRule from 'jss/src/rules/StyleRule'
+import type {Plugin, StyleRule} from 'jss'
 
 type Options = {
   isolate?: boolean | string,

--- a/packages/jss-plugin-syntax-rule-value-function/.size-snapshot.json
+++ b/packages/jss-plugin-syntax-rule-value-function/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "dist/jss-plugin-syntax-rule-value-function.js": {
-    "bundled": 2112,
+    "bundled": 2085,
     "minified": 842,
     "gzipped": 479
   },
   "dist/jss-plugin-syntax-rule-value-function.min.js": {
-    "bundled": 2112,
+    "bundled": 2085,
     "minified": 842,
     "gzipped": 479
   },
   "dist/jss-plugin-syntax-rule-value-function.cjs.js": {
-    "bundled": 1709,
+    "bundled": 1684,
     "minified": 752,
     "gzipped": 416
   },
   "dist/jss-plugin-syntax-rule-value-function.esm.js": {
-    "bundled": 1637,
+    "bundled": 1612,
     "minified": 693,
     "gzipped": 369,
     "treeshaked": {

--- a/packages/jss-plugin-syntax-rule-value-function/src/index.js
+++ b/packages/jss-plugin-syntax-rule-value-function/src/index.js
@@ -1,7 +1,5 @@
 /* @flow */
-import {RuleList, createRule} from 'jss'
-import type StyleRule from 'jss/src/rules/StyleRule'
-import type {Rule, JssStyle, RuleOptions} from 'jss/src/types'
+import {RuleList, createRule, type Rule, type JssStyle, type RuleOptions, type StyleRule} from 'jss'
 
 // A symbol replacement.
 let now = Date.now()

--- a/packages/jss-plugin-syntax-rule-value-observable/src/index.js
+++ b/packages/jss-plugin-syntax-rule-value-observable/src/index.js
@@ -1,8 +1,6 @@
 /* @flow */
 import $$observable from 'symbol-observable'
-import {createRule} from 'jss'
-import type StyleRule from 'jss/src/rules/StyleRule'
-import type {Rule, RuleOptions, JssStyle} from 'jss/src/types'
+import {createRule, type StyleRule, type Rule, type RuleOptions, type JssStyle} from 'jss'
 import type {Observable} from './types'
 
 const isObservable = value => value && value[$$observable] && value === value[$$observable]()

--- a/packages/jss/src/index.js
+++ b/packages/jss/src/index.js
@@ -7,7 +7,13 @@
  * @license MIT
  */
 import Jss from './Jss'
-import StyleSheet from './StyleSheet'
+import type StyleSheet from './StyleSheet'
+import type ConditionalRule from './rules/ConditionalRule'
+import type KeyframesRule from './rules/KeyframesRule'
+import type StyleRule from './rules/StyleRule'
+import type ViewportRule from './rules/ViewportRule'
+import type SimpleRule from './rules/SimpleRule'
+import type FontFaceRule from './rules/FontFaceRule'
 import type {JssOptions} from './types'
 
 /**
@@ -26,7 +32,16 @@ export type {
   RuleOptions,
   Classes
 } from './types'
-export type {Jss, StyleSheet}
+export type {
+  Jss,
+  StyleSheet,
+  ConditionalRule,
+  KeyframesRule,
+  StyleRule,
+  ViewportRule,
+  SimpleRule,
+  FontFaceRule
+}
 
 /**
  * Extracts a styles object with only rules that contain function values.

--- a/packages/jss/src/types/jss.js
+++ b/packages/jss/src/types/jss.js
@@ -66,7 +66,7 @@ export type RuleOptions = {
   selector?: string,
   sheet?: StyleSheet,
   index?: number,
-  parent?: ConditionalRule | KeyframesRule | StyleSheet,
+  parent?: ConditionalRule | KeyframesRule,
   classes: Classes,
   jss: Jss,
   generateClassName: generateClassName,

--- a/packages/jss/src/types/jss.js
+++ b/packages/jss/src/types/jss.js
@@ -66,7 +66,7 @@ export type RuleOptions = {
   selector?: string,
   sheet?: StyleSheet,
   index?: number,
-  parent?: ConditionalRule | KeyframesRule,
+  parent?: ConditionalRule | KeyframesRule | StyleSheet,
   classes: Classes,
   jss: Jss,
   generateClassName: generateClassName,


### PR DESCRIPTION
Same problem with the `RuleOptions` as in #779.

Also, I'm importing the type of the StyleRule from the src. We should maybe export the Rules as well as they are needed for better typing in some of the plugins.