### PR TITLE
Added typings to the camel case plugin

### DIFF
--- a/packages/jss-plugin-syntax-camel-case/src/index.js
+++ b/packages/jss-plugin-syntax-camel-case/src/index.js
@@ -1,3 +1,5 @@
+// @flow
+import type {Plugin} from 'jss'
 import hyphenate from 'hyphenate-style-name'
 
 /**
@@ -26,7 +28,7 @@ function convertCase(style) {
  *
  * @param {Rule} rule
  */
-export default function camelCase() {
+export default function camelCase(): Plugin {
   function onProcessStyle(style) {
     if (Array.isArray(style)) {
       // Handle rules like @font-face, which can have multiple styles in an array

--- a/packages/jss/src/types/jss.js
+++ b/packages/jss/src/types/jss.js
@@ -95,7 +95,7 @@ export type Plugin = {
   onProcessRule?: (rule: Rule, sheet?: StyleSheet) => void,
   onProcessStyle?: (style: JssStyle, rule: Rule, sheet?: StyleSheet) => JssStyle,
   onProcessSheet?: (sheet?: StyleSheet) => void,
-  onChangeValue?: (value: string, prop: string, rule: Rule) => string,
+  onChangeValue?: (value: string, prop: string, rule: StyleRule) => string | null | false,
   onUpdate?: (data: Object, rule: Rule, sheet?: StyleSheet) => void
 }
 


### PR DESCRIPTION
Updated the type definition of the onChangeValue function inside Plugins, because we call the onChangeValue only in the StyleRule.