### PR TITLE
Added typing to jss-preset-default

### DIFF
--- a/packages/jss-plugin-syntax-default-unit/src/index.js
+++ b/packages/jss-plugin-syntax-default-unit/src/index.js
@@ -52,7 +52,7 @@ function iterate(prop, value, options) {
   return convertedValue
 }
 
-type Options = {[key: string]: string}
+export type Options = {[key: string]: string}
 
 /**
  * Add unit to numeric values.

--- a/packages/jss-preset-default/src/index.js
+++ b/packages/jss-preset-default/src/index.js
@@ -1,29 +1,32 @@
+// @flow
 import functions from 'jss-plugin-syntax-rule-value-function'
 import observable from 'jss-plugin-syntax-rule-value-observable'
 import template from 'jss-plugin-syntax-template'
 import global from 'jss-plugin-syntax-global'
-// import extend from 'jss-plugin-syntax-extend'
+import extend from 'jss-plugin-syntax-extend'
 import nested from 'jss-plugin-syntax-nested'
 import compose from 'jss-plugin-syntax-compose'
 import camelCase from 'jss-plugin-syntax-camel-case'
-// import defaultUnit from 'jss-plugin-syntax-default-unit'
-// import expand from 'jss-plugin-syntax-expand'
+import defaultUnit, {type Options as DefaultUnitOptions} from 'jss-plugin-syntax-default-unit'
+import expand from 'jss-plugin-syntax-expand'
 import vendorPrefixer from 'jss-plugin-vendor-prefixer'
 import propsSort from 'jss-plugin-props-sort'
 
-export default (options = {}) => ({
+type Options = {defaultUnit?: DefaultUnitOptions}
+
+export default (options: Options = {}) => ({
   plugins: [
-    functions(options.function),
-    observable(options.observable),
-    template(options.template),
-    global(options.global),
-    // extend(options.extend),
-    nested(options.nested),
-    compose(options.compose),
-    camelCase(options.camelCase),
-    // defaultUnit(options.defaultUnit),
-    // expand(options.expand),
-    vendorPrefixer(options.vendorPrefixer),
-    propsSort(options.propsSort)
+    functions(),
+    observable(),
+    template(),
+    global(),
+    extend(),
+    nested(),
+    compose(),
+    camelCase(),
+    defaultUnit(options.defaultUnit),
+    expand(),
+    vendorPrefixer(),
+    propsSort()
   ]
 })


### PR DESCRIPTION
I had to manually export and import the options because Flow doesn't seem to know how to extract function parameters sadly.