### PR TITLE
fix(jss): Wrong sheet order when the insertion point is a DOM element.

### DIFF
--- a/packages/jss-plugin-syntax-extend/.size-snapshot.json
+++ b/packages/jss-plugin-syntax-extend/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "dist/jss-plugin-syntax-extend.js": {
-    "bundled": 6646,
+    "bundled": 6945,
     "minified": 2004,
     "gzipped": 993
   },
   "dist/jss-plugin-syntax-extend.min.js": {
-    "bundled": 5108,
+    "bundled": 5407,
     "minified": 1484,
     "gzipped": 716
   },
   "dist/jss-plugin-syntax-extend.cjs.js": {
-    "bundled": 3117,
+    "bundled": 3404,
     "minified": 1384,
     "gzipped": 620
   },
   "dist/jss-plugin-syntax-extend.esm.js": {
-    "bundled": 2899,
+    "bundled": 3186,
     "minified": 1216,
     "gzipped": 551,
     "treeshaked": {

--- a/packages/jss-preset-default/.size-snapshot.json
+++ b/packages/jss-preset-default/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "dist/jss-preset-default.js": {
-    "bundled": 50916,
-    "minified": 17370,
-    "gzipped": 5038
+    "bundled": 70985,
+    "minified": 25510,
+    "gzipped": 7103
   },
   "dist/jss-preset-default.min.js": {
-    "bundled": 47564,
-    "minified": 15810,
-    "gzipped": 4762
+    "bundled": 66515,
+    "minified": 23430,
+    "gzipped": 6821
   },
   "dist/jss-preset-default.cjs.js": {
-    "bundled": 1367,
-    "minified": 1033,
-    "gzipped": 375
+    "bundled": 1381,
+    "minified": 1174,
+    "gzipped": 393
   },
   "dist/jss-preset-default.esm.js": {
-    "bundled": 989,
-    "minified": 745,
-    "gzipped": 296,
+    "bundled": 943,
+    "minified": 841,
+    "gzipped": 315,
     "treeshaked": {
       "rollup": {
-        "code": 331,
-        "import_statements": 331
+        "code": 436,
+        "import_statements": 436
       },
       "webpack": {
-        "code": 1579
+        "code": 1786
       }
     }
   }

--- a/packages/jss/.size-snapshot.json
+++ b/packages/jss/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "dist/jss.js": {
-    "bundled": 70577,
-    "minified": 20173,
-    "gzipped": 6124
+    "bundled": 70552,
+    "minified": 20157,
+    "gzipped": 6118
   },
   "dist/jss.min.js": {
-    "bundled": 69339,
-    "minified": 19555,
-    "gzipped": 5805
+    "bundled": 69314,
+    "minified": 19539,
+    "gzipped": 5799
   },
   "dist/jss.cjs.js": {
-    "bundled": 48406,
-    "minified": 20842,
-    "gzipped": 5950
+    "bundled": 48381,
+    "minified": 20826,
+    "gzipped": 5947
   },
   "dist/jss.esm.js": {
-    "bundled": 47981,
-    "minified": 20488,
-    "gzipped": 5866,
+    "bundled": 47956,
+    "minified": 20472,
+    "gzipped": 5859,
     "treeshaked": {
       "rollup": {
-        "code": 17463,
+        "code": 17447,
         "import_statements": 85
       },
       "webpack": {
-        "code": 18755
+        "code": 18739
       }
     }
   }

--- a/packages/jss/src/renderers/DomRenderer.js
+++ b/packages/jss/src/renderers/DomRenderer.js
@@ -263,7 +263,7 @@ function insertStyle(style: HTMLElement, options: PriorityOptions) {
     // https://stackoverflow.com/questions/41328728/force-casting-in-flow
     const insertionPointElement: HTMLElement = (insertionPoint: any)
     const {parentNode} = insertionPointElement
-    if (parentNode) parentNode.insertBefore(style, insertionPointElement.nextSibling)
+    if (parentNode) parentNode.insertBefore(style, prevNode)
     else warning(false, '[JSS] Insertion point is not in the DOM.')
     return
   }

--- a/packages/jss/tests/functional/priority.js
+++ b/packages/jss/tests/functional/priority.js
@@ -193,25 +193,29 @@ describe('Functional: dom priority', () => {
     let insertionPoint
     let sheet1
     let sheet2
+    let sheet3
     beforeEach(() => {
       insertionPoint = document.body.appendChild(document.createElement('div'))
       const jss = create({insertionPoint})
       sheet2 = jss.createStyleSheet({}, {meta: 'sheet2', index: 2}).attach()
       sheet1 = jss.createStyleSheet({}, {meta: 'sheet1', index: 1}).attach()
+      sheet3 = jss.createStyleSheet({}, {meta: 'sheet3', index: 3}).attach()
     })
 
     afterEach(() => {
       document.body.removeChild(insertionPoint)
       sheet2.detach()
       sheet1.detach()
+      sheet3.detach()
     })
 
     it('should insert sheets in the correct order', () => {
       const styleElements = document.body.getElementsByTagName('style')
 
-      expect(styleElements.length).to.be(2)
+      expect(styleElements.length).to.be(3)
       expect(styleElements[0].getAttribute('data-meta')).to.be('sheet1')
       expect(styleElements[1].getAttribute('data-meta')).to.be('sheet2')
+      expect(styleElements[2].getAttribute('data-meta')).to.be('sheet3')
     })
   })
 

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/react-jss.js": {
-    "bundled": 210195,
-    "minified": 57193,
-    "gzipped": 15857
+    "bundled": 236799,
+    "minified": 65315,
+    "gzipped": 17965
   },
   "dist/react-jss.min.js": {
-    "bundled": 176301,
-    "minified": 48360,
-    "gzipped": 13683
+    "bundled": 201497,
+    "minified": 55962,
+    "gzipped": 15781
   },
   "dist/react-jss.cjs.js": {
     "bundled": 17646,


### PR DESCRIPTION
When a new sheet is added with an index higher than all of those that already exist and the insertion point is an element the style sheets are actually added to the top of the list of sheets instead of the bottom.

The logic for inserting into the head vs inserting into a different element should be the same but currently isn't.

The modified test fails without the change and passes after.

This bug is particularly impactful when using the ShadowDOM as styles need to be added to an element within the shadow tree instead of the head and currently prevents using material-ui components inside a shadow root.

Fixes #752