### PR TITLE
Fix snapshot sizes and run prettier

### DIFF
--- a/packages/jss-plugin-syntax-compose/readme.md
+++ b/packages/jss-plugin-syntax-compose/readme.md
@@ -26,6 +26,7 @@ const styles = {
   }
 }
 ```
+
 Compiles to:
 
 ```css
@@ -43,7 +44,9 @@ When you use it:
 <button className={classes.button}>Button</button>
 <button className={classes.buttonActive}>Active Button</button>
 ```
+
 It renders to:
+
 ```html
 <button class="button-123456 btn">Button</button>
 <button class="buttonActive-123456 btn btn-primary">Active Button</button>
@@ -110,7 +113,9 @@ When you use it:
 <button className={classes.buttonActiveDisabled}>Active Disabled Button</button>
 <button className={classes.buttonDisabled}>Disabled Button with active state</button>
 ```
+
 It renders to:
+
 ```html
 <button class="buttonActiveDisabled-123456 buttonActive-123456 button-123456">Active Disabled Button</button>
 <button class="buttonDisabled-123456 button-123456 active-123456 disabled-123456">Disabled Button with active state</button>
@@ -148,7 +153,9 @@ When you use it:
 ```javascript
 <button className={classes.button}>Button</button>
 ```
+
 It renders to:
+
 ```html
 <button class="button-123456 active-123456 btn btn-primary">Button</button>
 ```

--- a/packages/jss-plugin-syntax-extend/.size-snapshot.json
+++ b/packages/jss-plugin-syntax-extend/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "dist/jss-plugin-syntax-extend.js": {
-    "bundled": 6646,
+    "bundled": 6945,
     "minified": 2004,
     "gzipped": 993
   },
   "dist/jss-plugin-syntax-extend.min.js": {
-    "bundled": 5108,
+    "bundled": 5407,
     "minified": 1484,
     "gzipped": 716
   },
   "dist/jss-plugin-syntax-extend.cjs.js": {
-    "bundled": 3117,
+    "bundled": 3404,
     "minified": 1384,
     "gzipped": 620
   },
   "dist/jss-plugin-syntax-extend.esm.js": {
-    "bundled": 2899,
+    "bundled": 3186,
     "minified": 1216,
     "gzipped": 551,
     "treeshaked": {

--- a/packages/jss-preset-default/.size-snapshot.json
+++ b/packages/jss-preset-default/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "dist/jss-preset-default.js": {
-    "bundled": 50916,
-    "minified": 17370,
-    "gzipped": 5038
+    "bundled": 70985,
+    "minified": 25510,
+    "gzipped": 7103
   },
   "dist/jss-preset-default.min.js": {
-    "bundled": 47564,
-    "minified": 15810,
-    "gzipped": 4762
+    "bundled": 66515,
+    "minified": 23430,
+    "gzipped": 6821
   },
   "dist/jss-preset-default.cjs.js": {
-    "bundled": 1367,
-    "minified": 1033,
-    "gzipped": 375
+    "bundled": 1381,
+    "minified": 1174,
+    "gzipped": 393
   },
   "dist/jss-preset-default.esm.js": {
-    "bundled": 989,
-    "minified": 745,
-    "gzipped": 296,
+    "bundled": 943,
+    "minified": 841,
+    "gzipped": 315,
     "treeshaked": {
       "rollup": {
-        "code": 331,
-        "import_statements": 331
+        "code": 436,
+        "import_statements": 436
       },
       "webpack": {
-        "code": 1579
+        "code": 1786
       }
     }
   }

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/react-jss.js": {
-    "bundled": 210195,
-    "minified": 57193,
-    "gzipped": 15857
+    "bundled": 236824,
+    "minified": 65331,
+    "gzipped": 17972
   },
   "dist/react-jss.min.js": {
-    "bundled": 176301,
-    "minified": 48360,
-    "gzipped": 13683
+    "bundled": 201522,
+    "minified": 55978,
+    "gzipped": 15787
   },
   "dist/react-jss.cjs.js": {
     "bundled": 17646,


### PR DESCRIPTION
For some reason, the snapshot files got out of date, and prettier didn't rewrite a markdown file.