### PR TITLE
Update js-api.md

### DIFF
--- a/docs/js-api.md
+++ b/docs/js-api.md
@@ -37,7 +37,7 @@ Options:
 - `virtual` - if true, JSS will use VirtualRenderer.
 - `insertionPoint` - string value of a DOM comment node which marks the start of sheets or a rendered DOM node. Sheets rendered by this Jss instance are inserted after this point sequentially.
 
-**Note**: Each `jss.setup()` call will perform a shallow merge with the old options except for `plugins`. Passed `plugins` will be added to the existing plugins if they do not already exist.
+**Note**: Each `jss.setup()` call will perform a shallow merge with the old options except for `plugins`. Passed `plugins` will be added to the existing plugins.
 
 
 See [setup examples](./setup.md#specify-dom-insertion-point).

--- a/docs/js-api.md
+++ b/docs/js-api.md
@@ -37,6 +37,9 @@ Options:
 - `virtual` - if true, JSS will use VirtualRenderer.
 - `insertionPoint` - string value of a DOM comment node which marks the start of sheets or a rendered DOM node. Sheets rendered by this Jss instance are inserted after this point sequentially.
 
+**Note**: Each `jss.setup()` call will perform a shallow merge with the old options except for `plugins`. Passed `plugins` will be added to the existing plugins if they do not already exist.
+
+
 See [setup examples](./setup.md#specify-dom-insertion-point).
 
 ## Quick setup with preset

--- a/docs/js-api.md
+++ b/docs/js-api.md
@@ -37,8 +37,6 @@ Options:
 - `virtual` - if true, JSS will use VirtualRenderer.
 - `insertionPoint` - string value of a DOM comment node which marks the start of sheets or a rendered DOM node. Sheets rendered by this Jss instance are inserted after this point sequentially.
 
-**Note**: Each `jss.setup()` call will overwrite all previous settings.
-
 See [setup examples](./setup.md#specify-dom-insertion-point).
 
 ## Quick setup with preset


### PR DESCRIPTION
__What would you like to add/fix?__
- Fix note about setup overwrite

Looking at the source https://github.com/cssinjs/jss/blob/dd20297caba69ac4c390f1460dca0034691f4a2a/packages/jss/src/Jss.js#L47 options are merged on setup not completely overwritten.

I'm also asking because `react-jss` expects the options to be public readonly and the typings over at DefinitelyTyped do not have options listed either. 

All of which is no direct concern of you but I'd like to get some feedback before I work on PRs in those packages. Might also be a good idea to document the options property in the api docs.