### PR TITLE
react-jss: Remove usage of deprecated lifecycle methods (#802)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,9 @@
   "rules": {
     "import/no-unresolved": 0,
     "flowtype/define-flow-type": 1,
-    "flowtype/use-flow-type": 1
+    "flowtype/use-flow-type": 1,
+    "react/no-did-mount-set-state": 0,
+    "react/no-did-update-set-state": 0
   },
   "globals": {
     "benchmark": true,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/react-jss.js": {
-    "bundled": 237577,
-    "minified": 64861,
-    "gzipped": 18070
+    "bundled": 237881,
+    "minified": 64802,
+    "gzipped": 18064
   },
   "dist/react-jss.min.js": {
-    "bundled": 202268,
-    "minified": 55514,
-    "gzipped": 15888
+    "bundled": 202572,
+    "minified": 55455,
+    "gzipped": 15887
   },
   "dist/react-jss.cjs.js": {
-    "bundled": 16929,
-    "minified": 7086,
-    "gzipped": 2428
+    "bundled": 17185,
+    "minified": 7027,
+    "gzipped": 2423
   },
   "dist/react-jss.esm.js": {
-    "bundled": 16379,
-    "minified": 6616,
-    "gzipped": 2316,
+    "bundled": 16635,
+    "minified": 6557,
+    "gzipped": 2310,
     "treeshaked": {
       "rollup": {
         "code": 1979,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/react-jss.js": {
-    "bundled": 237881,
-    "minified": 64802,
-    "gzipped": 18064
+    "bundled": 237176,
+    "minified": 64744,
+    "gzipped": 18046
   },
   "dist/react-jss.min.js": {
-    "bundled": 202572,
-    "minified": 55455,
-    "gzipped": 15887
+    "bundled": 201867,
+    "minified": 55397,
+    "gzipped": 15869
   },
   "dist/react-jss.cjs.js": {
-    "bundled": 17185,
-    "minified": 7027,
-    "gzipped": 2423
+    "bundled": 16624,
+    "minified": 6969,
+    "gzipped": 2405
   },
   "dist/react-jss.esm.js": {
-    "bundled": 16635,
-    "minified": 6557,
-    "gzipped": 2310,
+    "bundled": 16074,
+    "minified": 6499,
+    "gzipped": 2295,
     "treeshaked": {
       "rollup": {
         "code": 1979,

--- a/packages/react-jss/src/JssProvider.test.js
+++ b/packages/react-jss/src/JssProvider.test.js
@@ -270,9 +270,7 @@ describe('JssProvider', () => {
       })
 
       class MyComponent extends Component {
-        componentWillMount() {
-          this.value = true
-        }
+        value = true
 
         render() {
           this.value = !this.value

--- a/packages/react-jss/src/createHoc.js
+++ b/packages/react-jss/src/createHoc.js
@@ -110,9 +110,6 @@ export default function createHOC<
       const theme = isThemingEnabled ? themeListener.initial(context) : noTheme
 
       this.state = this.createState({theme, classes: {}}, props)
-    }
-
-    componentWillMount() {
       this.manage(this.state)
     }
 
@@ -121,23 +118,22 @@ export default function createHOC<
         this.unsubscribeId = themeListener.subscribe(this.context, this.setTheme)
       }
     }
-
+    // TODO: remove this lifecycle when migrating to new Context API
     componentWillReceiveProps(nextProps: OuterPropsType, nextContext: Context) {
       this.context = nextContext
-      const {dynamicSheet} = this.state
-      if (dynamicSheet) dynamicSheet.update(nextProps)
-    }
-
-    componentWillUpdate(nextProps: OuterPropsType, nextState: State) {
-      if (isThemingEnabled && this.state.theme !== nextState.theme) {
-        const newState = this.createState(nextState, nextProps)
-        this.manage(newState)
-        this.manager.unmanage(this.state.theme)
-        this.setState(newState)
-      }
     }
 
     componentDidUpdate(prevProps: OuterPropsType, prevState: State) {
+      const {dynamicSheet} = this.state
+      if (dynamicSheet) dynamicSheet.update(this.props)
+
+      if (isThemingEnabled && this.state.theme !== prevState.theme) {
+        const newState = this.createState(this.state, this.props)
+        this.manage(newState)
+        this.manager.unmanage(prevState.theme)
+        this.setState(newState)
+      }
+
       // We remove previous dynamicSheet only after new one was created to avoid FOUC.
       if (prevState.dynamicSheet !== this.state.dynamicSheet && prevState.dynamicSheet) {
         this.jss.removeStyleSheet(prevState.dynamicSheet)

--- a/packages/react-jss/src/createHoc.js
+++ b/packages/react-jss/src/createHoc.js
@@ -118,10 +118,6 @@ export default function createHOC<
         this.unsubscribeId = themeListener.subscribe(this.context, this.setTheme)
       }
     }
-    // TODO: remove this lifecycle when migrating to new Context API
-    componentWillReceiveProps(nextProps: OuterPropsType, nextContext: Context) {
-      this.context = nextContext
-    }
 
     componentDidUpdate(prevProps: OuterPropsType, prevState: State) {
       const {dynamicSheet} = this.state

--- a/packages/react-jss/src/injectSheet.test.js
+++ b/packages/react-jss/src/injectSheet.test.js
@@ -37,6 +37,21 @@ describe('injectSheet', () => {
       })()
     })
 
+    it.skip('should work in StrictMode without error on React 16.3+', () => {
+      if (!React.StrictMode) {
+        return
+      }
+      spy(console, 'error')
+      render(
+        <React.StrictMode>
+          <MyComponent />
+        </React.StrictMode>,
+        node
+      )
+      expect(console.error.notCalled).to.be(true)
+      console.error.restore()
+    })
+
     it('should attach and detach a sheet', () => {
       render(<MyComponent />, node)
       expect(document.querySelectorAll('style').length).to.be(1)

--- a/packages/react-jss/src/injectSheet.test.js
+++ b/packages/react-jss/src/injectSheet.test.js
@@ -37,7 +37,7 @@ describe('injectSheet', () => {
       })()
     })
 
-    it.skip('should work in StrictMode without error on React 16.3+', () => {
+    it('should work in StrictMode without error on React 16.3+', () => {
       if (!React.StrictMode) {
         return
       }
@@ -48,8 +48,10 @@ describe('injectSheet', () => {
         </React.StrictMode>,
         node
       )
+      /* eslint-disable no-console */
       expect(console.error.notCalled).to.be(true)
       console.error.restore()
+      /* eslint-enable no-console */
     })
 
     it('should attach and detach a sheet', () => {


### PR DESCRIPTION
Addressing #802 

I had removed (almost) all of the usage of old lifecycle methods. I had not removed the `componentWillReceiveProps` because it is currently used for `context`, hence I also skipped the new `StrictMode` test.

For eslint, I had turned off `react/no-did-mount-set-state` and `react/no-did-update-set-state` (as written in [React's blog post](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#fetching-external-data-when-props-change)):

> Sometimes people use componentWillUpdate out of a misplaced fear that by the time componentDidUpdate fires, it is “too late” to update the state of other components. This is not the case. React ensures that any setState calls that happen during componentDidMount and componentDidUpdate are flushed before the user sees the updated UI. 

However, I am not sure if that's the case for versions prior `16.3`.