### PR TITLE
[react-jss] Drop React 0.13

### DIFF
--- a/packages/react-jss/package.json
+++ b/packages/react-jss/package.json
@@ -36,7 +36,7 @@
     "prepare": "node ../../scripts/prepare.js"
   },
   "peerDependencies": {
-    "react": ">=0.13"
+    "react": ">=0.14"
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",


### PR DESCRIPTION
__What would you like to add/fix?__ Drop react 0.13 to eventually switch to the new context API polyfill.

__Corresponding issue (if exists):__ #836 
