### PR TITLE
Added withTheme option

### DIFF
--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/react-jss.js": {
-    "bundled": 173003,
-    "minified": 61728,
-    "gzipped": 17826
+    "bundled": 170386,
+    "minified": 60909,
+    "gzipped": 17535
   },
   "dist/react-jss.min.js": {
-    "bundled": 149829,
-    "minified": 54460,
-    "gzipped": 15670
+    "bundled": 147212,
+    "minified": 53641,
+    "gzipped": 15375
   },
   "dist/react-jss.cjs.js": {
-    "bundled": 16624,
-    "minified": 6969,
-    "gzipped": 2405
+    "bundled": 16678,
+    "minified": 6986,
+    "gzipped": 2418
   },
   "dist/react-jss.esm.js": {
-    "bundled": 16074,
-    "minified": 6499,
-    "gzipped": 2295,
+    "bundled": 16128,
+    "minified": 6516,
+    "gzipped": 2307,
     "treeshaked": {
       "rollup": {
         "code": 1979,

--- a/packages/react-jss/src/createHoc.js
+++ b/packages/react-jss/src/createHoc.js
@@ -80,7 +80,8 @@ export default function createHOC<
   InnerComponent: InnerComponentType,
   options: Options
 ): ComponentType<OuterPropsType> {
-  const isThemingEnabled = typeof stylesOrCreator === 'function'
+  const isThemedStyles = typeof stylesOrCreator === 'function'
+  const isThemingEnabled = isThemedStyles || options.withTheme
   const {theming = defaultTheming, inject, jss: optionsJss, ...sheetOptions} = options
   const injectMap = inject ? toMap(inject) : defaultInjectProps
   const {themeListener} = theming
@@ -123,7 +124,7 @@ export default function createHOC<
       const {dynamicSheet} = this.state
       if (dynamicSheet) dynamicSheet.update(this.props)
 
-      if (isThemingEnabled && this.state.theme !== prevState.theme) {
+      if (isThemedStyles && this.state.theme !== prevState.theme) {
         const newState = this.createState(this.state, this.props)
         this.manage(newState)
         this.manager.unmanage(prevState.theme)
@@ -169,7 +170,7 @@ export default function createHOC<
         staticSheet = this.jss.createStyleSheet(styles, {
           ...sheetOptions,
           ...contextSheetOptions,
-          meta: `${displayName}, ${isThemingEnabled ? 'Themed' : 'Unthemed'}, Static`,
+          meta: `${displayName}, ${isThemedStyles ? 'Themed' : 'Unthemed'}, Static`,
           classNamePrefix
         })
         this.manager.add(theme, staticSheet)
@@ -184,7 +185,7 @@ export default function createHOC<
         dynamicSheet = this.jss.createStyleSheet(dynamicStyles, {
           ...sheetOptions,
           ...contextSheetOptions,
-          meta: `${displayName}, ${isThemingEnabled ? 'Themed' : 'Unthemed'}, Dynamic`,
+          meta: `${displayName}, ${isThemedStyles ? 'Themed' : 'Unthemed'}, Dynamic`,
           classNamePrefix,
           link: true
         })

--- a/packages/react-jss/src/createHoc.js
+++ b/packages/react-jss/src/createHoc.js
@@ -126,8 +126,9 @@ export default function createHOC<
 
       if (isThemedStyles && this.state.theme !== prevState.theme) {
         const newState = this.createState(this.state, this.props)
+        const managerTheme = isThemedStyles ? prevState.theme : noTheme
         this.manage(newState)
-        this.manager.unmanage(prevState.theme)
+        this.manager.unmanage(managerTheme)
         this.setState(newState)
       }
 
@@ -142,7 +143,9 @@ export default function createHOC<
         themeListener.unsubscribe(this.context, this.unsubscribeId)
       }
 
-      this.manager.unmanage(this.state.theme)
+      const managerTheme = isThemedStyles ? this.state.theme : noTheme
+
+      this.manager.unmanage(managerTheme)
       if (this.state.dynamicSheet) {
         this.jss.removeStyleSheet(this.state.dynamicSheet)
       }
@@ -159,7 +162,8 @@ export default function createHOC<
       }
 
       let classNamePrefix = defaultClassNamePrefix
-      let staticSheet = this.manager.get(theme)
+      const managerTheme = isThemedStyles ? theme : noTheme
+      let staticSheet = this.manager.get(managerTheme)
 
       if (contextSheetOptions && contextSheetOptions.classNamePrefix) {
         classNamePrefix = contextSheetOptions.classNamePrefix + classNamePrefix
@@ -173,7 +177,7 @@ export default function createHOC<
           meta: `${displayName}, ${isThemedStyles ? 'Themed' : 'Unthemed'}, Static`,
           classNamePrefix
         })
-        this.manager.add(theme, staticSheet)
+        this.manager.add(managerTheme, staticSheet)
         // $FlowFixMe Cannot add random fields to instance of class StyleSheet
         staticSheet[dynamicStylesNs] = getDynamicStyles(styles)
       }
@@ -216,8 +220,9 @@ export default function createHOC<
         return
       }
       const registry = this.context[ns.sheetsRegistry]
+      const managerTheme = isThemedStyles ? theme : noTheme
 
-      const staticSheet = this.manager.manage(theme)
+      const staticSheet = this.manager.manage(managerTheme)
       if (registry) registry.add(staticSheet)
 
       if (dynamicSheet) {
@@ -247,8 +252,9 @@ export default function createHOC<
 
     render() {
       const {theme, dynamicSheet, classes} = this.state
+      const managerTheme = isThemedStyles ? theme : noTheme
       const {innerRef, ...props}: OuterPropsType = this.props
-      const sheet = dynamicSheet || this.manager.get(theme)
+      const sheet = dynamicSheet || this.manager.get(managerTheme)
 
       if (injectMap.sheet && !props.sheet) props.sheet = sheet
       if (isThemingEnabled && injectMap.theme && !props.theme) props.theme = theme

--- a/packages/react-jss/src/types.js
+++ b/packages/react-jss/src/types.js
@@ -20,6 +20,7 @@ type Theming = {
 }
 
 export type Options = {
+  withTheme?: boolean,
   theming?: Theming,
   inject?: Array<'classes' | 'themes' | 'sheet'>,
   jss?: Jss


### PR DESCRIPTION
__What would you like to add/fix?__ Add an option for manually subscribing to the theme and passing it down to the component, even if the styles aren't themed.

__Fixed:__ Currently, there are still multiple stylesheets for different themes generated even though the styles aren't different. 

__Corresponding issue:__ #856 
