### PR TITLE
Update json-api.md

### DIFF
--- a/docs/json-api.md
+++ b/docs/json-api.md
@@ -154,7 +154,7 @@ const animationId = random()
 const styles = {
   [`@keyframes ${animationId}`]: {
     from: {opacity: 0},
-    to {opacity: 1}
+    to: {opacity: 1}
   }
 }
 ```


### PR DESCRIPTION
"ES6 with generated keyframe id" code sample is missing a property/value colon separator.
