### PR TITLE
Ignore undefine, null, or empty value rules when generate style.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 - [jss] Fix sheet ordering when the last sheet was the last sibling in the head element ([#819](https://github.com/cssinjs/jss/pull/819))
 - [jss] Migrated to a monorepo structure ([#729](https://github.com/cssinjs/jss/pull/729))
 - [jss-plugin-syntax-nested] Fixed referencing rules inside media queries ([#900](https://github.com/cssinjs/jss/pull/900))
+- [jss-plugin-syntax-global] TypeError: Cannot read property '@global' of undefined ([#905](https://github.com/cssinjs/jss/pull/905))
 
 ### Breaking changes
 

--- a/packages/jss-plugin-syntax-global/.size-snapshot.json
+++ b/packages/jss-plugin-syntax-global/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/jss-plugin-syntax-global.js": {
-    "bundled": 5091,
-    "minified": 2236,
-    "gzipped": 926
+    "bundled": 5106,
+    "minified": 2243,
+    "gzipped": 929
   },
   "dist/jss-plugin-syntax-global.min.js": {
-    "bundled": 5091,
-    "minified": 2236,
-    "gzipped": 926
+    "bundled": 5106,
+    "minified": 2243,
+    "gzipped": 929
   },
   "dist/jss-plugin-syntax-global.cjs.js": {
-    "bundled": 4286,
-    "minified": 2311,
-    "gzipped": 895
+    "bundled": 4301,
+    "minified": 2318,
+    "gzipped": 900
   },
   "dist/jss-plugin-syntax-global.esm.js": {
-    "bundled": 4074,
-    "minified": 2150,
-    "gzipped": 812,
+    "bundled": 4089,
+    "minified": 2157,
+    "gzipped": 815,
     "treeshaked": {
       "rollup": {
         "code": 55,

--- a/packages/jss-plugin-syntax-global/src/index.js
+++ b/packages/jss-plugin-syntax-global/src/index.js
@@ -114,7 +114,7 @@ function addScope(selector, scope) {
 
 function handleNestedGlobalContainerRule(rule) {
   const {options, style} = rule
-  const rules = style[at]
+  const rules = style ? style[at] : null
 
   if (!rules) return
 

--- a/packages/jss-plugin-syntax-global/src/index.test.js
+++ b/packages/jss-plugin-syntax-global/src/index.test.js
@@ -19,7 +19,17 @@ describe('jss-global', () => {
   describe('@global rule with null, undefined or empty value', () => {
     let sheet
 
-    beforeEach(() => {
+    it('should generate correct CSS for one rule', () => {
+      sheet = jss.createStyleSheet({
+        '@global a': {
+          color: 'red'
+        }
+      })
+      expect(sheet.getRule('a')).to.be(undefined)
+      expect(sheet.toString()).to.be('a {\n  color: red;\n}')
+    })
+
+    it('should generate correct CSS without empty values', () => {
       sheet = jss.createStyleSheet({
         '@global': {
           a: null,
@@ -28,9 +38,11 @@ describe('jss-global', () => {
           d: {color: 'red'}
         }
       })
-    })
-
-    it('should generate correct CSS without empty values', () => {
+      expect(sheet.getRule('@global')).to.not.be(undefined)
+      expect(sheet.getRule('a')).to.be(undefined)
+      expect(sheet.getRule('b')).to.be(undefined)
+      expect(sheet.getRule('c')).to.be(undefined)
+      expect(sheet.getRule('d')).to.be(undefined)
       expect(sheet.toString()).to.be('d {\n  color: red;\n}')
     })
   })

--- a/packages/jss-plugin-syntax-global/src/index.test.js
+++ b/packages/jss-plugin-syntax-global/src/index.test.js
@@ -19,6 +19,15 @@ describe('jss-global', () => {
   describe('@global rule with null, undefined or empty value', () => {
     let sheet
 
+    it('should generate empty style when @global rule is undefined', () => {
+      sheet = jss.createStyleSheet({
+        '@global a': undefined,
+        '@global b': null,
+        '@global c': ''
+      })
+      expect(sheet.toString()).to.be('')
+    })
+
     it('should generate correct CSS for one rule', () => {
       sheet = jss.createStyleSheet({
         '@global a': {

--- a/packages/jss-plugin-syntax-global/src/index.test.js
+++ b/packages/jss-plugin-syntax-global/src/index.test.js
@@ -242,10 +242,8 @@ describe('jss-global', () => {
   })
 
   describe('@global rules with null, undefined or empty value', () => {
-    let sheet
-
     it('should generate correct CSS with prefix @global rules', () => {
-      sheet = jss.createStyleSheet({
+      const sheet = jss.createStyleSheet({
         '@global a': undefined,
         '@global b': null
       })
@@ -253,19 +251,13 @@ describe('jss-global', () => {
     })
 
     it('should generate correct CSS with @global container rule', () => {
-      sheet = jss.createStyleSheet({
+      const sheet = jss.createStyleSheet({
         '@global': {
           a: null,
-          b: undefined,
-          d: {color: 'red'}
+          b: undefined
         }
       })
-      expect(sheet.getRule('@global')).to.not.be(undefined)
-      expect(sheet.getRule('a')).to.be(undefined)
-      expect(sheet.getRule('b')).to.be(undefined)
-      expect(sheet.getRule('c')).to.be(undefined)
-      expect(sheet.getRule('d')).to.be(undefined)
-      expect(sheet.toString()).to.be('d {\n  color: red;\n}')
+      expect(sheet.toString()).to.be('')
     })
   })
 

--- a/packages/jss-plugin-syntax-global/src/index.test.js
+++ b/packages/jss-plugin-syntax-global/src/index.test.js
@@ -16,6 +16,25 @@ describe('jss-global', () => {
     jss = create(settings).use(global())
   })
 
+  describe('@global rule with null, undefined or empty value', () => {
+    let sheet
+
+    beforeEach(() => {
+      sheet = jss.createStyleSheet({
+        '@global': {
+          a: null,
+          b: undefined,
+          c: '',
+          d: {color: 'red'}
+        }
+      })
+    })
+
+    it('should generate correct CSS without empty values', () => {
+      expect(sheet.toString()).to.be('d {\n  color: red;\n}')
+    })
+  })
+
   describe('@global root container', () => {
     let sheet
 

--- a/packages/jss-plugin-syntax-global/src/index.test.js
+++ b/packages/jss-plugin-syntax-global/src/index.test.js
@@ -16,46 +16,6 @@ describe('jss-global', () => {
     jss = create(settings).use(global())
   })
 
-  describe('@global rule with null, undefined or empty value', () => {
-    let sheet
-
-    it('should generate empty style when @global rule is undefined', () => {
-      sheet = jss.createStyleSheet({
-        '@global a': undefined,
-        '@global b': null,
-        '@global c': ''
-      })
-      expect(sheet.toString()).to.be('')
-    })
-
-    it('should generate correct CSS for one rule', () => {
-      sheet = jss.createStyleSheet({
-        '@global a': {
-          color: 'red'
-        }
-      })
-      expect(sheet.getRule('a')).to.be(undefined)
-      expect(sheet.toString()).to.be('a {\n  color: red;\n}')
-    })
-
-    it('should generate correct CSS without empty values', () => {
-      sheet = jss.createStyleSheet({
-        '@global': {
-          a: null,
-          b: undefined,
-          c: '',
-          d: {color: 'red'}
-        }
-      })
-      expect(sheet.getRule('@global')).to.not.be(undefined)
-      expect(sheet.getRule('a')).to.be(undefined)
-      expect(sheet.getRule('b')).to.be(undefined)
-      expect(sheet.getRule('c')).to.be(undefined)
-      expect(sheet.getRule('d')).to.be(undefined)
-      expect(sheet.toString()).to.be('d {\n  color: red;\n}')
-    })
-  })
-
   describe('@global root container', () => {
     let sheet
 
@@ -278,6 +238,34 @@ describe('jss-global', () => {
           '  color: red;\n' +
           '}'
       )
+    })
+  })
+
+  describe('@global rules with null, undefined or empty value', () => {
+    let sheet
+
+    it('should generate correct CSS with prefix @global rules', () => {
+      sheet = jss.createStyleSheet({
+        '@global a': undefined,
+        '@global b': null
+      })
+      expect(sheet.toString()).to.be('')
+    })
+
+    it('should generate correct CSS with @global container rule', () => {
+      sheet = jss.createStyleSheet({
+        '@global': {
+          a: null,
+          b: undefined,
+          d: {color: 'red'}
+        }
+      })
+      expect(sheet.getRule('@global')).to.not.be(undefined)
+      expect(sheet.getRule('a')).to.be(undefined)
+      expect(sheet.getRule('b')).to.be(undefined)
+      expect(sheet.getRule('c')).to.be(undefined)
+      expect(sheet.getRule('d')).to.be(undefined)
+      expect(sheet.toString()).to.be('d {\n  color: red;\n}')
     })
   })
 

--- a/packages/jss-preset-default/.size-snapshot.json
+++ b/packages/jss-preset-default/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/jss-preset-default.js": {
-    "bundled": 67188,
-    "minified": 23219,
-    "gzipped": 6967
+    "bundled": 67203,
+    "minified": 23226,
+    "gzipped": 6969
   },
   "dist/jss-preset-default.min.js": {
-    "bundled": 66072,
-    "minified": 22699,
-    "gzipped": 6714
+    "bundled": 66087,
+    "minified": 22706,
+    "gzipped": 6715
   },
   "dist/jss-preset-default.cjs.js": {
     "bundled": 1399,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/react-jss.js": {
-    "bundled": 124979,
-    "minified": 43264,
-    "gzipped": 13014
+    "bundled": 124994,
+    "minified": 43271,
+    "gzipped": 13017
   },
   "dist/react-jss.min.js": {
-    "bundled": 101571,
-    "minified": 36093,
-    "gzipped": 10925
+    "bundled": 101586,
+    "minified": 36100,
+    "gzipped": 10926
   },
   "dist/react-jss.cjs.js": {
     "bundled": 16667,


### PR DESCRIPTION
Fix #899 