### PR TITLE
Ensure class name generator is re-used when mounting and unmounting jss providers

### DIFF
--- a/packages/react-jss/src/JssProvider.js
+++ b/packages/react-jss/src/JssProvider.js
@@ -67,13 +67,18 @@ export default class JssProvider extends Component<Props> {
       sheetOptions.generateId = generateId
     } else if (!sheetOptions.generateId) {
       if (!this.generateId) {
-        let createGenerateId = createGenerateIdDefault
-        if (localJss && localJss.options.createGenerateId) {
-          createGenerateId = localJss.options.createGenerateId
+        if (localJss && localJss.generateClassName) {
+          // re-use the same classname generator pinned to the local jss instance
+          this.generateClassName = localJss.generateClassName
+        } else {
+          let createGenerateId = createGenerateIdDefault
+          if (localJss && localJss.options.createGenerateId) {
+            createGenerateId = localJss.options.createGenerateId
+          }
+          // Make sure we don't loose the generator when JssProvider is used inside of a stateful
+          // component which decides to rerender.
+          this.generateId = createGenerateId()
         }
-        // Make sure we don't loose the generator when JssProvider is used inside of a stateful
-        // component which decides to rerender.
-        this.generateId = createGenerateId()
       }
 
       sheetOptions.generateId = this.generateId


### PR DESCRIPTION
__What would you like to add/fix?__
JssProvider creates a new classsname generator each time it is mounted.
When a local JSS thing is available, use the already generated function.

Not sure if this is the right approach, as I think `localJss.options.createGenerateId` should be singleton where `ruleCounter` is consistent between ID generators
https://github.com/cssinjs/jss/blob/0abd98b65abb521b7b213cbc3218fbda76ca3db5/packages/jss/src/utils/createGenerateId.js#L17

__Corresponding issue (if exists):__
#917 