### PR TITLE
Fix hoisting of new react features

### DIFF
--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/react-jss.js": {
-    "bundled": 147311,
-    "minified": 48847,
-    "gzipped": 14501
+    "bundled": 147748,
+    "minified": 48996,
+    "gzipped": 14503
   },
   "dist/react-jss.min.js": {
-    "bundled": 112487,
-    "minified": 38142,
-    "gzipped": 11777
+    "bundled": 112924,
+    "minified": 38291,
+    "gzipped": 11780
   },
   "dist/react-jss.cjs.js": {
     "bundled": 16595,

--- a/packages/react-jss/package.json
+++ b/packages/react-jss/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "@types/react": "^16.4.18",
-    "hoist-non-react-statics": "^2.5.0",
+    "hoist-non-react-statics": "^3.2.0",
     "jss": "^9.7.0",
     "jss-preset-default": "^4.3.0",
     "prop-types": "^15.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4930,15 +4930,17 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^2.5.0:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
-  integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
-
 hoist-non-react-statics@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.1.0.tgz#42414ccdfff019cd2168168be998c7b3bd5245c0"
   integrity sha512-MYcYuROh7SBM69xHGqXEwQqDux34s9tz+sCnxJmN18kgWh6JFdTw/5YdZtqsOdZJXddE/wUpCzfEdDrJj8p0Iw==
+  dependencies:
+    react-is "^16.3.2"
+
+hoist-non-react-statics@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.2.0.tgz#d21b9fc72b50fdc38c5d88f6e2c52f2c2dbe5ee2"
+  integrity sha512-3IascCRfaEkbmHjJnUxWSspIUE1okLPjGTMVXW8zraUo1t3yg1BadKAxAGILHwgoBzmMnzrgeeaDGBvpuPz6dA==
   dependencies:
     react-is "^16.3.2"
 


### PR DESCRIPTION
__What would you like to add/fix?__
- hoisting of new react features

__Corresponding issue (if exists):__
cssinjs/react-jss#314
> `hoist-non-react-statics@2.x` does not support `forwardRef` components, `contextType` static nor `getDerivedStateFromError` static. The major version bump was due to the added requirement of react >= 0.14 which was dropped in `hoist-non-react-statics@3.2.0`. Therefore this change should not be breaking.
> 
> [`hoist-non-react-statics` changelog](https://github.com/mridgway/hoist-non-react-statics/blob/master/CHANGELOG.md)