### PR TITLE
[jss] Add a benchmark for creating jss instances

### DIFF
--- a/packages/jss/benchmark/tests/create-instance.js
+++ b/packages/jss/benchmark/tests/create-instance.js
@@ -1,0 +1,18 @@
+import {create} from 'jss'
+import preset from 'jss-preset-default'
+
+// Avoid memory leak with registry.
+const options = {virtual: true}
+
+suite('create a new instance with and without preset', () => {
+  benchmark('without preset', () => {
+    create(options)
+  })
+
+  benchmark('with preset', () => {
+    create({
+      ...options,
+      ...preset()
+    })
+  })
+})

--- a/packages/jss/benchmark/tests/create-instance.js
+++ b/packages/jss/benchmark/tests/create-instance.js
@@ -4,7 +4,7 @@ import preset from 'jss-preset-default'
 // Avoid memory leak with registry.
 const options = {virtual: true}
 
-suite('create a new instance with and without preset', () => {
+suite('create a new instance', () => {
   benchmark('without preset', () => {
     create(options)
   })


### PR DESCRIPTION
__What would you like to add/fix?__
Add a benchmark for creating new jss instances. Once without any plugins and once with the preset.

Results:
Chrome 70.0.3538 (Mac OS X 10.14.2)  create a new instance with and without preset: without preset at 205906 ops/sec
Chrome 70.0.3538 (Mac OS X 10.14.2)  create a new instance with and without preset: with preset at 51269 ops/sec
