### PR TITLE
Add `unpkg` key to package.json

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
-## Next / 2018-09-16
+## Next / 2018-12-18
 
+- [jss-starter-kit] Introduced `jss-starter-kit.bundle.js`, which packages all the other libraries into one import for playgrounds like Codepen. ([#936](https://github.com/cssinjs/jss/pull/936))
 - [jss] Fix multiple cases where linking CSS rules didn't work ([#815](https://github.com/cssinjs/jss/pull/815), [#710](https://github.com/cssinjs/jss/pull/710), [#664](https://github.com/cssinjs/jss/pull/664))
 - [jss] Added support for Typed CSSOM values ([#882](https://github.com/cssinjs/jss/pull/882))
 - [jss] Added scoped keyframes support ([#346](https://github.com/cssinjs/jss/pull/346))

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -10,6 +10,9 @@ yarn add jss
 
 For bower or direct script injection use [unpkg](https://unpkg.com):
 
+Unminified, bundled ESM:
+https://unpkg.com/jss-starter-kit/dist/jss-starter-kit.bundle.js
+
 Unminified UMD:
 https://unpkg.com/jss/dist/jss.js
 

--- a/packages/jss-plugin-cache/package.json
+++ b/packages/jss-plugin-cache/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://cssinjs.org/jss-cache",
   "main": "dist/jss-plugin-cache.cjs.js",
   "module": "dist/jss-plugin-cache.esm.js",
+  "unpkg": "dist/jss-plugin-cache.bundle.js",
   "typings": "./src/index.d.ts",
   "author": {
     "name": "Oleg Slobodskoi",

--- a/packages/jss-plugin-isolate/package.json
+++ b/packages/jss-plugin-isolate/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://cssinjs.org/jss-isolate",
   "main": "dist/jss-plugin-isolate.cjs.js",
   "module": "dist/jss-plugin-isolate.esm.js",
+  "unpkg": "dist/jss-plugin-isolate.bundle.js",
   "typings": "./src/index.d.ts",
   "author": {
     "name": "Maksim Koretskiy",

--- a/packages/jss-plugin-props-sort/package.json
+++ b/packages/jss-plugin-props-sort/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://cssinjs.org/jss-props-sort",
   "main": "dist/jss-plugin-props-sort.cjs.js",
   "module": "dist/jss-plugin-props-sort.esm.js",
+  "unpkg": "dist/jss-plugin-props-sort.bundle.js",
   "typings": "./src/index.d.ts",
   "author": {
     "name": "Oleg Slobodskoi",

--- a/packages/jss-plugin-syntax-camel-case/package.json
+++ b/packages/jss-plugin-syntax-camel-case/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://cssinjs.org/jss-camel-case",
   "main": "dist/jss-plugin-syntax-camel-case.cjs.js",
   "module": "dist/jss-plugin-syntax-camel-case.esm.js",
+  "unpkg": "dist/jss-plugin-syntax-camel-case.bundle.js",
   "typings": "./src/index.d.ts",
   "author": {
     "name": "Oleg Slobodskoi",

--- a/packages/jss-plugin-syntax-compose/package.json
+++ b/packages/jss-plugin-syntax-compose/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://cssinjs.org/jss-compose",
   "main": "dist/jss-plugin-syntax-compose.cjs.js",
   "module": "dist/jss-plugin-syntax-compose.esm.js",
+  "unpkg": "dist/jss-plugin-syntax-compose.bundle.js",
   "typings": "./src/index.d.ts",
   "author": {
     "name": "Pavel Davydov",

--- a/packages/jss-plugin-syntax-default-unit/package.json
+++ b/packages/jss-plugin-syntax-default-unit/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://cssinjs.org/jss-default-unit",
   "main": "dist/jss-plugin-syntax-default-unit.cjs.js",
   "module": "dist/jss-plugin-syntax-default-unit.esm.js",
+  "unpkg": "dist/jss-plugin-syntax-default-unit.bundle.js",
   "typings": "./src/index.d.ts",
   "author": {
     "name": "Oleg Slobodskoi",

--- a/packages/jss-plugin-syntax-expand/package.json
+++ b/packages/jss-plugin-syntax-expand/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://cssinjs.org/jss-expand",
   "main": "dist/jss-plugin-syntax-expand.cjs.js",
   "module": "dist/jss-plugin-syntax-expand.esm.js",
+  "unpkg": "dist/jss-plugin-syntax-expand.bundle.js",
   "typings": "./src/index.d.ts",
   "author": {
     "name": "Pavel Davydov",

--- a/packages/jss-plugin-syntax-extend/package.json
+++ b/packages/jss-plugin-syntax-extend/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://cssinjs.org/jss-extend",
   "main": "dist/jss-plugin-syntax-extend.cjs.js",
   "module": "dist/jss-plugin-syntax-extend.esm.js",
+  "unpkg": "dist/jss-plugin-syntax-extend.bundle.js",
   "typings": "./src/index.d.ts",
   "author": {
     "name": "Oleg Slobodskoi",

--- a/packages/jss-plugin-syntax-global/package.json
+++ b/packages/jss-plugin-syntax-global/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://cssinjs.org/jss-global",
   "main": "dist/jss-plugin-syntax-global.cjs.js",
   "module": "dist/jss-plugin-syntax-global.esm.js",
+  "unpkg": "dist/jss-plugin-syntax-global.bundle.js",
   "typings": "./src/index.d.ts",
   "author": {
     "name": "Oleg Slobodskoi",

--- a/packages/jss-plugin-syntax-nested/package.json
+++ b/packages/jss-plugin-syntax-nested/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://cssinjs.org/jss-nested",
   "main": "dist/jss-plugin-syntax-nested.cjs.js",
   "module": "dist/jss-plugin-syntax-nested.esm.js",
+  "unpkg": "dist/jss-plugin-syntax-nested.bundle.js",
   "typings": "./src/index.d.ts",
   "author": {
     "name": "Oleg Slobodskoi",

--- a/packages/jss-plugin-syntax-rule-value-function/package.json
+++ b/packages/jss-plugin-syntax-rule-value-function/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://cssinjs.org/",
   "main": "dist/jss-plugin-syntax-rule-value-function.cjs.js",
   "module": "dist/jss-plugin-syntax-rule-value-function.esm.js",
+  "unpkg": "dist/jss-plugin-syntax-rule-value-function.bundle.js",
   "typings": "./src/index.d.ts",
   "author": {
     "name": "Oleg Slobodskoi",

--- a/packages/jss-plugin-syntax-rule-value-observable/package.json
+++ b/packages/jss-plugin-syntax-rule-value-observable/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://cssinjs.org/",
   "main": "dist/jss-plugin-syntax-rule-value-observable.cjs.js",
   "module": "dist/jss-plugin-syntax-rule-value-observable.esm.js",
+  "unpkg": "dist/jss-plugin-syntax-rule-value-observable.bundle.js",
   "typings": "./src/index.d.ts",
   "author": {
     "name": "Oleg Slobodskoi",

--- a/packages/jss-plugin-syntax-template/package.json
+++ b/packages/jss-plugin-syntax-template/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://cssinjs.org/jss-template",
   "main": "dist/jss-plugin-syntax-template.cjs.js",
   "module": "dist/jss-plugin-syntax-template.esm.js",
+  "unpkg": "dist/jss-plugin-syntax-template.bundle.js",
   "typings": "./src/index.d.ts",
   "author": {
     "name": "Oleg Slobodskoi",

--- a/packages/jss-plugin-vendor-prefixer/package.json
+++ b/packages/jss-plugin-vendor-prefixer/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://cssinjs.org/jss-vendor-prefixer",
   "main": "dist/jss-plugin-vendor-prefixer.cjs.js",
   "module": "dist/jss-plugin-vendor-prefixer.esm.js",
+  "unpkg": "dist/jss-plugin-vendor-prefixer.bundle.js",
   "typings": "./src/index.d.ts",
   "author": {
     "name": "Oleg Slobodskoi",

--- a/packages/jss-preset-default/package.json
+++ b/packages/jss-preset-default/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://cssinjs.org/jss-preset-default",
   "main": "dist/jss-preset-default.cjs.js",
   "module": "dist/jss-preset-default.esm.js",
+  "unpkg": "dist/jss-preset-default.bundle.js",
   "typings": "./src/index.d.ts",
   "author": {
     "name": "Oleg Slobodskoi",

--- a/packages/jss-starter-kit/.size-snapshot.json
+++ b/packages/jss-starter-kit/.size-snapshot.json
@@ -1,0 +1,31 @@
+{
+  "dist/jss-starter-kit.js": {
+    "bundled": 82381,
+    "minified": 33203,
+    "gzipped": 9557
+  },
+  "dist/jss-starter-kit.min.js": {
+    "bundled": 81265,
+    "minified": 32683,
+    "gzipped": 9306
+  },
+  "dist/jss-starter-kit.cjs.js": {
+    "bundled": 2480,
+    "minified": 2273,
+    "gzipped": 682
+  },
+  "dist/jss-starter-kit.esm.js": {
+    "bundled": 1408,
+    "minified": 1302,
+    "gzipped": 452,
+    "treeshaked": {
+      "rollup": {
+        "code": 836,
+        "import_statements": 541
+      },
+      "webpack": {
+        "code": 2342
+      }
+    }
+  }
+}

--- a/packages/jss-starter-kit/LICENSE
+++ b/packages/jss-starter-kit/LICENSE
@@ -1,0 +1,8 @@
+The MIT License (MIT)
+Copyright (c) 2014-present Oleg Isonen/Slobodskoi & contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/jss-starter-kit/package.json
+++ b/packages/jss-starter-kit/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "jss-starter-kit",
+  "description": "A bundle to get you started playing with JSS.  Not optimized for production deployment.",
+  "version": "9.8.4",
+  "license": "MIT",
+  "homepage": "https://cssinjs.org/",
+  "main": "dist/jss-starter-kit.cjs.js",
+  "module": "dist/jss-starter-kit.esm.js",
+  "unpkg": "dist/jss-starter-kit.bundle.js",
+  "typings": "./src/index.d.ts",
+  "author": {
+    "name": "Oleg Slobodskoi",
+    "email": "oleg008@gmail.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:cssinjs/jss.git"
+  },
+  "bugs": {
+    "url": "https://github.com/cssinjs/jss/issues/new"
+  },
+  "files": [
+    "dist",
+    "src",
+    "LICENSE"
+  ],
+  "keywords": [
+    "jss",
+    "style",
+    "sheet",
+    "stylesheet",
+    "css",
+    "components",
+    "composable",
+    "css in js",
+    "css-in-js"
+  ],
+  "scripts": {
+    "build": "node ../../scripts/build.js",
+    "check-snapshot": "node ../../scripts/match-snapshot.js"
+  },
+  "dependencies": {
+    "jss": "^9",
+    "jss-plugin-cache": "^3",
+    "jss-plugin-isolate": "^5",
+    "jss-preset-default": "^4"
+  }
+}

--- a/packages/jss-starter-kit/readme.md
+++ b/packages/jss-starter-kit/readme.md
@@ -1,0 +1,67 @@
+# jss-starter-kit:🚰 the whole kitchen sink
+
+[![Gitter](https://badges.gitter.im/JoinChat.svg)](https://gitter.im/cssinjs/lobby)
+
+The `jss-starter-kit` combines all of the other [packages](https://github.com/cssinjs/jss/tree/master/packages) into a single bundle, to make it easy to import directly into a playground like Codepen, or a local HTML file.
+
+:warning: This bundle includes every JSS package, unminified. It's great for experimenting, but not suitable for production deployment.
+
+## Quick start
+
+There's an instance of JSS already set up with all of the default plugins, exported as `jss`.
+
+```javascript
+import {jss} from 'https://unpkg.com/jss-starter-kit'
+
+// Notice that you can use camel-cased style keys here, because
+// the default preset include jss-plugin-syntax-camel-case.  If you want to use
+// jss in your production application, you'll need to manually install the
+// plugins you need.
+const {classes} = jss
+  .createStyleSheet({
+    wrapper: {
+      padding: 40,
+      background: '#f7df1e',
+      textAlign: 'center'
+    },
+    title: {
+      font: {
+        size: 40,
+        weight: 900
+      },
+      color: '#24292e'
+    },
+    link: {
+      color: '#24292e',
+      '&:hover': {
+        opacity: 0.5
+      }
+    }
+  })
+  .attach()
+
+document.body.innerHTML = `
+  <div class="${classes.wrapper}">
+    <h1 class="${classes.title}">Hello JSS!</h1>
+    <a
+      class=${classes.link}
+      href="http://cssinjs.org/"
+      traget="_blank"
+    >
+      See docs
+    </a>
+  </div>
+`
+```
+
+## Plugins
+
+[Every plugin shipped by JSS](https://github.com/cssinjs/jss/tree/master/packages) is included here. See [`index.js`](https://github.com/cssinjs/jss/blob/master/packages/jss-starter-kit/src/index.js) to see the names they are exported as.
+
+## Issues
+
+File a bug against [cssinjs/jss prefixed with \[jss-starter-kit\]](https://github.com/cssinjs/jss/issues/new?title=[jss-starter-kit]%20).
+
+## License
+
+MIT

--- a/packages/jss-starter-kit/src/index.js
+++ b/packages/jss-starter-kit/src/index.js
@@ -4,7 +4,7 @@ import preset from 'jss-preset-default'
 
 console.warn(`The JSS Starter Kit is for learning and experimentation.  It's not optimized for production deployment.
 
-If you'd like to JSS in production, try using the "jss" and "jss-preset-default" bundles directly.  See an example at https://github.com/cssinjs/jss#example`)
+If you'd like to use JSS in production, try including the "jss" and "jss-preset-default" modules directly.  See an example at https://github.com/cssinjs/jss#example`)
 
 jss.setup(preset())
 

--- a/packages/jss-starter-kit/src/index.js
+++ b/packages/jss-starter-kit/src/index.js
@@ -1,0 +1,28 @@
+// @flow
+import jss from 'jss'
+import preset from 'jss-preset-default'
+
+console.warn(`The JSS Starter Kit is for learning and experimentation.  It's not optimized for production deployment.
+
+If you'd like to JSS in production, try using the "jss" and "jss-preset-default" bundles directly.  See an example at https://github.com/cssinjs/jss#example`)
+
+jss.setup(preset())
+
+export {default as jss} from 'jss'
+export {default as preset} from 'jss-preset-default'
+export {default as functions} from 'jss-plugin-syntax-rule-value-function'
+export {default as observable} from 'jss-plugin-syntax-rule-value-observable'
+export {default as template} from 'jss-plugin-syntax-template'
+export {default as global} from 'jss-plugin-syntax-global'
+export {default as extend} from 'jss-plugin-syntax-extend'
+export {default as nested} from 'jss-plugin-syntax-nested'
+export {default as compose} from 'jss-plugin-syntax-compose'
+export {default as camelCase} from 'jss-plugin-syntax-camel-case'
+export {default as defaultUnit} from 'jss-plugin-syntax-default-unit'
+export {default as expand} from 'jss-plugin-syntax-expand'
+export {default as vendorPrefixer} from 'jss-plugin-vendor-prefixer'
+export {default as propsSort} from 'jss-plugin-props-sort'
+export {default as isolate} from 'jss-plugin-isolate'
+export {default as cache} from 'jss-plugin-cache'
+
+export default jss

--- a/packages/jss/package.json
+++ b/packages/jss/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://cssinjs.org/",
   "main": "dist/jss.cjs.js",
   "module": "dist/jss.esm.js",
+  "unpkg": "dist/jss.bundle.js",
   "typings": "./src/index.d.ts",
   "author": {
     "name": "Oleg Slobodskoi",

--- a/packages/react-jss/package.json
+++ b/packages/react-jss/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "main": "dist/react-jss.cjs.js",
   "module": "dist/react-jss.esm.js",
+  "unpkg": "dist/react-jss.bundle.js",
   "homepage": "https://cssinjs.org/react-jss",
   "typings": "./src/index.d.ts",
   "author": {

--- a/readme.md
+++ b/readme.md
@@ -50,8 +50,8 @@ If you are a Sass (SCSS) user, this course will show how to express popular Sass
 ## Example
 
 Try it out on [playground](https://codesandbox.io/s/z21lpmvv33).
-You need to [setup plugins](docs/setup.md#setup-with-plugins) before.
-You can use a [preset](https://github.com/cssinjs/jss-preset-default) for a quick setup with default plugins.
+You need to [setup plugins](docs/setup.md#setup-with-plugins) first.
+You can use a [preset](https://github.com/cssinjs/jss-preset-default) for a quick setup with default plugins, or try [`jss-starter-kit`](packages/jss-starter-kit) for easy experimentation..
 
 ```javascript
 import jss from 'jss'

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -135,5 +135,22 @@ export default [
       replace({'process.env.VERSION': JSON.stringify(pkg.version)}),
       sizeSnapshot(snapshotOptions)
     ]
+  },
+
+  {
+    input,
+    output: {file: pkg.unpkg, format: 'esm'},
+    plugins: [
+      nodeResolve(),
+      babel(getBabelOptions({useESModules: true})),
+      commonjs(commonjsOptions),
+      nodeGlobals({process: false}),
+      replace({
+        'process.env.VERSION': JSON.stringify(pkg.version)
+      })
+      // sizeSnapshot barfs with
+      // [!] (size-snapshot plugin) Error: Error transforming bundle with 'size-snapshot' plugin: ModuleNotFoundError: Module not found: Error: Can't resolve 'jss/node_modules/rollup-plugin-size-snapshot/node_modules/webpack/buildin/harmony-module.js' in '/'
+      // sizeSnapshot(snapshotOptions),
+    ]
   }
 ]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -46,7 +46,13 @@ const getBabelOptions = ({useESModules}) => ({
 })
 
 const commonjsOptions = {
-  ignoreGlobal: true
+  ignoreGlobal: true,
+  // The CommonJS plugin can't resolve the exports in `react` automatically.
+  // https://github.com/rollup/rollup-plugin-commonjs#custom-named-exports
+  // https://github.com/reduxjs/react-redux/issues/643#issuecomment-285008041
+  namedExports: {
+    react: ['Component']
+  }
 }
 
 const snapshotOptions = {
@@ -146,11 +152,11 @@ export default [
       commonjs(commonjsOptions),
       nodeGlobals({process: false}),
       replace({
+        'process.env.NODE_ENV': JSON.stringify('development'),
         'process.env.VERSION': JSON.stringify(pkg.version)
       })
-      // sizeSnapshot barfs with
-      // [!] (size-snapshot plugin) Error: Error transforming bundle with 'size-snapshot' plugin: ModuleNotFoundError: Module not found: Error: Can't resolve 'jss/node_modules/rollup-plugin-size-snapshot/node_modules/webpack/buildin/harmony-module.js' in '/'
-      // sizeSnapshot(snapshotOptions),
+      // size-snapshot is disabled until this is resolved:
+      // https://github.com/TrySound/rollup-plugin-size-snapshot/issues/24
     ]
   }
 ]


### PR DESCRIPTION
This provides a completely bundled distribution, ready for importing from CDNs like unpkg.com for use in sandboxes like Codepen.  It allows this code to work natively in the browser:

```typescript
import { create as createJSS } from 'https://unpkg.com/jss';
```

The PR is a work-in-progress, but I'd rather start a conversation with an example than with prose.  As it is, I can't get `sizeSnapshot` to work with the bundled version.

I also wonder how best to handle plugins/presets.  The easiest options would be to add `unpkg` entry points to each `package`, and force authors to use multiple imports:

```typescript
import { create as createJSS } from 'https://unpkg.com/jss';
import createDefaultJSSPreset from 'https://unpkg.com/jss-preset-default';
```

I wonder what the best way to produce a batteries-included bundle is.  Perhaps there should be another bundle `jss-all` that exports all the other packages.  Then usage would be:

```typescript
import * as jssAll from 'https://unpkg.com/jss-all';

const jss = jssAll.create(jssAll.preset());
```

## Todo
- [x] Add unpkg field to every package
- [ ] ~~Understand and fix the `sizeSnapshot` crash~~
- [x] Make a `jss-starter-kit` package.
  - [x] `console.warn` that it's for learning and prototyping only, not bundled for production use.
- [x] Changelog
- [x] Docs [here](https://github.com/cssinjs/jss/blob/master/docs/setup.md)