### PR TITLE
Move react-jss types to dev dependencies

### DIFF
--- a/packages/react-jss/package.json
+++ b/packages/react-jss/package.json
@@ -42,11 +42,13 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@types/react": "^16.4.18",
     "hoist-non-react-statics": "^3.2.0",
     "jss": "^10.0.0-alpha.8",
     "jss-preset-default": "^10.0.0-alpha.8",
     "prop-types": "^15.6.0",
     "theming": "^3.0.2"
+  },
+  "devDependencies": {
+    "@types/react": "^16.7.20"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1388,6 +1388,14 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
+"@types/react@^16.7.20":
+  version "16.7.20"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.7.20.tgz#13ae752c012710d0fa800985ca809814b51d3b58"
+  integrity sha512-Qd5RWkwl6SL7R2XzLk/cicjVQm1Mhc6HqXY5Ei4pWd1Vi8Fkbd5O0sA398x8fRSTPAuHdDYD9nrWmJMYTJI0vQ==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
 "@webassemblyjs/ast@1.5.13":
   version "1.5.13"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.5.13.tgz#81155a570bd5803a30ec31436bc2c9c0ede38f25"


### PR DESCRIPTION
__What would you like to add/fix?__
Installing external types can have a problem when the end user also installs the same types package.

As we shouldn't force someone to install the @types/react package, I just moved to the dev dependencies. I think we can expect someone to have the appropriate package installed when using `react-jss` and using typescript

__Corresponding issue (if exists):__ #976 
