### PR TITLE
Update lerna

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,9 +4,7 @@
   "version": "10.0.0-alpha.8",
   "command": {
     "publish": {
-      "allowBranch": [
-        "master"
-      ],
+      "allowBranch": ["master"],
       "forcePublish": "*"
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "lerna run prepare",
+    "build": "lerna run build",
     "check:all": "yarn check:flow && yarn check:ts && yarn check:snapshots && yarn check:lint",
     "check:flow": "flow check --max-warnings=0",
     "check:ts": "tsc",

--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "yarn workspaces run prepare",
+    "build": "lerna run prepare",
     "check:all": "yarn check:flow && yarn check:ts && yarn check:snapshots yarn check:lint",
     "check:flow": "flow check --max-warnings=0",
     "check:ts": "tsc",
-    "check:snapshots": "yarn workspaces run check-snapshot",
+    "check:snapshots": "lerna run check-snapshot",
     "check:lint": "eslint scripts/ packages/ docs/ --ext js,md",
-    "prepublish-packages": "yarn build && yarn check:all && yarn format:ci && yarn test",
+    "prepublish-packages": "yarn check:all && yarn format:ci && yarn test",
     "publish-packages": "lerna publish",
     "format": "prettier \"*.{js,md,json}\" \"{docs,packages,scripts}/**/*.{js,md,json}\" --write",
     "format:ci": "yarn format -- --list-different",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "scripts": {
     "build": "lerna run prepare",
-    "check:all": "yarn check:flow && yarn check:ts && yarn check:snapshots yarn check:lint",
+    "check:all": "yarn check:flow && yarn check:ts && yarn check:snapshots && yarn check:lint",
     "check:flow": "flow check --max-warnings=0",
     "check:ts": "tsc",
     "check:snapshots": "lerna run check-snapshot",

--- a/packages/jss-plugin-cache/package.json
+++ b/packages/jss-plugin-cache/package.json
@@ -35,7 +35,7 @@
   ],
   "scripts": {
     "build": "node ../../scripts/build.js",
-    "postversion": "yarn prepare",
+    "postversion": "yarn build",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "devDependencies": {

--- a/packages/jss-plugin-cache/package.json
+++ b/packages/jss-plugin-cache/package.json
@@ -34,7 +34,8 @@
     "insane"
   ],
   "scripts": {
-    "prepare": "node ../../scripts/build.js",
+    "build": "node ../../scripts/build.js",
+    "postversion": "yarn prepare",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "devDependencies": {

--- a/packages/jss-plugin-camel-case/package.json
+++ b/packages/jss-plugin-camel-case/package.json
@@ -34,7 +34,7 @@
   ],
   "scripts": {
     "build": "node ../../scripts/build.js",
-    "postversion": "yarn prepare",
+    "postversion": "yarn build",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "devDependencies": {

--- a/packages/jss-plugin-camel-case/package.json
+++ b/packages/jss-plugin-camel-case/package.json
@@ -33,7 +33,8 @@
     "camel case"
   ],
   "scripts": {
-    "prepare": "node ../../scripts/build.js",
+    "build": "node ../../scripts/build.js",
+    "postversion": "yarn prepare",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "devDependencies": {

--- a/packages/jss-plugin-compose/package.json
+++ b/packages/jss-plugin-compose/package.json
@@ -34,7 +34,8 @@
     "composition"
   ],
   "scripts": {
-    "prepare": "node ../../scripts/build.js",
+    "build": "node ../../scripts/build.js",
+    "postversion": "yarn prepare",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "devDependencies": {

--- a/packages/jss-plugin-compose/package.json
+++ b/packages/jss-plugin-compose/package.json
@@ -35,7 +35,7 @@
   ],
   "scripts": {
     "build": "node ../../scripts/build.js",
-    "postversion": "yarn prepare",
+    "postversion": "yarn build",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "devDependencies": {

--- a/packages/jss-plugin-default-unit/package.json
+++ b/packages/jss-plugin-default-unit/package.json
@@ -35,7 +35,8 @@
     "default-unit"
   ],
   "scripts": {
-    "prepare": "node ../../scripts/build.js",
+    "build": "node ../../scripts/build.js",
+    "postversion": "yarn prepare",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "devDependencies": {

--- a/packages/jss-plugin-default-unit/package.json
+++ b/packages/jss-plugin-default-unit/package.json
@@ -36,7 +36,7 @@
   ],
   "scripts": {
     "build": "node ../../scripts/build.js",
-    "postversion": "yarn prepare",
+    "postversion": "yarn build",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "devDependencies": {

--- a/packages/jss-plugin-expand/package.json
+++ b/packages/jss-plugin-expand/package.json
@@ -34,7 +34,7 @@
   ],
   "scripts": {
     "build": "node ../../scripts/build.js",
-    "postversion": "yarn prepare",
+    "postversion": "yarn build",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "devDependencies": {

--- a/packages/jss-plugin-expand/package.json
+++ b/packages/jss-plugin-expand/package.json
@@ -33,7 +33,8 @@
     "expand"
   ],
   "scripts": {
-    "prepare": "node ../../scripts/build.js",
+    "build": "node ../../scripts/build.js",
+    "postversion": "yarn prepare",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "devDependencies": {

--- a/packages/jss-plugin-extend/package.json
+++ b/packages/jss-plugin-extend/package.json
@@ -34,7 +34,7 @@
   ],
   "scripts": {
     "build": "node ../../scripts/build.js",
-    "postversion": "yarn prepare",
+    "postversion": "yarn build",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "devDependencies": {

--- a/packages/jss-plugin-extend/package.json
+++ b/packages/jss-plugin-extend/package.json
@@ -33,7 +33,8 @@
     "css in js"
   ],
   "scripts": {
-    "prepare": "node ../../scripts/build.js",
+    "build": "node ../../scripts/build.js",
+    "postversion": "yarn prepare",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "devDependencies": {

--- a/packages/jss-plugin-global/package.json
+++ b/packages/jss-plugin-global/package.json
@@ -35,7 +35,7 @@
   ],
   "scripts": {
     "build": "node ../../scripts/build.js",
-    "postversion": "yarn prepare",
+    "postversion": "yarn build",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "peerDependencies": {

--- a/packages/jss-plugin-global/package.json
+++ b/packages/jss-plugin-global/package.json
@@ -34,7 +34,8 @@
     "unscoped"
   ],
   "scripts": {
-    "prepare": "node ../../scripts/build.js",
+    "build": "node ../../scripts/build.js",
+    "postversion": "yarn prepare",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "peerDependencies": {

--- a/packages/jss-plugin-isolate/package.json
+++ b/packages/jss-plugin-isolate/package.json
@@ -34,7 +34,8 @@
     "reset"
   ],
   "scripts": {
-    "prepare": "node ../../scripts/build.js",
+    "build": "node ../../scripts/build.js",
+    "postversion": "yarn prepare",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "devDependencies": {

--- a/packages/jss-plugin-isolate/package.json
+++ b/packages/jss-plugin-isolate/package.json
@@ -35,7 +35,7 @@
   ],
   "scripts": {
     "build": "node ../../scripts/build.js",
-    "postversion": "yarn prepare",
+    "postversion": "yarn build",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "devDependencies": {

--- a/packages/jss-plugin-nested/package.json
+++ b/packages/jss-plugin-nested/package.json
@@ -35,7 +35,7 @@
   ],
   "scripts": {
     "build": "node ../../scripts/build.js",
-    "postversion": "yarn prepare",
+    "postversion": "yarn build",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "devDependencies": {

--- a/packages/jss-plugin-nested/package.json
+++ b/packages/jss-plugin-nested/package.json
@@ -34,7 +34,8 @@
     "nesting"
   ],
   "scripts": {
-    "prepare": "node ../../scripts/build.js",
+    "build": "node ../../scripts/build.js",
+    "postversion": "yarn prepare",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "devDependencies": {

--- a/packages/jss-plugin-props-sort/package.json
+++ b/packages/jss-plugin-props-sort/package.json
@@ -34,7 +34,8 @@
     "props"
   ],
   "scripts": {
-    "prepare": "node ../../scripts/build.js",
+    "build": "node ../../scripts/build.js",
+    "postversion": "yarn prepare",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "devDependencies": {

--- a/packages/jss-plugin-props-sort/package.json
+++ b/packages/jss-plugin-props-sort/package.json
@@ -35,7 +35,7 @@
   ],
   "scripts": {
     "build": "node ../../scripts/build.js",
-    "postversion": "yarn prepare",
+    "postversion": "yarn build",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "devDependencies": {

--- a/packages/jss-plugin-rule-value-function/package.json
+++ b/packages/jss-plugin-rule-value-function/package.json
@@ -41,7 +41,7 @@
   ],
   "scripts": {
     "build": "node ../../scripts/build.js",
-    "postversion": "yarn prepare",
+    "postversion": "yarn build",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "peerDependencies": {

--- a/packages/jss-plugin-rule-value-function/package.json
+++ b/packages/jss-plugin-rule-value-function/package.json
@@ -40,7 +40,8 @@
     "animation"
   ],
   "scripts": {
-    "prepare": "node ../../scripts/build.js",
+    "build": "node ../../scripts/build.js",
+    "postversion": "yarn prepare",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "peerDependencies": {

--- a/packages/jss-plugin-rule-value-observable/package.json
+++ b/packages/jss-plugin-rule-value-observable/package.json
@@ -39,7 +39,8 @@
     "rxjs"
   ],
   "scripts": {
-    "prepare": "node ../../scripts/build.js",
+    "build": "node ../../scripts/build.js",
+    "postversion": "yarn prepare",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "peerDependencies": {

--- a/packages/jss-plugin-rule-value-observable/package.json
+++ b/packages/jss-plugin-rule-value-observable/package.json
@@ -40,7 +40,7 @@
   ],
   "scripts": {
     "build": "node ../../scripts/build.js",
-    "postversion": "yarn prepare",
+    "postversion": "yarn build",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "peerDependencies": {

--- a/packages/jss-plugin-template/package.json
+++ b/packages/jss-plugin-template/package.json
@@ -34,7 +34,7 @@
   ],
   "scripts": {
     "build": "node ../../scripts/build.js",
-    "postversion": "yarn prepare",
+    "postversion": "yarn build",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "devDependencies": {

--- a/packages/jss-plugin-template/package.json
+++ b/packages/jss-plugin-template/package.json
@@ -33,7 +33,8 @@
     "template"
   ],
   "scripts": {
-    "prepare": "node ../../scripts/build.js",
+    "build": "node ../../scripts/build.js",
+    "postversion": "yarn prepare",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "devDependencies": {

--- a/packages/jss-plugin-vendor-prefixer/package.json
+++ b/packages/jss-plugin-vendor-prefixer/package.json
@@ -32,7 +32,8 @@
     "prefixer"
   ],
   "scripts": {
-    "prepare": "node ../../scripts/build.js",
+    "build": "node ../../scripts/build.js",
+    "postversion": "yarn prepare",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "dependencies": {

--- a/packages/jss-plugin-vendor-prefixer/package.json
+++ b/packages/jss-plugin-vendor-prefixer/package.json
@@ -33,7 +33,7 @@
   ],
   "scripts": {
     "build": "node ../../scripts/build.js",
-    "postversion": "yarn prepare",
+    "postversion": "yarn build",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "dependencies": {

--- a/packages/jss-preset-default/package.json
+++ b/packages/jss-preset-default/package.json
@@ -30,7 +30,8 @@
     "default"
   ],
   "scripts": {
-    "prepare": "node ../../scripts/build.js",
+    "build": "node ../../scripts/build.js",
+    "postversion": "yarn prepare",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "devDependencies": {

--- a/packages/jss-preset-default/package.json
+++ b/packages/jss-preset-default/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "build": "node ../../scripts/build.js",
-    "postversion": "yarn prepare",
+    "postversion": "yarn build",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "devDependencies": {

--- a/packages/jss-starter-kit/package.json
+++ b/packages/jss-starter-kit/package.json
@@ -37,7 +37,7 @@
   ],
   "scripts": {
     "build": "node ../../scripts/build.js",
-    "postversion": "yarn prepare",
+    "postversion": "yarn build",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "dependencies": {

--- a/packages/jss-starter-kit/package.json
+++ b/packages/jss-starter-kit/package.json
@@ -36,7 +36,8 @@
     "css-in-js"
   ],
   "scripts": {
-    "prepare": "node ../../scripts/build.js",
+    "build": "node ../../scripts/build.js",
+    "postversion": "yarn prepare",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "dependencies": {

--- a/packages/jss/package.json
+++ b/packages/jss/package.json
@@ -37,7 +37,7 @@
   ],
   "scripts": {
     "build": "node ../../scripts/build.js",
-    "postversion": "yarn prepare",
+    "postversion": "yarn build",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "dependencies": {

--- a/packages/jss/package.json
+++ b/packages/jss/package.json
@@ -36,7 +36,8 @@
     "css-in-js"
   ],
   "scripts": {
-    "prepare": "node ../../scripts/build.js",
+    "build": "node ../../scripts/build.js",
+    "postversion": "yarn prepare",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "dependencies": {

--- a/packages/react-jss/package.json
+++ b/packages/react-jss/package.json
@@ -34,7 +34,8 @@
     "decorator"
   ],
   "scripts": {
-    "prepare": "node ../../scripts/build.js",
+    "build": "node ../../scripts/build.js",
+    "postversion": "yarn prepare",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "peerDependencies": {

--- a/packages/react-jss/package.json
+++ b/packages/react-jss/package.json
@@ -35,7 +35,7 @@
   ],
   "scripts": {
     "build": "node ../../scripts/build.js",
-    "postversion": "yarn prepare",
+    "postversion": "yarn build",
     "check-snapshot": "node ../../scripts/match-snapshot.js"
   },
   "peerDependencies": {


### PR DESCRIPTION
__What would you like to add/fix?__
- Uses `postversion` hook to build packages now
- Renamed `prepare` script back to build again
- Use lerna to execute scripts inside packages (lerna has a nicer output)
- Fix `check:all` command

__Corresponding issue (if exists):__ #984 
