### PR TITLE
Fix react-jss exports from jss-starter-kit

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+## Next
+
+### Bug fixes
+
+- [jss-starter-kit] Fix react-jss exports and add missing jss exports ([#1001](https://github.com/cssinjs/jss/pull/1001))
+
 ## 10.0.0-alpha.9 (2019-1-25)
 
 ### Bug fixes

--- a/packages/jss-starter-kit/.size-snapshot.json
+++ b/packages/jss-starter-kit/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "dist/jss-starter-kit.js": {
-    "bundled": 81472,
-    "minified": 33168,
-    "gzipped": 9474
+    "bundled": 81292,
+    "minified": 33042,
+    "gzipped": 9420
   },
   "dist/jss-starter-kit.min.js": {
-    "bundled": 80718,
-    "minified": 32710,
-    "gzipped": 9262
+    "bundled": 80538,
+    "minified": 32564,
+    "gzipped": 9209
   },
   "dist/jss-starter-kit.cjs.js": {
-    "bundled": 2762,
-    "minified": 2513,
-    "gzipped": 795
+    "bundled": 2583,
+    "minified": 2327,
+    "gzipped": 747
   },
   "dist/jss-starter-kit.esm.js": {
-    "bundled": 1479,
-    "minified": 1362,
-    "gzipped": 517,
+    "bundled": 1435,
+    "minified": 1317,
+    "gzipped": 470,
     "treeshaked": {
       "rollup": {
         "code": 792,
         "import_statements": 489
       },
       "webpack": {
-        "code": 2328
+        "code": 2364
       }
     }
   }

--- a/packages/jss-starter-kit/.size-snapshot.json
+++ b/packages/jss-starter-kit/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/jss-starter-kit.js": {
-    "bundled": 81048,
-    "minified": 32915,
-    "gzipped": 9378
+    "bundled": 81472,
+    "minified": 33168,
+    "gzipped": 9474
   },
   "dist/jss-starter-kit.min.js": {
-    "bundled": 80294,
-    "minified": 32437,
-    "gzipped": 9166
+    "bundled": 80718,
+    "minified": 32710,
+    "gzipped": 9262
   },
   "dist/jss-starter-kit.cjs.js": {
-    "bundled": 2341,
-    "minified": 2127,
-    "gzipped": 689
+    "bundled": 2762,
+    "minified": 2513,
+    "gzipped": 795
   },
   "dist/jss-starter-kit.esm.js": {
-    "bundled": 1385,
-    "minified": 1273,
-    "gzipped": 462,
+    "bundled": 1479,
+    "minified": 1362,
+    "gzipped": 517,
     "treeshaked": {
       "rollup": {
         "code": 792,

--- a/packages/jss-starter-kit/package.json
+++ b/packages/jss-starter-kit/package.json
@@ -43,6 +43,7 @@
     "jss": "10.0.0-alpha.9",
     "jss-plugin-cache": "10.0.0-alpha.9",
     "jss-plugin-isolate": "10.0.0-alpha.9",
-    "jss-preset-default": "10.0.0-alpha.9"
+    "jss-preset-default": "10.0.0-alpha.9",
+    "react-jss": "10.0.0-alpha.9"
   }
 }

--- a/packages/jss-starter-kit/src/index.js
+++ b/packages/jss-starter-kit/src/index.js
@@ -8,9 +8,25 @@ If you'd like to use JSS in production, try including the "jss" and "jss-preset-
 
 jss.setup(preset())
 
-export {jss, preset}
+export {
+  jss,
+  preset,
+}
 
-export * as reactJss from 'react-jss'
+export {
+  SheetsRegistry,
+  SheetsManager,
+  createGenerateId,
+} from 'jss'
+
+export {
+  withTheme,
+  createTheming,
+  default as withStyles,
+  ThemeProvider,
+  JssProvider,
+} from 'react-jss'
+
 export {default as functions} from 'jss-plugin-rule-value-function'
 export {default as observable} from 'jss-plugin-rule-value-observable'
 export {default as template} from 'jss-plugin-template'

--- a/packages/jss-starter-kit/src/index.js
+++ b/packages/jss-starter-kit/src/index.js
@@ -8,17 +8,12 @@ If you'd like to use JSS in production, try including the "jss" and "jss-preset-
 
 jss.setup(preset())
 
-export {jss, preset}
+export {jss as default, preset}
 
-export {SheetsRegistry, SheetsManager, createGenerateId} from 'jss'
+export * from 'jss'
+export * from 'react-jss'
 
-export {
-  withTheme,
-  createTheming,
-  default as withStyles,
-  ThemeProvider,
-  JssProvider
-} from 'react-jss'
+export {default as withStyles} from 'react-jss'
 
 export {default as functions} from 'jss-plugin-rule-value-function'
 export {default as observable} from 'jss-plugin-rule-value-observable'

--- a/packages/jss-starter-kit/src/index.js
+++ b/packages/jss-starter-kit/src/index.js
@@ -8,23 +8,16 @@ If you'd like to use JSS in production, try including the "jss" and "jss-preset-
 
 jss.setup(preset())
 
-export {
-  jss,
-  preset,
-}
+export {jss, preset}
 
-export {
-  SheetsRegistry,
-  SheetsManager,
-  createGenerateId,
-} from 'jss'
+export {SheetsRegistry, SheetsManager, createGenerateId} from 'jss'
 
 export {
   withTheme,
   createTheming,
   default as withStyles,
   ThemeProvider,
-  JssProvider,
+  JssProvider
 } from 'react-jss'
 
 export {default as functions} from 'jss-plugin-rule-value-function'


### PR DESCRIPTION
__What would you like to add/fix?__
Fix `react-jss` export and add some missing exports from `jss`

__Corresponding issue (if exists):__ #948 
