### PR TITLE
Fix order of travis execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ after_success:
   - bash <(curl -s https://codecov.io/bash)
 script:
   - yarn format:ci
-  - yarn build
   - yarn check:all
+  - yarn build
   - yarn test
 env:
   global:


### PR DESCRIPTION
Currently, Travis builds the packages before running the size snapshot matches, which causes them always to pass
