### PR TITLE
[jss-plugin-camel-case] Support css vars better

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 ### Bug fixes
 
 - [jss-starter-kit] Fix react-jss exports and add missing jss exports ([#1001](https://github.com/cssinjs/jss/pull/1001))
+- [jss-plugin-camel-case] Fix hyphenating css variables ([#1017](https://github.com/cssinjs/jss/pull/1017))
 
 ## 10.0.0-alpha.9 (2019-1-25)
 

--- a/packages/jss-plugin-camel-case/.size-snapshot.json
+++ b/packages/jss-plugin-camel-case/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/jss-plugin-camel-case.js": {
-    "bundled": 2277,
-    "minified": 747,
-    "gzipped": 433
+    "bundled": 2403,
+    "minified": 800,
+    "gzipped": 458
   },
   "dist/jss-plugin-camel-case.min.js": {
-    "bundled": 2277,
-    "minified": 747,
-    "gzipped": 433
+    "bundled": 2403,
+    "minified": 800,
+    "gzipped": 458
   },
   "dist/jss-plugin-camel-case.cjs.js": {
-    "bundled": 1593,
-    "minified": 682,
-    "gzipped": 371
+    "bundled": 1703,
+    "minified": 735,
+    "gzipped": 393
   },
   "dist/jss-plugin-camel-case.esm.js": {
-    "bundled": 1375,
-    "minified": 510,
-    "gzipped": 283,
+    "bundled": 1485,
+    "minified": 563,
+    "gzipped": 307,
     "treeshaked": {
       "rollup": {
         "code": 29,

--- a/packages/jss-plugin-camel-case/src/index.js
+++ b/packages/jss-plugin-camel-case/src/index.js
@@ -12,7 +12,9 @@ function convertCase(style) {
   const converted = {}
 
   for (const prop in style) {
-    converted[hyphenate(prop)] = style[prop]
+    const key = prop.startsWith('--') ? prop : hyphenate(prop);
+
+    converted[key] = style[prop]
   }
 
   if (style.fallbacks) {
@@ -42,6 +44,10 @@ export default function camelCase(): Plugin {
   }
 
   function onChangeValue(value, prop, rule) {
+    if (prop.startsWith('--')) {
+      return value;
+    }
+
     const hyphenatedProp = hyphenate(prop)
 
     // There was no camel case in place

--- a/packages/jss-plugin-camel-case/src/index.js
+++ b/packages/jss-plugin-camel-case/src/index.js
@@ -12,7 +12,7 @@ function convertCase(style) {
   const converted = {}
 
   for (const prop in style) {
-    const key = prop.startsWith('--') ? prop : hyphenate(prop);
+    const key = prop.startsWith('--') ? prop : hyphenate(prop)
 
     converted[key] = style[prop]
   }
@@ -45,7 +45,7 @@ export default function camelCase(): Plugin {
 
   function onChangeValue(value, prop, rule) {
     if (prop.startsWith('--')) {
-      return value;
+      return value
     }
 
     const hyphenatedProp = hyphenate(prop)

--- a/packages/jss-plugin-camel-case/src/index.test.js
+++ b/packages/jss-plugin-camel-case/src/index.test.js
@@ -161,4 +161,48 @@ describe('jss-plugin-camel-case', () => {
       `)
     })
   })
+
+  describe('css variables', () => {
+    let localJss
+    beforeEach(() => {
+      localJss = create(settings).use(functionPlugin(), camelCase())
+    })
+
+    it('with static css variable', () => {
+      const sheet = localJss.createStyleSheet({
+        a: {
+          '--fontSize': 12
+        }
+      })
+      expect(sheet.toString()).to.be(stripIndent`
+        .a-id {
+          --fontSize: 12;
+        }
+      `)
+    })
+
+    it('with dynamic css variable', () => {
+      const sheet = localJss.createStyleSheet({
+        a: {
+          '--fontSize': size => size
+        }
+      })
+
+      sheet.update(12)
+
+      expect(sheet.toString()).to.be(stripIndent`
+        .a-id {
+          --fontSize: 12;
+        }
+      `)
+
+      sheet.update(16)
+
+      expect(sheet.toString()).to.be(stripIndent`
+        .a-id {
+          --fontSize: 16;
+        }
+      `)
+    })
+  })
 })

--- a/packages/jss-preset-default/.size-snapshot.json
+++ b/packages/jss-preset-default/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/jss-preset-default.js": {
-    "bundled": 65798,
-    "minified": 22853,
-    "gzipped": 6771
+    "bundled": 65916,
+    "minified": 22906,
+    "gzipped": 6792
   },
   "dist/jss-preset-default.min.js": {
-    "bundled": 65044,
-    "minified": 22390,
-    "gzipped": 6561
+    "bundled": 65162,
+    "minified": 22443,
+    "gzipped": 6582
   },
   "dist/jss-preset-default.cjs.js": {
     "bundled": 1329,

--- a/packages/jss-starter-kit/.size-snapshot.json
+++ b/packages/jss-starter-kit/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/jss-starter-kit.js": {
-    "bundled": 81292,
-    "minified": 33042,
-    "gzipped": 9420
+    "bundled": 81410,
+    "minified": 33095,
+    "gzipped": 9439
   },
   "dist/jss-starter-kit.min.js": {
-    "bundled": 80538,
-    "minified": 32564,
-    "gzipped": 9209
+    "bundled": 80656,
+    "minified": 32617,
+    "gzipped": 9227
   },
   "dist/jss-starter-kit.cjs.js": {
     "bundled": 2583,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/react-jss.js": {
-    "bundled": 131866,
-    "minified": 44695,
-    "gzipped": 13215
+    "bundled": 131984,
+    "minified": 44748,
+    "gzipped": 13238
   },
   "dist/react-jss.min.js": {
-    "bundled": 100134,
-    "minified": 34854,
-    "gzipped": 10467
+    "bundled": 100252,
+    "minified": 34907,
+    "gzipped": 10489
   },
   "dist/react-jss.cjs.js": {
     "bundled": 14377,


### PR DESCRIPTION
__What would you like to add/fix?__
Currently, css variables are also being hyphenated.

__Corresponding issue (if exists):__ #1012 
