### PR TITLE
[react-jss] Add react stylesheet defintion for ts autocomplete

### DIFF
--- a/docs/react-jss.md
+++ b/docs/react-jss.md
@@ -46,11 +46,11 @@ Try it out in the [playground](https://codesandbox.io/s/j3l06yyqpw).
 ```javascript
 import React from 'react'
 import {render} from 'react-dom'
-import withStyles from 'react-jss'
+import withStyles, {StyleSheet} from 'react-jss'
 
 // Create your Styles. Remember, since React-JSS uses the default preset,
 // most plugins are available without further configuration needed.
-const styles = {
+const styles: StyleSheet = {
   myButton: {
     color: 'green',
     margin: {

--- a/packages/react-jss/src/index.d.ts
+++ b/packages/react-jss/src/index.d.ts
@@ -1,4 +1,4 @@
-import {ComponentType, ReactNode} from 'react'
+import {ComponentType, ReactNode, CSSProperties} from 'react'
 import {
   CreateGenerateId,
   GenerateId,
@@ -19,6 +19,14 @@ declare const JssProvider: ComponentType<{
   disableStylesGeneration?: boolean
   children: ReactNode
 }>
+
+type StyleSheetLiteralValue = string | number | CSSProperties
+type StyleSheetComputedValue<Props> = (props: Props) => StyleSheetLiteralValue
+type StyleSheetValue<Props> = StyleSheetLiteralValue | StyleSheetComputedValue<Props>
+
+type StyleSheet<Props = {}> = {
+  [key: string]: StyleSheet<Props> | StyleSheetValue<Props>
+}
 
 type ThemedStyles<Theme> = (theme: Theme) => Styles
 
@@ -50,7 +58,8 @@ export {
   WithStyles,
   ThemeProvider,
   withTheme,
-  createTheming
+  createTheming,
+  StyleSheet
 }
 
 export default withStyles


### PR DESCRIPTION
__What would you like to add/fix?__

Right now there doesn't seem to be a way to get typechecking/autocompletion when defining style rules.

This adds a type definition for style rule definitions, so you can go like this:
```typescript
const styles: StyleSheet = {
  myButton: {
    color: 'green',
  }
}
```

and valid CSS properties will typecheck/autocomplete. I think the [definitely typed defs](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jss/css.d.ts) do some fancier version of this. This isn't ready to merge or anything, b/c:

- [ ] Only done for react-jss
- [ ] I'm not sure the type def is right - are style rules actually arbitrarily recursive?
- [ ] `StyleSheet` is probably a bad name since it's a browser global
- [ ] The `StyleSheet` type should probably be used in place of the `Style` type at use sites.
- [ ] Not tested - not sure there's a good way to do it with the test suite.
- [ ] Etc! Probably other things.

Happy to take a stab at figuring the above out if this seems like a useful approach.