### PR TITLE
Update publish scripts

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,10 @@
 {
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "10.0.0-alpha.9"
+  "version": "10.0.0-alpha.9",
+  "commands": {
+    "publish": {
+      "allow-branch": ["master"]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -20,14 +20,13 @@
     "---Release Scripts---": "",
     "version": "yarn build && yarn test && node ./scripts/update-changelog && node ./scripts/add-git-files",
     "prerelease": "yarn check:all && yarn format:ci",
-    "release": "lerna publish prerelease --exact --force-publish *",
+    "release": "lerna publish",
     "postrelease": "node ./scripts/create-github-release",
-    "release:patch": "lerna publish patch --dist-tag latest --exact --force-publish *",
-    "release:minor": "lerna publish minor --dist-tag latest --exact --force-publish *",
-    "release:major": "lerna publish major --dist-tag latest --exact --force-publish *",
-    "release:alpha:patch": "lerna publish prepatch --dist-tag next --exact --force-publish *",
-    "release:alpha:minor": "lerna publish preminor --dist-tag next --exact --force-publish *",
-    "release:alpha:major": "lerna publish premajor --dist-tag next --exact --force-publish *"
+    "release:patch": "yarn release patch --dist-tag latest --exact --force-publish *",
+    "release:minor": "yarn release minor --dist-tag latest --exact --force-publish *",
+    "release:major": "yarn release major --dist-tag latest --exact --force-publish *",
+    "release:prerelease": "yarn release prerelease --dist-tag next --exact --force-publish *",
+    "release:alpha:major": "yarn release premajor --dist-tag next --exact --force-publish *"
   },
   "lint-staged": {
     "**/*.{js,md,json,ts}": [

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "---Release Scripts---": "",
     "version": "yarn build && yarn test && node ./scripts/update-changelog && node ./scripts/add-git-files",
     "prerelease": "yarn check:all && yarn format:ci",
-    "release": "lerna publish --exact --force-publish *",
+    "release": "lerna publish prerelease --exact --force-publish *",
     "postrelease": "node ./scripts/create-github-release",
     "release:patch": "lerna publish patch --dist-tag latest --exact --force-publish *",
     "release:minor": "lerna publish minor --dist-tag latest --exact --force-publish *",

--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
     "---Release Scripts---": "",
     "version": "yarn build && yarn test && node ./scripts/update-changelog && node ./scripts/add-git-files",
     "prerelease": "yarn check:all && yarn format:ci",
-    "release": "lerna publish --exact --force-publish * --allow-branch master",
+    "release": "lerna publish --exact --force-publish *",
     "postrelease": "node ./scripts/create-github-release",
-    "release:patch": "yarn release patch --dist-tag latest",
-    "release:minor": "yarn release minor --dist-tag latest",
-    "release:major": "yarn release major --dist-tag latest",
-    "release:alpha:patch": "yarn release --dist-tag next",
-    "release:alpha:minor": "yarn release --dist-tag next",
-    "release:alpha:major": "yarn release --dist-tag next"
+    "release:patch": "lerna publish patch --dist-tag latest --exact --force-publish *",
+    "release:minor": "lerna publish minor --dist-tag latest --exact --force-publish *",
+    "release:major": "lerna publish major --dist-tag latest --exact --force-publish *",
+    "release:alpha:patch": "lerna publish prepatch --dist-tag next --exact --force-publish *",
+    "release:alpha:minor": "lerna publish preminor --dist-tag next --exact --force-publish *",
+    "release:alpha:major": "lerna publish premajor --dist-tag next --exact --force-publish *"
   },
   "lint-staged": {
     "**/*.{js,md,json,ts}": [


### PR DESCRIPTION
__What would you like to add/fix?__
This fixes the publishing finally.
For all of the below scripts, the dist tag will be automatically set.

How to publish now (there are five scripts):

`release:patch` -> Release a new patch version
`release:minor` -> Release a new minor version
`release:major` -> Release a new major version
If we are on an alpha version, any of the above scripts will mature the version.

I think we only need to have a new alpha version in case of major versions, that's why only the major version exists here.
`release:alpha:major` -> Release a new alpha version of a new major version This will increment the major version and add a `-alpha.0` suffix

`release:prerelease` -> Release a new prerelease version. This will increment the prerelease number. 