### PR TITLE
[jss] Remove prop when null is returned from a function rule/value

### DIFF
--- a/packages/jss-plugin-rule-value-function/src/function-values.test.js
+++ b/packages/jss-plugin-rule-value-function/src/function-values.test.js
@@ -284,6 +284,7 @@ describe('jss-plugin-rule-value-function: Function values', () => {
       })
 
       it('should remove declarations when value is null', () => {
+        sheet.update({color: 'green'})
         sheet.update({color: null})
 
         expect(sheet.toString()).to.be(stripIndent`
@@ -298,6 +299,7 @@ describe('jss-plugin-rule-value-function: Function values', () => {
       })
 
       it('should remove declarations when value is undefined', () => {
+        sheet.update({color: 'green'})
         sheet.update({color: undefined})
 
         expect(sheet.toString()).to.be(stripIndent`
@@ -312,6 +314,7 @@ describe('jss-plugin-rule-value-function: Function values', () => {
       })
 
       it('should remove declarations when value is false', () => {
+        sheet.update({color: 'green'})
         sheet.update({color: false})
 
         expect(sheet.toString()).to.be(stripIndent`


### PR DESCRIPTION
__What would you like to add/fix?__
Currently, a prop is not removed when a function value returns undefined.

I got two tests to fail. I narrowed down to the problem that `renderable` is not defined in the `StyleRule`: https://github.com/cssinjs/jss/blob/master/packages/jss/src/plugins/styleRule.js#L69

@kof can you also please have a look why it's not defined?

__Corresponding issue (if exists):__ #1026 
