### PR TITLE
[react-jss] Add dynamic rules to static sheet

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@
 
 - [react-jss] Replace spaces inside the display name with hyphens ([#1049](https://github.com/cssinjs/jss/pull/1049))
 
+### Improvements
+
+- [react-jss] Add dynamic rules to the static sheet ([#1048](https://github.com/cssinjs/jss/pull/1048))
+
 ## 10.0.0-alpha.12 (2019-2-27)
 
 ### Bug fixes

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/react-jss.js": {
-    "bundled": 110399,
-    "minified": 37053,
-    "gzipped": 11908
+    "bundled": 110413,
+    "minified": 37067,
+    "gzipped": 11910
   },
   "dist/react-jss.min.js": {
-    "bundled": 85860,
-    "minified": 29807,
-    "gzipped": 9735
+    "bundled": 85874,
+    "minified": 29821,
+    "gzipped": 9737
   },
   "dist/react-jss.cjs.js": {
-    "bundled": 15384,
-    "minified": 7062,
-    "gzipped": 2367
+    "bundled": 15398,
+    "minified": 7076,
+    "gzipped": 2369
   },
   "dist/react-jss.esm.js": {
-    "bundled": 14703,
-    "minified": 6482,
-    "gzipped": 2247,
+    "bundled": 14717,
+    "minified": 6496,
+    "gzipped": 2249,
     "treeshaked": {
       "rollup": {
         "code": 1946,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "dist/react-jss.js": {
-    "bundled": 109683,
-    "minified": 36814,
-    "gzipped": 11859
+    "bundled": 110399,
+    "minified": 37053,
+    "gzipped": 11908
   },
   "dist/react-jss.min.js": {
-    "bundled": 85144,
-    "minified": 29568,
-    "gzipped": 9685
+    "bundled": 85860,
+    "minified": 29807,
+    "gzipped": 9735
   },
   "dist/react-jss.cjs.js": {
-    "bundled": 14716,
-    "minified": 6874,
-    "gzipped": 2310
+    "bundled": 15384,
+    "minified": 7062,
+    "gzipped": 2367
   },
   "dist/react-jss.esm.js": {
-    "bundled": 14035,
-    "minified": 6294,
-    "gzipped": 2193,
+    "bundled": 14703,
+    "minified": 6482,
+    "gzipped": 2247,
     "treeshaked": {
       "rollup": {
         "code": 1946,
         "import_statements": 457
       },
       "webpack": {
-        "code": 3338
+        "code": 3310
       }
     }
   }

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "dist/react-jss.js": {
-    "bundled": 110994,
-    "minified": 37054,
-    "gzipped": 11932
+    "bundled": 110610,
+    "minified": 36986,
+    "gzipped": 11979
   },
   "dist/react-jss.min.js": {
-    "bundled": 86435,
-    "minified": 29789,
-    "gzipped": 9749
+    "bundled": 86051,
+    "minified": 29721,
+    "gzipped": 9794
   },
   "dist/react-jss.cjs.js": {
-    "bundled": 15965,
-    "minified": 7063,
-    "gzipped": 2397
+    "bundled": 15563,
+    "minified": 7161,
+    "gzipped": 2471
   },
   "dist/react-jss.esm.js": {
-    "bundled": 15284,
-    "minified": 6483,
-    "gzipped": 2278,
+    "bundled": 14882,
+    "minified": 6581,
+    "gzipped": 2353,
     "treeshaked": {
       "rollup": {
         "code": 1946,
         "import_statements": 457
       },
       "webpack": {
-        "code": 3310
+        "code": 3346
       }
     }
   }

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/react-jss.js": {
-    "bundled": 110413,
-    "minified": 37067,
-    "gzipped": 11910
+    "bundled": 110518,
+    "minified": 37015,
+    "gzipped": 11920
   },
   "dist/react-jss.min.js": {
-    "bundled": 85874,
-    "minified": 29821,
-    "gzipped": 9737
+    "bundled": 85979,
+    "minified": 29769,
+    "gzipped": 9748
   },
   "dist/react-jss.cjs.js": {
-    "bundled": 15398,
-    "minified": 7076,
-    "gzipped": 2369
+    "bundled": 15499,
+    "minified": 7024,
+    "gzipped": 2378
   },
   "dist/react-jss.esm.js": {
-    "bundled": 14717,
-    "minified": 6496,
-    "gzipped": 2249,
+    "bundled": 14818,
+    "minified": 6444,
+    "gzipped": 2259,
     "treeshaked": {
       "rollup": {
         "code": 1946,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/react-jss.js": {
-    "bundled": 110916,
-    "minified": 37031,
-    "gzipped": 11929
+    "bundled": 110994,
+    "minified": 37054,
+    "gzipped": 11932
   },
   "dist/react-jss.min.js": {
-    "bundled": 86357,
-    "minified": 29766,
-    "gzipped": 9747
+    "bundled": 86435,
+    "minified": 29789,
+    "gzipped": 9749
   },
   "dist/react-jss.cjs.js": {
-    "bundled": 15893,
-    "minified": 7040,
-    "gzipped": 2390
+    "bundled": 15965,
+    "minified": 7063,
+    "gzipped": 2397
   },
   "dist/react-jss.esm.js": {
-    "bundled": 15212,
-    "minified": 6460,
-    "gzipped": 2271,
+    "bundled": 15284,
+    "minified": 6483,
+    "gzipped": 2278,
     "treeshaked": {
       "rollup": {
         "code": 1946,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/react-jss.js": {
-    "bundled": 110518,
-    "minified": 37015,
-    "gzipped": 11920
+    "bundled": 110896,
+    "minified": 37012,
+    "gzipped": 11918
   },
   "dist/react-jss.min.js": {
-    "bundled": 85979,
-    "minified": 29769,
-    "gzipped": 9748
+    "bundled": 86357,
+    "minified": 29766,
+    "gzipped": 9747
   },
   "dist/react-jss.cjs.js": {
-    "bundled": 15499,
-    "minified": 7024,
-    "gzipped": 2378
+    "bundled": 15873,
+    "minified": 7021,
+    "gzipped": 2376
   },
   "dist/react-jss.esm.js": {
-    "bundled": 14818,
-    "minified": 6444,
-    "gzipped": 2259,
+    "bundled": 15192,
+    "minified": 6441,
+    "gzipped": 2257,
     "treeshaked": {
       "rollup": {
         "code": 1946,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/react-jss.js": {
-    "bundled": 110896,
-    "minified": 37012,
-    "gzipped": 11918
+    "bundled": 110916,
+    "minified": 37031,
+    "gzipped": 11929
   },
   "dist/react-jss.min.js": {
     "bundled": 86357,
@@ -10,14 +10,14 @@
     "gzipped": 9747
   },
   "dist/react-jss.cjs.js": {
-    "bundled": 15873,
-    "minified": 7021,
-    "gzipped": 2376
+    "bundled": 15893,
+    "minified": 7040,
+    "gzipped": 2390
   },
   "dist/react-jss.esm.js": {
-    "bundled": 15192,
-    "minified": 6441,
-    "gzipped": 2257,
+    "bundled": 15212,
+    "minified": 6460,
+    "gzipped": 2271,
     "treeshaked": {
       "rollup": {
         "code": 1946,

--- a/packages/react-jss/src/JssProvider.test.js
+++ b/packages/react-jss/src/JssProvider.test.js
@@ -260,7 +260,7 @@ describe('React-JSS: JssProvider', () => {
         .button-0 {
           color: red;
         }
-        .button-1 {
+        .button-0-1 {
           border: green;
         }
       `)
@@ -278,7 +278,7 @@ describe('React-JSS: JssProvider', () => {
         .button-0 {
           color: red;
         }
-        .button-1 {
+        .button-0-1 {
           border: blue;
         }
       `)

--- a/packages/react-jss/src/types.js
+++ b/packages/react-jss/src/types.js
@@ -33,8 +33,8 @@ export type InnerProps = {
 }
 
 export type DynamicRules = {
-  [key: string]: BaseRule,
-};
+  [key: string]: BaseRule
+}
 
 export type ThemedStyles<Theme> = (theme: Theme) => StaticStyles
 export type Styles<Theme> = StaticStyles | ThemedStyles<Theme>

--- a/packages/react-jss/src/types.js
+++ b/packages/react-jss/src/types.js
@@ -1,5 +1,5 @@
 // @flow
-import type {StyleSheetFactoryOptions, Jss, SheetsRegistry, SheetsManager} from 'jss'
+import type {StyleSheetFactoryOptions, Jss, SheetsRegistry, SheetsManager, BaseRule} from 'jss'
 import type {Node} from 'react'
 import type {Theming} from 'theming'
 
@@ -31,6 +31,10 @@ export type InnerProps = {
   children?: Node,
   classes: {}
 }
+
+export type DynamicRules = {
+  [key: string]: BaseRule,
+};
 
 export type ThemedStyles<Theme> = (theme: Theme) => StaticStyles
 export type Styles<Theme> = StaticStyles | ThemedStyles<Theme>

--- a/packages/react-jss/src/withStyles.js
+++ b/packages/react-jss/src/withStyles.js
@@ -232,7 +232,7 @@ export default function withStyles<Theme: {}, S: Styles<Theme>>(
         const rules = {};
 
         for (const key in sheet.dynamicStyles) {
-          rules[key] = sheet.addRule(`${key}-${this.instanceId}`, rules[key])
+          rules[key] = sheet.addRule(`${key}-${this.instanceId}`, sheet.dynamicStyles[key])
         }
 
         return rules;

--- a/packages/react-jss/src/withStyles.js
+++ b/packages/react-jss/src/withStyles.js
@@ -79,6 +79,10 @@ export default function withStyles<Theme: {}, S: Styles<Theme>>(
       static defaultProps = {...InnerComponent.defaultProps}
 
       static getSheetClasses(sheet, dynamicRules: ?DynamicRules) {
+        if (!dynamicRules) {
+          return sheet.classes
+        }
+
         const classes = {}
 
         // $FlowFixMe

--- a/packages/react-jss/src/withStyles.js
+++ b/packages/react-jss/src/withStyles.js
@@ -97,9 +97,11 @@ export default function withStyles<Theme: {}, S: Styles<Theme>>(
           return
         }
 
+        // Loop over each dynamic rule and update it
+        // We can't just update the whole sheet as this has all of the rules for every component instance
         for (const key in dynamicRules) {
           // $FlowFixMe: Not sure why it throws an error here
-          sheet.update(dynamicRules[key].key, props, {})
+          sheet.update(dynamicRules[key].key, props)
         }
       }
 
@@ -108,6 +110,8 @@ export default function withStyles<Theme: {}, S: Styles<Theme>>(
           return
         }
 
+        // Loop over each dynamic rule and remove the dynamic rule
+        // We can't just remove the whole sheet as this has all of the rules for every component instance
         for (const key in dynamicRules) {
           sheet.deleteRule(dynamicRules[key].key)
         }
@@ -119,6 +123,7 @@ export default function withStyles<Theme: {}, S: Styles<Theme>>(
 
         const rules: DynamicRules = {}
 
+        // Loop over each dynamic rule and add it to the stylesheet
         for (const key in sheet.dynamicStyles) {
           // $FlowFixMe
           const ruleKey = `${key}-${sheet.dynamicRuleCounter++}`

--- a/packages/react-jss/src/withStyles.js
+++ b/packages/react-jss/src/withStyles.js
@@ -13,9 +13,9 @@ import defaultJss from './jss'
 import JssContext from './JssContext'
 
 interface State {
-  dynamicRules?: ?DynamicRules,
-  sheet?: StyleSheet,
-  classes: {}
+  dynamicRules?: ?DynamicRules;
+  sheet?: StyleSheet;
+  classes: {};
 }
 
 /**
@@ -78,38 +78,38 @@ export default function withStyles<Theme: {}, S: Styles<Theme>>(
       static defaultProps = {...InnerComponent.defaultProps}
 
       static getSheetClasses(sheet, dynamicRules: ?DynamicRules) {
-        const classes = {};
+        const classes = {}
 
         // $FlowFixMe
         for (const key in sheet.styles) {
-          classes[key] = sheet.classes[key];
+          classes[key] = sheet.classes[key]
 
           if (dynamicRules && key in dynamicRules) {
             classes[key] += ` ${sheet.classes[dynamicRules[key].key]}`
           }
         }
 
-        return classes;
+        return classes
       }
 
-      static updateDynamicRules(props: HOCProps<Theme, Props>, { dynamicRules, sheet }: State) {
+      static updateDynamicRules(props: HOCProps<Theme, Props>, {dynamicRules, sheet}: State) {
         if (!sheet) {
-          return;
+          return
         }
 
         for (const key in dynamicRules) {
           // $FlowFixMe: Not sure why it throws an error here
-          sheet.update(dynamicRules[key].key, props, {});
+          sheet.update(dynamicRules[key].key, props, {})
         }
       }
 
-      static removeDynamicRules(props: Props, { dynamicRules, sheet }: State) {
+      static removeDynamicRules(props: Props, {dynamicRules, sheet}: State) {
         if (!sheet) {
-          return;
+          return
         }
 
         for (const key in dynamicRules) {
-          sheet.deleteRule(dynamicRules[key].key);
+          sheet.deleteRule(dynamicRules[key].key)
         }
       }
 
@@ -117,19 +117,19 @@ export default function withStyles<Theme: {}, S: Styles<Theme>>(
         // $FlowFixMe Cannot access random fields on instance of class StyleSheet
         if (!sheet.dynamicStyles) return undefined
 
-        const rules: DynamicRules = {};
+        const rules: DynamicRules = {}
 
         for (const key in sheet.dynamicStyles) {
           // $FlowFixMe
-          const ruleKey = `${key}-${sheet.dynamicRuleCounter++}`;
-          const rule = sheet.addRule(ruleKey, sheet.dynamicStyles[key]);
+          const ruleKey = `${key}-${sheet.dynamicRuleCounter++}`
+          const rule = sheet.addRule(ruleKey, sheet.dynamicStyles[key])
 
           if (rule) {
-            rules[key] = rule;
+            rules[key] = rule
           }
         }
 
-        return rules;
+        return rules
       }
 
       mergeClassesProp = memoize(
@@ -208,10 +208,10 @@ export default function withStyles<Theme: {}, S: Styles<Theme>>(
         sheet.dynamicStyles = dynamicStyles
 
         // $FlowFixMe Cannot add random fields to instance of class StyleSheet
-        sheet.styles = themedStyles;
+        sheet.styles = themedStyles
 
         // $FlowFixMe
-        sheet.dynamicRuleCounter = 0;
+        sheet.dynamicRuleCounter = 0
 
         this.manager.add(theme, sheet)
 
@@ -253,7 +253,7 @@ export default function withStyles<Theme: {}, S: Styles<Theme>>(
         return {
           sheet,
           dynamicRules,
-          classes: WithStyles.getSheetClasses(sheet, dynamicRules),
+          classes: WithStyles.getSheetClasses(sheet, dynamicRules)
         }
       }
 

--- a/packages/react-jss/tests/dynamic-styles.js
+++ b/packages/react-jss/tests/dynamic-styles.js
@@ -94,10 +94,10 @@ describe('React-JSS: dynamic styles', () => {
         .button-0 {
           color: ${color};
         }
-        .button-1 {
+        .button-0-1 {
           height: 10px;
         }
-        .button-2 {
+        .button-1-2 {
           height: 20px;
         }
       `)
@@ -118,10 +118,10 @@ describe('React-JSS: dynamic styles', () => {
         .button-0 {
           color: ${color};
         }
-        .button-1 {
+        .button-0-1 {
           height: 10px;
         }
-        .button-2 {
+        .button-1-2 {
           height: 20px;
         }
       `)
@@ -132,10 +132,10 @@ describe('React-JSS: dynamic styles', () => {
         .button-0 {
           color: ${color};
         }
-        .button-1 {
+        .button-0-1 {
           height: 20px;
         }
-        .button-2 {
+        .button-1-2 {
           height: 40px;
         }
       `)
@@ -161,7 +161,7 @@ describe('React-JSS: dynamic styles', () => {
         .button-0 {
           width: 10px;
         }
-        .button-1 {
+        .button-0-1 {
           height: 10px;
         }
       `)
@@ -172,7 +172,7 @@ describe('React-JSS: dynamic styles', () => {
         .button-0 {
           width: 10px;
         }
-        .button-1 {}
+        .button-0-1 {}
       `)
     })
 
@@ -198,7 +198,8 @@ describe('React-JSS: dynamic styles', () => {
         .button0-0 {
           width: 10px;
         }
-        .button1-2 {
+        .button1-1 {}
+        .button1-0-2 {
           height: 10px;
         }
       `)
@@ -209,7 +210,8 @@ describe('React-JSS: dynamic styles', () => {
         .button0-0 {
           width: 10px;
         }
-        .button1-2 {}
+        .button1-1 {}
+        .button1-0-2 {}
       `)
     })
 
@@ -256,14 +258,12 @@ describe('React-JSS: dynamic styles', () => {
         </JssProvider>
       )
 
-      expect(registry.registry.length).to.equal(2)
+      expect(registry.registry.length).to.equal(1)
       expect(registry.registry[0].attached).to.equal(true)
-      expect(registry.registry[1].attached).to.equal(true)
 
       renderer.unmount()
 
       expect(registry.registry[0].attached).to.equal(false)
-      expect(registry.registry[1].attached).to.equal(false)
     })
 
     it('should have correct meta attribute', () => {
@@ -273,8 +273,7 @@ describe('React-JSS: dynamic styles', () => {
         </JssProvider>
       )
 
-      expect(registry.registry[0].options.meta).to.equal('NoRenderer, Unthemed, Static')
-      expect(registry.registry[1].options.meta).to.equal('NoRenderer, Unthemed, Dynamic')
+      expect(registry.registry[0].options.meta).to.equal('NoRenderer, Unthemed')
     })
 
     it('should reuse static sheet, but generate separate dynamic once', () => {
@@ -285,7 +284,7 @@ describe('React-JSS: dynamic styles', () => {
         </JssProvider>
       )
 
-      expect(registry.registry.length).to.equal(3)
+      expect(registry.registry.length).to.equal(1)
     })
 
     it('should have dynamic and static styles', () => {
@@ -296,7 +295,7 @@ describe('React-JSS: dynamic styles', () => {
       )
       const props = renderer.root.findByType(NoRenderer).props
 
-      expect(props.classes.button).to.equal('button-0 button-1')
+      expect(props.classes.button).to.equal('button-0 button-0-1')
     })
 
     it('should generate different dynamic values', () => {
@@ -307,18 +306,17 @@ describe('React-JSS: dynamic styles', () => {
         </JssProvider>
       )
 
-      expect(removeWhitespaces(registry.toString())).to.equal(
-        removeWhitespaces(`
-          .button-1 {
-            color: ${color};
-            height: 10px;
-          }
-          .button-2 {
-            color: ${color};
-            height: 20px;
-          }
-        `)
-      )
+      expect(registry.toString()).to.equal(stripIndent`
+        .button-0 {
+          color: rgb(255,255,255);
+        }
+        .button-0-1 {
+          height: 10px;
+        }
+        .button-1-2 {
+          height: 20px;
+        }
+      `)
     })
 
     it('should update dynamic values', () => {

--- a/packages/react-jss/tests/dynamic-styles.js
+++ b/packages/react-jss/tests/dynamic-styles.js
@@ -42,14 +42,12 @@ describe('React-JSS: dynamic styles', () => {
         </JssProvider>
       )
 
-      expect(registry.registry.length).to.equal(2)
+      expect(registry.registry.length).to.equal(1)
       expect(registry.registry[0].attached).to.equal(true)
-      expect(registry.registry[1].attached).to.equal(true)
 
       renderer.unmount()
 
       expect(registry.registry[0].attached).to.equal(false)
-      expect(registry.registry[1].attached).to.equal(false)
     })
 
     it('should have correct meta attribute', () => {
@@ -59,11 +57,10 @@ describe('React-JSS: dynamic styles', () => {
         </JssProvider>
       )
 
-      expect(registry.registry[0].options.meta).to.equal('NoRenderer, Unthemed, Static')
-      expect(registry.registry[1].options.meta).to.equal('NoRenderer, Unthemed, Dynamic')
+      expect(registry.registry[0].options.meta).to.equal('NoRenderer, Unthemed')
     })
 
-    it('should reuse static sheet, but generate separate dynamic once', () => {
+    it('should reuse sheet between component instances', () => {
       TestRenderer.create(
         <JssProvider registry={registry}>
           <MyComponent height={2} />
@@ -71,7 +68,7 @@ describe('React-JSS: dynamic styles', () => {
         </JssProvider>
       )
 
-      expect(registry.registry.length).to.equal(3)
+      expect(registry.registry.length).to.equal(1)
     })
 
     it('should have dynamic and static styles', () => {
@@ -82,7 +79,7 @@ describe('React-JSS: dynamic styles', () => {
       )
       const props = renderer.root.findByType(NoRenderer).props
 
-      expect(props.classes.button).to.equal('button-0 button-1')
+      expect(props.classes.button).to.equal('button-0 button-0-1')
     })
 
     it('should generate different dynamic values', () => {

--- a/packages/react-jss/tests/dynamic-styles.js
+++ b/packages/react-jss/tests/dynamic-styles.js
@@ -1,13 +1,12 @@
 /* eslint-disable global-require, react/prop-types, react/no-find-dom-node, react/no-multi-comp, react/prefer-stateless-function */
 
 import expect from 'expect.js'
-import React, {PureComponent} from 'react'
+import React from 'react'
 import TestRenderer from 'react-test-renderer'
 import {stripIndent} from 'common-tags'
 
 import injectSheet, {JssProvider, SheetsRegistry} from '../src'
 
-const removeWhitespaces = str => str.replace(/\s/g, '')
 const createGenerateId = () => {
   let counter = 0
   return rule => `${rule.key}-${counter++}`
@@ -200,7 +199,7 @@ describe('React-JSS: dynamic styles', () => {
         }
         .button1-1 {}
         .button1-0-2 {
-          height: 10px;
+          height: 10;
         }
       `)
 
@@ -307,13 +306,13 @@ describe('React-JSS: dynamic styles', () => {
       )
 
       expect(registry.toString()).to.equal(stripIndent`
-        .button-0 {
-          color: rgb(255,255,255);
-        }
+        .button-0 {}
         .button-0-1 {
+          color: rgb(255, 255, 255);
           height: 10px;
         }
         .button-1-2 {
+          color: rgb(255, 255, 255);
           height: 20px;
         }
       `)
@@ -321,47 +320,41 @@ describe('React-JSS: dynamic styles', () => {
 
     it('should update dynamic values', () => {
       const generateId = createGenerateId()
-      class Container extends PureComponent {
-        render() {
-          const {height} = this.props
-          return (
-            <JssProvider registry={registry} generateId={generateId}>
-              <MyComponent height={height} />
-              <MyComponent height={height * 2} />
-            </JssProvider>
-          )
-        }
+      function Container({height}) {
+        return (
+          <JssProvider registry={registry} generateId={generateId}>
+            <MyComponent height={height} />
+            <MyComponent height={height * 2} />
+          </JssProvider>
+        )
       }
 
       const renderer = TestRenderer.create(<Container height={10} />)
 
-      expect(removeWhitespaces(registry.toString())).to.equal(
-        removeWhitespaces(`
-          .button-1 {
-            color: ${color};
-            height: 10px;
-          }
-          .button-2 {
-            color: ${color};
-            height: 20px;
-          }
-       `)
-      )
-
+      expect(registry.toString()).to.equal(stripIndent`
+        .button-0 {}
+        .button-0-1 {
+          color: ${color};
+          height: 10px;
+        }
+        .button-1-2 {
+          color: ${color};
+          height: 20px;
+        }
+      `)
       renderer.update(<Container height={20} />)
 
-      expect(removeWhitespaces(registry.toString())).to.equal(
-        removeWhitespaces(`
-          .button-1 {
-            color: ${color};
-            height: 20px;
-          }
-          .button-2 {
-            color: ${color};
-            height: 40px;
-          }
-        `)
-      )
+      expect(registry.toString()).to.equal(stripIndent`
+        .button-0 {}
+        .button-0-1 {
+          color: ${color};
+          height: 20px;
+        }
+        .button-1-2 {
+          color: ${color};
+          height: 40px;
+        }
+      `)
     })
 
     it('should use the default props', () => {

--- a/packages/react-jss/tests/dynamic-styles.js
+++ b/packages/react-jss/tests/dynamic-styles.js
@@ -199,7 +199,7 @@ describe('React-JSS: dynamic styles', () => {
         }
         .button1-1 {}
         .button1-0-2 {
-          height: 10;
+          height: 10px;
         }
       `)
 

--- a/packages/react-jss/tests/theming.js
+++ b/packages/react-jss/tests/theming.js
@@ -127,7 +127,7 @@ describe('React-JSS: theming', () => {
       </JssProvider>
     )
 
-    expect(registry.registry.length).to.equal(2)
+    expect(registry.registry.length).to.equal(1)
   })
 
   it('one themed instance wo/ = 1 style, theme update = 1 style', () => {
@@ -164,7 +164,7 @@ describe('React-JSS: theming', () => {
       </ThemeProvider>
     )
 
-    expect(registry.registry.length).to.equal(2)
+    expect(registry.registry.length).to.equal(1)
 
     renderer.update(
       <ThemeProvider theme={ThemeB}>
@@ -175,8 +175,7 @@ describe('React-JSS: theming', () => {
     )
 
     expect(registry.registry[0].attached).to.be(false)
-    expect(registry.registry[1].attached).to.be(false)
-    expect(registry.registry.length).to.equal(4)
+    expect(registry.registry.length).to.equal(2)
   })
 
   it('two themed instances wo/ dynamic props w/ same theme = 1 style', () => {
@@ -204,7 +203,7 @@ describe('React-JSS: theming', () => {
       </JssProvider>
     )
 
-    expect(registry.registry.length).to.equal(3)
+    expect(registry.registry.length).to.equal(1)
   })
 
   it('two themed instances w/ dynamic props w/ same theme = 3 styles, theme update = 3 styles', () => {
@@ -218,7 +217,7 @@ describe('React-JSS: theming', () => {
       </ThemeProvider>
     )
 
-    expect(registry.registry.length).to.equal(3)
+    expect(registry.registry.length).to.equal(1)
 
     renderer.update(
       <ThemeProvider theme={ThemeB}>
@@ -230,9 +229,7 @@ describe('React-JSS: theming', () => {
     )
 
     expect(registry.registry[0].attached).to.equal(false)
-    expect(registry.registry[1].attached).to.equal(false)
-    expect(registry.registry[2].attached).to.equal(false)
-    expect(registry.registry.length).to.equal(6)
+    expect(registry.registry.length).to.equal(2)
   })
 
   it('two themed instances wo/ dynamic props w/ same theme = 1 styles, different theme update = 2 styles', () => {
@@ -277,7 +274,7 @@ describe('React-JSS: theming', () => {
       </JssProvider>
     )
 
-    expect(registry.registry.length).to.equal(3)
+    expect(registry.registry.length).to.equal(1)
 
     renderer.update(
       <JssProvider registry={registry}>
@@ -290,8 +287,7 @@ describe('React-JSS: theming', () => {
       </JssProvider>
     )
 
-    expect(registry.registry[2].attached).to.equal(false)
-    expect(registry.registry.length).to.equal(5)
+    expect(registry.registry.length).to.equal(2)
   })
 
   it('two themed instances wo/ dynamic props w/ different themes = 2 styles, same theme update = 1 style', () => {
@@ -337,7 +333,7 @@ describe('React-JSS: theming', () => {
       </JssProvider>
     )
 
-    expect(registry.registry.length).to.equal(4)
+    expect(registry.registry.length).to.equal(2)
 
     renderer.update(
       <JssProvider registry={registry}>
@@ -350,9 +346,8 @@ describe('React-JSS: theming', () => {
       </JssProvider>
     )
 
-    expect(registry.registry[2].attached).to.equal(false)
-    expect(registry.registry[3].attached).to.equal(false)
-    expect(registry.registry.length).to.equal(5)
+    expect(registry.registry[1].attached).to.equal(false)
+    expect(registry.registry.length).to.equal(2)
   })
 
   describe('when theming object returned from createTheming is provided to injectSheet options', () => {


### PR DESCRIPTION
__What would you like to add/fix?__
This adds the dynamic rules to the static sheet instead of creating a new sheet for every component instance.

I haven't updated the tests, but this should also fix the issues with having to different sheets in `react-jss` (`compose` behaves a little bit different, dynamic keyframe names aren't possible).

__Corresponding issue (if exists):__ #1037 
