### PR TITLE
[react-jss] Fix display names with spaces inside

### DIFF
--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/react-jss.js": {
-    "bundled": 109683,
-    "minified": 36814,
-    "gzipped": 11859
+    "bundled": 109702,
+    "minified": 36832,
+    "gzipped": 11869
   },
   "dist/react-jss.min.js": {
     "bundled": 85144,
@@ -10,14 +10,14 @@
     "gzipped": 9685
   },
   "dist/react-jss.cjs.js": {
-    "bundled": 14716,
-    "minified": 6874,
-    "gzipped": 2310
+    "bundled": 14735,
+    "minified": 6892,
+    "gzipped": 2322
   },
   "dist/react-jss.esm.js": {
-    "bundled": 14035,
-    "minified": 6294,
-    "gzipped": 2193,
+    "bundled": 14054,
+    "minified": 6312,
+    "gzipped": 2206,
     "treeshaked": {
       "rollup": {
         "code": 1946,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/react-jss.js": {
-    "bundled": 109702,
-    "minified": 36832,
-    "gzipped": 11869
+    "bundled": 109703,
+    "minified": 36833,
+    "gzipped": 11871
   },
   "dist/react-jss.min.js": {
     "bundled": 85144,
@@ -10,14 +10,14 @@
     "gzipped": 9685
   },
   "dist/react-jss.cjs.js": {
-    "bundled": 14735,
-    "minified": 6892,
-    "gzipped": 2322
+    "bundled": 14736,
+    "minified": 6893,
+    "gzipped": 2323
   },
   "dist/react-jss.esm.js": {
-    "bundled": 14054,
-    "minified": 6312,
-    "gzipped": 2206,
+    "bundled": 14055,
+    "minified": 6313,
+    "gzipped": 2207,
     "treeshaked": {
       "rollup": {
         "code": 1946,

--- a/packages/react-jss/src/withStyles.js
+++ b/packages/react-jss/src/withStyles.js
@@ -66,7 +66,7 @@ export default function withStyles<Theme: {}, S: Styles<Theme>>(
   ): ComponentType<Props> => {
     const displayName = getDisplayName(InnerComponent)
     const defaultClassNamePrefix =
-      process.env.NODE_ENV === 'production' ? '' : `${displayName.replace(/\s/, '-')}-`
+      process.env.NODE_ENV === 'production' ? '' : `${displayName.replace(/\s/g, '-')}-`
     const managerId = managersCounter++
     const manager = new SheetsManager()
     const noTheme = {}

--- a/packages/react-jss/src/withStyles.js
+++ b/packages/react-jss/src/withStyles.js
@@ -65,7 +65,8 @@ export default function withStyles<Theme: {}, S: Styles<Theme>>(
     InnerComponent: ComponentType<Props> = NoRenderer
   ): ComponentType<Props> => {
     const displayName = getDisplayName(InnerComponent)
-    const defaultClassNamePrefix = process.env.NODE_ENV === 'production' ? '' : `${displayName}-`
+    const defaultClassNamePrefix =
+      process.env.NODE_ENV === 'production' ? '' : `${displayName.replace(/\s/, '-')}-`
     const managerId = managersCounter++
     const manager = new SheetsManager()
     const noTheme = {}

--- a/packages/react-jss/src/withStyles.test.js
+++ b/packages/react-jss/src/withStyles.test.js
@@ -218,10 +218,11 @@ describe('React-JSS: withStyles', () => {
       return `${rule.key}-id`
     }
 
-    const renderTest = () => {
+    const renderTest = (displayName = 'DisplayNameTest') => {
       function DisplayNameTest() {
         return null
       }
+      DisplayNameTest.displayName = displayName
       const MyComponent = withStyles({
         a: {color: 'red'}
       })(DisplayNameTest)
@@ -235,6 +236,11 @@ describe('React-JSS: withStyles', () => {
     it('should pass displayName as prefix', () => {
       renderTest()
       expect(classNamePrefix).to.be('DisplayNameTest-')
+    })
+
+    it('should handle spaces correctly', () => {
+      renderTest('Display Name Test')
+      expect(classNamePrefix).to.be('Display-Name-Test-')
     })
 
     it('should pass no prefix in production', () => {


### PR DESCRIPTION
__What would you like to add/fix?__
Replaces any whitespaces in a components display name with `-`.

__Corresponding issue:__ #938 
