### PR TITLE
Improve IE 11 support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+## 10.0.0-alpha.15
+
+### Bug fixes
+
+- [jss-plugin-camel-case] Fix some IE 11 regression ([#1065](https://github.com/cssinjs/jss/pull/1065))
+
 ## 10.0.0-alpha.14 (2019-3-17)
 
 ### Improvements

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-## 10.0.0-alpha.15
+## Next
 
 ### Bug fixes
 

--- a/packages/jss-plugin-camel-case/.size-snapshot.json
+++ b/packages/jss-plugin-camel-case/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/jss-plugin-camel-case.js": {
-    "bundled": 2383,
-    "minified": 856,
-    "gzipped": 486
+    "bundled": 2389,
+    "minified": 858,
+    "gzipped": 488
   },
   "dist/jss-plugin-camel-case.min.js": {
-    "bundled": 2383,
-    "minified": 856,
-    "gzipped": 486
+    "bundled": 2389,
+    "minified": 858,
+    "gzipped": 488
   },
   "dist/jss-plugin-camel-case.cjs.js": {
-    "bundled": 1703,
-    "minified": 735,
-    "gzipped": 393
+    "bundled": 1709,
+    "minified": 737,
+    "gzipped": 398
   },
   "dist/jss-plugin-camel-case.esm.js": {
-    "bundled": 1485,
-    "minified": 563,
-    "gzipped": 307,
+    "bundled": 1491,
+    "minified": 565,
+    "gzipped": 309,
     "treeshaked": {
       "rollup": {
         "code": 29,

--- a/packages/jss-plugin-camel-case/src/index.js
+++ b/packages/jss-plugin-camel-case/src/index.js
@@ -12,7 +12,7 @@ function convertCase(style) {
   const converted = {}
 
   for (const prop in style) {
-    const key = prop.startsWith('--') ? prop : hyphenate(prop)
+    const key = prop.indexOf('--') === 0 ? prop : hyphenate(prop)
 
     converted[key] = style[prop]
   }
@@ -44,7 +44,7 @@ export default function camelCase(): Plugin {
   }
 
   function onChangeValue(value, prop, rule) {
-    if (prop.startsWith('--')) {
+    if (prop.indexOf('--') === 0) {
       return value
     }
 

--- a/packages/jss-preset-default/.size-snapshot.json
+++ b/packages/jss-preset-default/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/jss-preset-default.js": {
-    "bundled": 53800,
-    "minified": 19104,
-    "gzipped": 6356
+    "bundled": 53806,
+    "minified": 19106,
+    "gzipped": 6354
   },
   "dist/jss-preset-default.min.js": {
-    "bundled": 53046,
-    "minified": 18645,
-    "gzipped": 6144
+    "bundled": 53052,
+    "minified": 18647,
+    "gzipped": 6142
   },
   "dist/jss-preset-default.cjs.js": {
     "bundled": 1329,

--- a/packages/jss-starter-kit/.size-snapshot.json
+++ b/packages/jss-starter-kit/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/jss-starter-kit.js": {
-    "bundled": 69342,
-    "minified": 29117,
-    "gzipped": 8981
+    "bundled": 69348,
+    "minified": 29119,
+    "gzipped": 8978
   },
   "dist/jss-starter-kit.min.js": {
-    "bundled": 68588,
-    "minified": 28659,
-    "gzipped": 8769
+    "bundled": 68594,
+    "minified": 28661,
+    "gzipped": 8766
   },
   "dist/jss-starter-kit.cjs.js": {
     "bundled": 2592,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/react-jss.js": {
-    "bundled": 109109,
-    "minified": 36983,
-    "gzipped": 11986
+    "bundled": 109115,
+    "minified": 36985,
+    "gzipped": 11985
   },
   "dist/react-jss.min.js": {
-    "bundled": 84550,
-    "minified": 29718,
-    "gzipped": 9800
+    "bundled": 84556,
+    "minified": 29720,
+    "gzipped": 9799
   },
   "dist/react-jss.cjs.js": {
     "bundled": 15499,


### PR DESCRIPTION
startsWith is not supported by IE 11

__What would you like to add/fix?__

![Capture d’écran 2019-03-18 à 18 22 27](https://user-images.githubusercontent.com/3165635/54549665-d1860500-49aa-11e9-87b0-8630add8df80.png)

__Corresponding issue (if exists):__

N/A