### PR TITLE
Fix typspec for default unit plugin

### DIFF
--- a/packages/jss-plugin-default-unit/src/index.d.ts
+++ b/packages/jss-plugin-default-unit/src/index.d.ts
@@ -2,4 +2,4 @@ import {Plugin} from 'jss'
 
 export type Options = {[key: string]: string}
 
-export default function jssPluginSyntaxDefaultUnit(options: Options): Plugin
+export default function jssPluginSyntaxDefaultUnit(options?: Options): Plugin


### PR DESCRIPTION
It seems that this plugin does not require me to pass the options.

https://github.com/cssinjs/jss/blob/27e2428297fa227d72d45d5757a74169edf70850/packages/jss-plugin-default-unit/src/index.js#L63

But the typespec is forcing me to pass a value.