### PR TITLE
Fix #1084

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ### Bug fixes
 
 - [jss-plugin-expand] Fix attributes spread for `border-bottom`, `border-top`, `border-left` and `border-right` ([#1083](https://github.com/cssinjs/jss/pull/1083))
+- [jss-plugin-props-sort] Fix sorting in Node 11 ([#1084](https://github.com/cssinjs/jss/pull/1083))
 
 ## 10.0.0-alpha.16 (2019-3-24)
 

--- a/packages/jss-plugin-expand/.size-snapshot.json
+++ b/packages/jss-plugin-expand/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/jss-plugin-expand.js": {
-    "bundled": 9945,
-    "minified": 4116,
-    "gzipped": 1452
+    "bundled": 10469,
+    "minified": 4500,
+    "gzipped": 1511
   },
   "dist/jss-plugin-expand.min.js": {
-    "bundled": 9945,
-    "minified": 4116,
-    "gzipped": 1452
+    "bundled": 10469,
+    "minified": 4500,
+    "gzipped": 1511
   },
   "dist/jss-plugin-expand.cjs.js": {
-    "bundled": 9005,
-    "minified": 4283,
-    "gzipped": 1451
+    "bundled": 9489,
+    "minified": 4667,
+    "gzipped": 1509
   },
   "dist/jss-plugin-expand.esm.js": {
-    "bundled": 8923,
-    "minified": 4214,
-    "gzipped": 1406,
+    "bundled": 9407,
+    "minified": 4598,
+    "gzipped": 1464,
     "treeshaked": {
       "rollup": {
         "code": 0,

--- a/packages/jss-plugin-props-sort/.size-snapshot.json
+++ b/packages/jss-plugin-props-sort/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/jss-plugin-props-sort.js": {
-    "bundled": 1018,
-    "minified": 503,
-    "gzipped": 319
+    "bundled": 1019,
+    "minified": 504,
+    "gzipped": 320
   },
   "dist/jss-plugin-props-sort.min.js": {
-    "bundled": 1018,
-    "minified": 503,
-    "gzipped": 319
+    "bundled": 1019,
+    "minified": 504,
+    "gzipped": 320
   },
   "dist/jss-plugin-props-sort.cjs.js": {
-    "bundled": 673,
-    "minified": 344,
-    "gzipped": 242
+    "bundled": 674,
+    "minified": 345,
+    "gzipped": 243
   },
   "dist/jss-plugin-props-sort.esm.js": {
-    "bundled": 591,
-    "minified": 275,
-    "gzipped": 201,
+    "bundled": 592,
+    "minified": 276,
+    "gzipped": 202,
     "treeshaked": {
       "rollup": {
         "code": 0,

--- a/packages/jss-plugin-props-sort/.size-snapshot.json
+++ b/packages/jss-plugin-props-sort/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/jss-plugin-props-sort.js": {
-    "bundled": 920,
-    "minified": 470,
-    "gzipped": 304
+    "bundled": 1018,
+    "minified": 503,
+    "gzipped": 319
   },
   "dist/jss-plugin-props-sort.min.js": {
-    "bundled": 920,
-    "minified": 470,
-    "gzipped": 304
+    "bundled": 1018,
+    "minified": 503,
+    "gzipped": 319
   },
   "dist/jss-plugin-props-sort.cjs.js": {
-    "bundled": 579,
-    "minified": 311,
-    "gzipped": 225
+    "bundled": 673,
+    "minified": 344,
+    "gzipped": 242
   },
   "dist/jss-plugin-props-sort.esm.js": {
-    "bundled": 497,
-    "minified": 242,
-    "gzipped": 184,
+    "bundled": 591,
+    "minified": 275,
+    "gzipped": 201,
     "treeshaked": {
       "rollup": {
         "code": 0,

--- a/packages/jss-plugin-props-sort/src/index.js
+++ b/packages/jss-plugin-props-sort/src/index.js
@@ -5,20 +5,23 @@ import type {Plugin} from 'jss'
  * Sort props by length.
  */
 export default function jssPropsSort(): Plugin {
-  function sort(prop0, prop1) {
+  const sort = (prop0, prop1) => {
+    if (prop0.length === prop1.length) {
+      return prop0 > prop1 ? 1 : 0
+    }
     return prop0.length - prop1.length
   }
 
-  function onProcessStyle(style, rule) {
-    if (rule.type !== 'style') return style
+  return {
+    onProcessStyle(style, rule) {
+      if (rule.type !== 'style') return style
 
-    const newStyle = {}
-    const props = Object.keys(style).sort(sort)
-    for (let i = 0; i < props.length; i++) {
-      newStyle[props[i]] = style[props[i]]
+      const newStyle = {}
+      const props = Object.keys(style).sort(sort)
+      for (let i = 0; i < props.length; i++) {
+        newStyle[props[i]] = style[props[i]]
+      }
+      return newStyle
     }
-    return newStyle
   }
-
-  return {onProcessStyle}
 }

--- a/packages/jss-plugin-props-sort/src/index.js
+++ b/packages/jss-plugin-props-sort/src/index.js
@@ -7,7 +7,7 @@ import type {Plugin} from 'jss'
 export default function jssPropsSort(): Plugin {
   const sort = (prop0, prop1) => {
     if (prop0.length === prop1.length) {
-      return prop0 > prop1 ? 1 : 0
+      return prop0 > prop1 ? 1 : -1
     }
     return prop0.length - prop1.length
   }

--- a/packages/jss-preset-default/.size-snapshot.json
+++ b/packages/jss-preset-default/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/jss-preset-default.js": {
-    "bundled": 53972,
-    "minified": 19132,
-    "gzipped": 6367
+    "bundled": 54594,
+    "minified": 19524,
+    "gzipped": 6443
   },
   "dist/jss-preset-default.min.js": {
-    "bundled": 53218,
-    "minified": 18673,
-    "gzipped": 6151
+    "bundled": 53840,
+    "minified": 19065,
+    "gzipped": 6229
   },
   "dist/jss-preset-default.cjs.js": {
     "bundled": 1329,

--- a/packages/jss-preset-default/.size-snapshot.json
+++ b/packages/jss-preset-default/.size-snapshot.json
@@ -1,12 +1,12 @@
 {
   "dist/jss-preset-default.js": {
-    "bundled": 54594,
-    "minified": 19524,
-    "gzipped": 6443
+    "bundled": 54595,
+    "minified": 19525,
+    "gzipped": 6444
   },
   "dist/jss-preset-default.min.js": {
-    "bundled": 53840,
-    "minified": 19065,
+    "bundled": 53841,
+    "minified": 19066,
     "gzipped": 6229
   },
   "dist/jss-preset-default.cjs.js": {

--- a/packages/jss-starter-kit/.size-snapshot.json
+++ b/packages/jss-starter-kit/.size-snapshot.json
@@ -1,12 +1,12 @@
 {
   "dist/jss-starter-kit.js": {
-    "bundled": 70136,
-    "minified": 29562,
-    "gzipped": 9074
+    "bundled": 70137,
+    "minified": 29563,
+    "gzipped": 9075
   },
   "dist/jss-starter-kit.min.js": {
-    "bundled": 69382,
-    "minified": 29104,
+    "bundled": 69383,
+    "minified": 29105,
     "gzipped": 8867
   },
   "dist/jss-starter-kit.cjs.js": {

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/react-jss.js": {
-    "bundled": 109281,
-    "minified": 37011,
-    "gzipped": 12000
+    "bundled": 109903,
+    "minified": 37406,
+    "gzipped": 12067
   },
   "dist/react-jss.min.js": {
-    "bundled": 84722,
-    "minified": 29746,
-    "gzipped": 9811
+    "bundled": 85344,
+    "minified": 30141,
+    "gzipped": 9882
   },
   "dist/react-jss.cjs.js": {
     "bundled": 15499,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/react-jss.js": {
-    "bundled": 109903,
-    "minified": 37406,
-    "gzipped": 12067
+    "bundled": 109904,
+    "minified": 37407,
+    "gzipped": 12068
   },
   "dist/react-jss.min.js": {
-    "bundled": 85344,
-    "minified": 30141,
-    "gzipped": 9882
+    "bundled": 85345,
+    "minified": 30142,
+    "gzipped": 9883
   },
   "dist/react-jss.cjs.js": {
     "bundled": 15499,


### PR DESCRIPTION
__What would you like to add/fix?__
When the props have the same length while sorting in jss-plugin-props-sort, we check if the first prop is bigger than the second one and return 1 then. That way we should have a consistent output of orders even across different node versions

__Corresponding issue (if exists):__ #1084 