### PR TITLE
Fix potential inherited prototype chain issue

### DIFF
--- a/packages/jss/.size-snapshot.json
+++ b/packages/jss/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "dist/jss.js": {
-    "bundled": 58906,
-    "minified": 21842,
-    "gzipped": 6572
+    "bundled": 58985,
+    "minified": 21874,
+    "gzipped": 6583
   },
   "dist/jss.min.js": {
-    "bundled": 57740,
-    "minified": 20925,
-    "gzipped": 6130
+    "bundled": 57819,
+    "minified": 20957,
+    "gzipped": 6141
   },
   "dist/jss.cjs.js": {
-    "bundled": 54364,
-    "minified": 23753,
-    "gzipped": 6620
+    "bundled": 54437,
+    "minified": 23785,
+    "gzipped": 6637
   },
   "dist/jss.esm.js": {
-    "bundled": 53868,
-    "minified": 23349,
-    "gzipped": 6537,
+    "bundled": 53941,
+    "minified": 23381,
+    "gzipped": 6554,
     "treeshaked": {
       "rollup": {
-        "code": 18985,
+        "code": 19017,
         "import_statements": 281
       },
       "webpack": {
-        "code": 20400
+        "code": 20432
       }
     }
   }

--- a/packages/jss/.size-snapshot.json
+++ b/packages/jss/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "dist/jss.js": {
-    "bundled": 58973,
-    "minified": 21865,
-    "gzipped": 6577
+    "bundled": 58998,
+    "minified": 21892,
+    "gzipped": 6581
   },
   "dist/jss.min.js": {
-    "bundled": 57803,
-    "minified": 20946,
-    "gzipped": 6136
+    "bundled": 57828,
+    "minified": 20973,
+    "gzipped": 6139
   },
   "dist/jss.cjs.js": {
-    "bundled": 54427,
-    "minified": 23776,
-    "gzipped": 6633
+    "bundled": 54452,
+    "minified": 23803,
+    "gzipped": 6643
   },
   "dist/jss.esm.js": {
-    "bundled": 53931,
-    "minified": 23372,
-    "gzipped": 6550,
+    "bundled": 53956,
+    "minified": 23399,
+    "gzipped": 6560,
     "treeshaked": {
       "rollup": {
-        "code": 19006,
+        "code": 19033,
         "import_statements": 281
       },
       "webpack": {
-        "code": 20421
+        "code": 20448
       }
     }
   }

--- a/packages/jss/.size-snapshot.json
+++ b/packages/jss/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "dist/jss.js": {
-    "bundled": 58985,
-    "minified": 21874,
-    "gzipped": 6583
+    "bundled": 58973,
+    "minified": 21865,
+    "gzipped": 6577
   },
   "dist/jss.min.js": {
-    "bundled": 57819,
-    "minified": 20957,
-    "gzipped": 6141
+    "bundled": 57803,
+    "minified": 20946,
+    "gzipped": 6136
   },
   "dist/jss.cjs.js": {
-    "bundled": 54437,
-    "minified": 23785,
-    "gzipped": 6637
+    "bundled": 54427,
+    "minified": 23776,
+    "gzipped": 6633
   },
   "dist/jss.esm.js": {
-    "bundled": 53941,
-    "minified": 23381,
-    "gzipped": 6554,
+    "bundled": 53931,
+    "minified": 23372,
+    "gzipped": 6550,
     "treeshaked": {
       "rollup": {
-        "code": 19017,
+        "code": 19006,
         "import_statements": 281
       },
       "webpack": {
-        "code": 20432
+        "code": 20421
       }
     }
   }

--- a/packages/jss/src/PluginsRegistry.js
+++ b/packages/jss/src/PluginsRegistry.js
@@ -120,6 +120,10 @@ export default class PluginsRegistry {
     this.registry = [...this.plugins.external, ...this.plugins.internal].reduce(
       (registry: Registry, plugin: Plugin) => {
         for (const name in plugin) {
+          if (!plugin.hasOwnProperty(name)) {
+            return
+          }
+
           if (name in registry) {
             registry[name].push(plugin[name])
           } else {

--- a/packages/jss/src/PluginsRegistry.js
+++ b/packages/jss/src/PluginsRegistry.js
@@ -120,14 +120,12 @@ export default class PluginsRegistry {
     this.registry = [...this.plugins.external, ...this.plugins.internal].reduce(
       (registry: Registry, plugin: Plugin) => {
         for (const name in plugin) {
-          if (!plugin.hasOwnProperty(name)) {
-            return
-          }
-
-          if (name in registry) {
-            registry[name].push(plugin[name])
-          } else {
-            warning(false, `[JSS] Unknown hook "${name}".`)
+          if (plugin.hasOwnProperty(name)) {
+            if (name in registry) {
+              registry[name].push(plugin[name])
+            } else {
+              warning(false, `[JSS] Unknown hook "${name}".`)
+            }
           }
         }
         return registry

--- a/packages/jss/src/PluginsRegistry.js
+++ b/packages/jss/src/PluginsRegistry.js
@@ -120,7 +120,7 @@ export default class PluginsRegistry {
     this.registry = [...this.plugins.external, ...this.plugins.internal].reduce(
       (registry: Registry, plugin: Plugin) => {
         for (const name in plugin) {
-          if (plugin.hasOwnProperty(name)) {
+          if (Object.prototype.hasOwnProperty.call(plugin, 'name')) {
             if (name in registry) {
               registry[name].push(plugin[name])
             } else {


### PR DESCRIPTION
- I was hit by this issue integrating Preact with Material-UI.
- It's an encouraged pattern by Eslint: https://eslint.org/docs/rules/guard-for-in#require-guarding-for-in-guard-for-in.
- Could it be preact-compat doing something strange? https://github.com/developit/preact-compat/blob/master/src/index.js#L46.

__What would you like to add/fix?__

`name` equals `$$typeof` in this fail.

![Capture d’écran 2019-04-18 à 12 11 27](https://user-images.githubusercontent.com/3165635/56354129-4aa79080-61d3-11e9-8160-842dc23b6e7a.png)
