### PR TITLE
Implements nesting in template string parser

### DIFF
--- a/docs/jss-plugin-template.md
+++ b/docs/jss-plugin-template.md
@@ -1,10 +1,9 @@
 ## Enables string templates
 
-Allows you to use string templates to declare CSS rules. It implements a **very naive** but **very fast (~42000 ops/sec)** runtime CSS parser, with certain limitations:
+Allows you to use string templates to declare CSS rules. It implements a **simplified** but **very fast** runtime CSS parser, with certain limitations:
 
-- Supports only rule body (no selectors)
-- Requires semicolon and a new line after the value (except the last line)
-- No nested rules support
+- Requires new lines at the end of each declaration.
+- Requires a closing curly brace of a nested rule to be on a separate line.
 
 ```js
 const styles = {
@@ -14,6 +13,9 @@ const styles = {
     color: red;
     margin: 20px 40px;
     padding: 10px;
+    &:hover span {
+      color: green;
+    }
   `,
   '@media print': {
     button: `color: black`

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -44,7 +44,7 @@ module.exports = config => {
       frameworks: ['benchmark'],
       // Using a fixed position for a file name, m.b. should use an args parser later.
       files: [process.argv[4] || 'packages/jss/benchmark/**/*.js'],
-      preprocessors: {'packages/jss/benchmark/**/*.js': ['webpack']},
+      preprocessors: {'packages/**/benchmark/**/*.js': ['webpack']},
       reporters: ['benchmark'],
       // Some tests are slow.
       browserNoActivityTimeout: 20000

--- a/packages/jss-plugin-template/.size-snapshot.json
+++ b/packages/jss-plugin-template/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "dist/jss-plugin-template.js": {
-    "bundled": 2573,
+    "bundled": 2581,
     "minified": 969,
-    "gzipped": 544
+    "gzipped": 545
   },
   "dist/jss-plugin-template.min.js": {
-    "bundled": 2131,
+    "bundled": 2139,
     "minified": 751,
-    "gzipped": 433
+    "gzipped": 436
   },
   "dist/jss-plugin-template.cjs.js": {
-    "bundled": 2138,
+    "bundled": 2146,
     "minified": 968,
-    "gzipped": 522
+    "gzipped": 520
   },
   "dist/jss-plugin-template.esm.js": {
-    "bundled": 1920,
+    "bundled": 1928,
     "minified": 800,
     "gzipped": 438,
     "treeshaked": {

--- a/packages/jss-plugin-template/.size-snapshot.json
+++ b/packages/jss-plugin-template/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/jss-plugin-template.js": {
-    "bundled": 2865,
-    "minified": 1051,
-    "gzipped": 555
+    "bundled": 2772,
+    "minified": 1069,
+    "gzipped": 564
   },
   "dist/jss-plugin-template.min.js": {
-    "bundled": 2325,
-    "minified": 774,
-    "gzipped": 439
+    "bundled": 2238,
+    "minified": 792,
+    "gzipped": 446
   },
   "dist/jss-plugin-template.cjs.js": {
-    "bundled": 2469,
+    "bundled": 2392,
     "minified": 1093,
-    "gzipped": 531
+    "gzipped": 533
   },
   "dist/jss-plugin-template.esm.js": {
-    "bundled": 2251,
+    "bundled": 2174,
     "minified": 925,
-    "gzipped": 450,
+    "gzipped": 453,
     "treeshaked": {
       "rollup": {
         "code": 21,

--- a/packages/jss-plugin-template/.size-snapshot.json
+++ b/packages/jss-plugin-template/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/jss-plugin-template.js": {
-    "bundled": 2581,
-    "minified": 969,
-    "gzipped": 545
+    "bundled": 2587,
+    "minified": 975,
+    "gzipped": 543
   },
   "dist/jss-plugin-template.min.js": {
-    "bundled": 2139,
-    "minified": 751,
-    "gzipped": 436
+    "bundled": 2145,
+    "minified": 757,
+    "gzipped": 433
   },
   "dist/jss-plugin-template.cjs.js": {
-    "bundled": 2146,
-    "minified": 968,
+    "bundled": 2152,
+    "minified": 974,
     "gzipped": 520
   },
   "dist/jss-plugin-template.esm.js": {
-    "bundled": 1928,
-    "minified": 800,
-    "gzipped": 438,
+    "bundled": 1934,
+    "minified": 806,
+    "gzipped": 439,
     "treeshaked": {
       "rollup": {
         "code": 21,

--- a/packages/jss-plugin-template/.size-snapshot.json
+++ b/packages/jss-plugin-template/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/jss-plugin-template.js": {
-    "bundled": 1777,
-    "minified": 730,
-    "gzipped": 453
+    "bundled": 2573,
+    "minified": 969,
+    "gzipped": 544
   },
   "dist/jss-plugin-template.min.js": {
-    "bundled": 1418,
-    "minified": 564,
-    "gzipped": 355
+    "bundled": 2131,
+    "minified": 751,
+    "gzipped": 433
   },
   "dist/jss-plugin-template.cjs.js": {
-    "bundled": 1341,
-    "minified": 686,
-    "gzipped": 423
+    "bundled": 2138,
+    "minified": 968,
+    "gzipped": 522
   },
   "dist/jss-plugin-template.esm.js": {
-    "bundled": 1123,
-    "minified": 518,
-    "gzipped": 341,
+    "bundled": 1920,
+    "minified": 800,
+    "gzipped": 438,
     "treeshaked": {
       "rollup": {
         "code": 21,

--- a/packages/jss-plugin-template/.size-snapshot.json
+++ b/packages/jss-plugin-template/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/jss-plugin-template.js": {
-    "bundled": 2587,
-    "minified": 975,
-    "gzipped": 543
+    "bundled": 2865,
+    "minified": 1051,
+    "gzipped": 555
   },
   "dist/jss-plugin-template.min.js": {
-    "bundled": 2145,
-    "minified": 757,
-    "gzipped": 433
+    "bundled": 2325,
+    "minified": 774,
+    "gzipped": 439
   },
   "dist/jss-plugin-template.cjs.js": {
-    "bundled": 2152,
-    "minified": 974,
-    "gzipped": 520
+    "bundled": 2469,
+    "minified": 1093,
+    "gzipped": 531
   },
   "dist/jss-plugin-template.esm.js": {
-    "bundled": 1934,
-    "minified": 806,
-    "gzipped": 439,
+    "bundled": 2251,
+    "minified": 925,
+    "gzipped": 450,
     "treeshaked": {
       "rollup": {
         "code": 21,

--- a/packages/jss-plugin-template/benchmark/tests/parse.js
+++ b/packages/jss-plugin-template/benchmark/tests/parse.js
@@ -1,3 +1,4 @@
+import stylis from 'stylis'
 import parse from '../../src/parse'
 
 const css = `
@@ -37,8 +38,21 @@ const css = `
   font-variant: normal normal;
   border-spacing: 0px;
 `
+
+stylis.set({
+  global: false,
+  keyframe: false,
+  prefix: false,
+  compress: false,
+  semicolon: true
+})
+
 suite('Parse', () => {
   benchmark('parse()', () => {
     parse(css)
+  })
+
+  benchmark('stylis()', () => {
+    stylis('#id', css)
   })
 })

--- a/packages/jss-plugin-template/package.json
+++ b/packages/jss-plugin-template/package.json
@@ -41,7 +41,8 @@
     "jss": "10.0.0-alpha.16",
     "tiny-warning": "^1.0.2"
   },
-  "devDepenndencies": {
-    "jss-plugin-nested": "^10.0.0-alpha.7"
+  "devDependencies": {
+    "jss-plugin-nested": "^10.0.0-alpha.16",
+    "stylis": "^3.5.4"
   }
 }

--- a/packages/jss-plugin-template/package.json
+++ b/packages/jss-plugin-template/package.json
@@ -40,5 +40,8 @@
     "@babel/runtime": "^7.3.1",
     "jss": "10.0.0-alpha.16",
     "tiny-warning": "^1.0.2"
+  },
+  "devDepenndencies": {
+    "jss-plugin-nested": "^10.0.0-alpha.7"
   }
 }

--- a/packages/jss-plugin-template/src/index.test.js
+++ b/packages/jss-plugin-template/src/index.test.js
@@ -77,14 +77,19 @@ describe.only('jss-plugin-template', () => {
       `)
   })
 
-  it.skip('should warn when semicolon not found', () => {
-    jss.createStyleSheet({
+  it('should not require semicolon', () => {
+    const sheet = jss.createStyleSheet({
       a: `
-          color: red;
+          color: red
           float: left
         `
     })
-    expect(spy.args[0][0]).to.be('Warning: [JSS] Missing semicolon in "float: left".')
+    expect(sheet.toString()).to.be(stripIndent`
+        .a-id {
+          color: red;
+          float: left;
+        }
+      `)
   })
 
   it('should support @media', () => {
@@ -191,7 +196,7 @@ describe.only('jss-plugin-template', () => {
       `)
   })
 
-  it.skip('should support multiple deeply nested rules', () => {
+  it('should support multiple deeply nested rules', () => {
     const sheet = jss.createStyleSheet({
       a: `
         color: green;

--- a/packages/jss-plugin-template/src/index.test.js
+++ b/packages/jss-plugin-template/src/index.test.js
@@ -4,13 +4,14 @@ import expect from 'expect.js'
 import {stripIndent} from 'common-tags'
 import {create} from 'jss'
 import sinon from 'sinon'
+import nested from 'jss-plugin-nested'
 import template from '.'
 
 const settings = {
   createGenerateId: () => rule => `${rule.key}-id`
 }
 
-describe('jss-plugin-template', () => {
+describe.only('jss-plugin-template', () => {
   let spy
   let jss
 
@@ -23,98 +24,97 @@ describe('jss-plugin-template', () => {
     console.warn.restore()
   })
 
-  describe('template literals', () => {
-    it('should convert a single single property/value', () => {
-      const sheet = jss.createStyleSheet({
-        a: `
+  it('should convert a single single property/value', () => {
+    const sheet = jss.createStyleSheet({
+      a: `
           color: red;
         `
-      })
-      expect(sheet.toString()).to.be(stripIndent`
+    })
+    expect(sheet.toString()).to.be(stripIndent`
         .a-id {
           color: red;
         }
       `)
-    })
+  })
 
-    it('should parse multiple props/values', () => {
-      const sheet = jss.createStyleSheet({
-        a: `
+  it('should parse multiple props/values', () => {
+    const sheet = jss.createStyleSheet({
+      a: `
           color: red;
           float: left;
         `
-      })
-      expect(sheet.toString()).to.be(stripIndent`
+    })
+    expect(sheet.toString()).to.be(stripIndent`
         .a-id {
           color: red;
           float: left;
         }
       `)
-      expect(spy.callCount).to.be(0)
+    expect(spy.callCount).to.be(0)
+  })
+
+  it('should warn when there is no colon found', () => {
+    jss.createStyleSheet({
+      a: 'color red;'
     })
 
-    it('should warn when there is no colon found', () => {
-      jss.createStyleSheet({
-        a: 'color red;'
-      })
+    expect(spy.callCount).to.be(1)
+    expect(spy.args[0][0]).to.be('Warning: [JSS] Missing colon in "color red".')
+  })
 
-      expect(spy.callCount).to.be(1)
-      expect(spy.calledWithExactly('Warning: [JSS] Malformed CSS string "color red;"')).to.be(true)
-    })
-
-    it('should strip spaces', () => {
-      const sheet = jss.createStyleSheet({
-        a: `
+  it('should strip spaces', () => {
+    const sheet = jss.createStyleSheet({
+      a: `
             color:     red   ;
             float:   left   ;
         `
-      })
-      expect(sheet.toString()).to.be(stripIndent`
+    })
+    expect(sheet.toString()).to.be(stripIndent`
         .a-id {
           color: red;
           float: left;
         }
       `)
-    })
+  })
 
-    it('should allow skiping last semicolon', () => {
-      const sheet = jss.createStyleSheet({
-        a: `
+  it('should allow skiping last semicolon', () => {
+    const sheet = jss.createStyleSheet({
+      a: `
           color: red;
           float: left
         `
-      })
-      expect(sheet.toString()).to.be(stripIndent`
+    })
+    expect(sheet.toString()).to.be(stripIndent`
         .a-id {
           color: red;
           float: left;
         }
       `)
-    })
+  })
 
-    it('should support @media', () => {
-      const sheet = jss.createStyleSheet({
-        '@media print': {
-          button: 'color: black'
-        }
-      })
-      expect(sheet.toString()).to.be(stripIndent`
+  it('should support @media', () => {
+    const sheet = jss.createStyleSheet({
+      '@media print': {
+        button: 'color: black'
+      }
+    })
+    expect(sheet.toString()).to.be(stripIndent`
         @media print {
           .button-id {
             color: black;
           }
         }
       `)
-    })
+  })
 
-    it('should support @keyframes', () => {
-      const sheet = jss.createStyleSheet({
-        '@keyframes a': {
-          from: 'opacity: 0',
-          to: 'opacity: 1'
-        }
-      })
-      expect(sheet.toString()).to.be(stripIndent`
+  it('should support @keyframes', () => {
+    const sheet = jss.createStyleSheet({
+      '@keyframes a': {
+        from: 'opacity: 0',
+        to: 'opacity: 1'
+      }
+    })
+    expect(sheet.toString()).to.be(stripIndent`
         @keyframes keyframes-a-id {
           from {
             opacity: 0;
@@ -124,6 +124,34 @@ describe('jss-plugin-template', () => {
           }
         }
       `)
-    })
   })
+
+  it('should support nesting', () => {
+    jss = create(settings).use(template(), nested())
+
+    const sheet = jss.createStyleSheet({
+      a: `
+        color: green;
+        & .b {
+          color: red;
+        }
+      `
+    })
+    expect(sheet.toString()).to.be(stripIndent`
+        .a-id {
+          color: green;
+        }
+        .a-id .b {
+          color: red;
+        }
+      `)
+  })
+
+  it('should warn when opening curly brace is missing', () => {})
+  it('should warn when closing curly brace is missing', () => {})
+  it('should warn when closing curly brace is not on an own line', () => {})
+  it('should warn when closing curly brace is not provided', () => {})
+  it('should support multiple first level nested rules ', () => {})
+  it('should support multiple deeply nested rules', () => {})
+  it('should regular props after a nested rule', () => {})
 })

--- a/packages/jss-plugin-template/src/index.test.js
+++ b/packages/jss-plugin-template/src/index.test.js
@@ -59,7 +59,7 @@ describe.only('jss-plugin-template', () => {
     })
 
     expect(spy.callCount).to.be(1)
-    expect(spy.args[0][0]).to.be('Warning: [JSS] Missing colon in "color red".')
+    expect(spy.args[0][0]).to.be('Warning: [JSS] Missing colon in "color red;".')
   })
 
   it('should strip spaces', () => {
@@ -77,25 +77,20 @@ describe.only('jss-plugin-template', () => {
       `)
   })
 
-  it('should allow skiping last semicolon', () => {
-    const sheet = jss.createStyleSheet({
+  it.skip('should warn when semicolon not found', () => {
+    jss.createStyleSheet({
       a: `
           color: red;
           float: left
         `
     })
-    expect(sheet.toString()).to.be(stripIndent`
-        .a-id {
-          color: red;
-          float: left;
-        }
-      `)
+    expect(spy.args[0][0]).to.be('Warning: [JSS] Missing semicolon in "float: left".')
   })
 
   it('should support @media', () => {
     const sheet = jss.createStyleSheet({
       '@media print': {
-        button: 'color: black'
+        button: 'color: black;'
       }
     })
     expect(sheet.toString()).to.be(stripIndent`
@@ -110,8 +105,8 @@ describe.only('jss-plugin-template', () => {
   it('should support @keyframes', () => {
     const sheet = jss.createStyleSheet({
       '@keyframes a': {
-        from: 'opacity: 0',
-        to: 'opacity: 1'
+        from: 'opacity: 0;',
+        to: 'opacity: 1;'
       }
     })
     expect(sheet.toString()).to.be(stripIndent`

--- a/packages/jss-plugin-template/src/index.test.js
+++ b/packages/jss-plugin-template/src/index.test.js
@@ -17,7 +17,7 @@ describe.only('jss-plugin-template', () => {
 
   beforeEach(() => {
     spy = sinon.spy(console, 'warn')
-    jss = create(settings).use(template())
+    jss = create(settings).use(template(), nested())
   })
 
   afterEach(() => {
@@ -122,8 +122,6 @@ describe.only('jss-plugin-template', () => {
   })
 
   it('should support nesting', () => {
-    jss = create(settings).use(template(), nested())
-
     const sheet = jss.createStyleSheet({
       a: `
         color: green;
@@ -142,11 +140,100 @@ describe.only('jss-plugin-template', () => {
       `)
   })
 
-  it('should warn when opening curly brace is missing', () => {})
-  it('should warn when closing curly brace is missing', () => {})
-  it('should warn when closing curly brace is not on an own line', () => {})
-  it('should warn when closing curly brace is not provided', () => {})
-  it('should support multiple first level nested rules ', () => {})
-  it('should support multiple deeply nested rules', () => {})
-  it('should regular props after a nested rule', () => {})
+  it('should warn when opening curly brace is missing', () => {
+    jss.createStyleSheet({
+      a: `
+        color: green;
+        & .b
+          color: red;
+        }
+      `
+    })
+    expect(spy.args[0][0]).to.be('Warning: [JSS] Missing opening curly brace in "& .b".')
+  })
+
+  it('should warn when closing curly brace is not on an own line', () => {
+    jss.createStyleSheet({
+      a: `
+        color: green;
+        & .b {
+          color: red;
+        } .a { color: blue; }
+      `
+    })
+    expect(spy.args[0][0]).to.be(
+      'Warning: [JSS] Missing opening curly brace in "} .a { color: blue; }".'
+    )
+  })
+
+  it('should support multiple first level nested rules', () => {
+    const sheet = jss.createStyleSheet({
+      a: `
+        color: green;
+        & .b {
+          color: red;
+        }
+        & .c {
+          color: blue;
+        }
+      `
+    })
+    expect(sheet.toString()).to.be(stripIndent`
+        .a-id {
+          color: green;
+        }
+        .a-id .b {
+          color: red;
+        }
+        .a-id .c {
+          color: blue;
+        }
+      `)
+  })
+
+  it.skip('should support multiple deeply nested rules', () => {
+    const sheet = jss.createStyleSheet({
+      a: `
+        color: green;
+        & .b {
+          color: red;
+          & .c {
+            color: blue;
+          }
+        }
+      `
+    })
+    expect(sheet.toString()).to.be(stripIndent`
+        .a-id {
+          color: green;
+        }
+        .a-id .b {
+          color: red;
+        }
+        .a-id .b .c {
+          color: blue;
+        }
+      `)
+  })
+
+  it('should regular props after a nested rule', () => {
+    const sheet = jss.createStyleSheet({
+      a: `
+        color: green;
+        & .b {
+          color: red;
+        }
+        float: left;
+      `
+    })
+    expect(sheet.toString()).to.be(stripIndent`
+        .a-id {
+          color: green;
+          float: left;
+        }
+        .a-id .b {
+          color: red;
+        }
+      `)
+  })
 })

--- a/packages/jss-plugin-template/src/parse.js
+++ b/packages/jss-plugin-template/src/parse.js
@@ -1,7 +1,7 @@
 // @flow
 import warning from 'tiny-warning'
 
-const semiWithNl = /[;\n]|[}\n]/
+const semiWithNl = /\n/
 
 /**
  * Naive CSS parser.
@@ -28,7 +28,7 @@ export default (cssText: string): Object => {
           warning(false, `[JSS] Missing opening curly brace in "${decl}".`)
           continue
         }
-        nestedRuleProp = decl.substr(0, openCurlyIndex).trim()
+        nestedRuleProp = decl.substr(0, openCurlyIndex - 1)
         style[nestedRuleProp] = {}
         continue
       }
@@ -47,7 +47,7 @@ export default (cssText: string): Object => {
     }
 
     const prop = decl.substr(0, colonIndex).trim()
-    const value = decl.substr(colonIndex + 1).trim()
+    const value = decl.substring(colonIndex + 1, decl.length - 1).trim()
 
     if (nestedRuleProp) {
       style[nestedRuleProp][prop] = value

--- a/packages/jss-plugin-template/src/parse.js
+++ b/packages/jss-plugin-template/src/parse.js
@@ -28,7 +28,7 @@ export default (cssText: string): Object => {
           warning(false, `[JSS] Missing opening curly brace in "${decl}".`)
           continue
         }
-        nestedRuleProp = decl.substr(0, openCurlyIndex - 1)
+        nestedRuleProp = decl.substring(0, openCurlyIndex - 1)
         style[nestedRuleProp] = {}
         continue
       }
@@ -46,7 +46,7 @@ export default (cssText: string): Object => {
       continue
     }
 
-    const prop = decl.substr(0, colonIndex).trim()
+    const prop = decl.substring(0, colonIndex).trim()
     const value = decl.substring(colonIndex + 1, decl.length - 1).trim()
 
     if (nestedRuleProp) {

--- a/packages/jss-plugin-template/src/parse.js
+++ b/packages/jss-plugin-template/src/parse.js
@@ -1,7 +1,7 @@
 // @flow
 import warning from 'tiny-warning'
 
-const semiWithNl = /;\n/
+const semiWithNl = /[;\n]|[}\n]/
 
 /**
  * Naive CSS parser.
@@ -9,21 +9,51 @@ const semiWithNl = /;\n/
  * - Requires semicolon and new line after the value (except of last line)
  * - No nested rules support
  */
-export default (cssText: string) => {
+export default (cssText: string): Object => {
   const style = {}
   const split = cssText.split(semiWithNl)
+  let nestedRuleProp
+
   for (let i = 0; i < split.length; i++) {
     const decl = (split[i] || '').trim()
 
     if (!decl) continue
+
+    if (nestedRuleProp === undefined) {
+      const ampIndex = decl.indexOf('&')
+      // We have a nested rule.
+      if (ampIndex !== -1) {
+        const openCurlyIndex = decl.indexOf('{')
+        if (openCurlyIndex === -1) {
+          warning(false, `[JSS] Missing opening curly brace in "${decl}".`)
+          continue
+        }
+        nestedRuleProp = decl.substr(0, openCurlyIndex).trim()
+        style[nestedRuleProp] = {}
+        continue
+      }
+    } else {
+      const closeCurlyIndex = decl.indexOf('}')
+      if (closeCurlyIndex !== -1) {
+        nestedRuleProp = undefined
+        continue
+      }
+    }
+
     const colonIndex = decl.indexOf(':')
     if (colonIndex === -1) {
-      warning(false, `[JSS] Malformed CSS string "${decl}"`)
+      warning(false, `[JSS] Missing colon in "${decl}".`)
       continue
     }
+
     const prop = decl.substr(0, colonIndex).trim()
     const value = decl.substr(colonIndex + 1).trim()
-    style[prop] = value
+
+    if (nestedRuleProp) {
+      style[nestedRuleProp][prop] = value
+    } else {
+      style[prop] = value
+    }
   }
   return style
 }

--- a/packages/jss-plugin-template/src/parse.js
+++ b/packages/jss-plugin-template/src/parse.js
@@ -1,67 +1,61 @@
 // @flow
 import warning from 'tiny-warning'
 
-const semiWithNl = /\n/
-
 /**
- * Naive CSS parser.
- * - Supports only rule body (no selectors)
- * - Requires semicolon and new line after the value (except of last line)
- * - No nested rules support
+ * Simplified CSS parser.
+ * - Requires new lines at the end of each declaration.
+ * - Requires a closing curly brace of a nested rule to be on a separate line.
  */
 const parse = (cssText: string): Object => {
   const style = {}
-  const split = cssText.split(semiWithNl)
-  let nestedRuleProp
+  const lines = cssText.split('\n')
+  const rules = [style]
 
-  for (let i = 0; i < split.length; i++) {
-    const decl = (split[i] || '').trim()
+  for (let i = 0; i < lines.length; i++) {
+    const decl = (lines[i] || '').trim()
 
     if (!decl) continue
 
     const ampIndex = decl.indexOf('&')
 
-    if (nestedRuleProp === undefined) {
-      // We have a nested rule.
-      if (ampIndex !== -1) {
-        const openCurlyIndex = decl.indexOf('{')
-        if (openCurlyIndex === -1) {
-          warning(false, `[JSS] Missing opening curly brace in "${decl}".`)
-          continue
-        }
-        nestedRuleProp = decl.substring(0, openCurlyIndex - 1)
-        style[nestedRuleProp] = {}
+    if (ampIndex !== -1) {
+      const openCurlyIndex = decl.indexOf('{')
+      if (openCurlyIndex === -1) {
+        warning(false, `[JSS] Missing opening curly brace in "${decl}".`)
         continue
       }
-    } else {
-      const closeCurlyIndex = decl.indexOf('}')
+      const key = decl.substring(0, openCurlyIndex - 1)
+      const nestedStyle = {}
+      rules[rules.length - 1][key] = nestedStyle
+      rules.push(nestedStyle)
+      continue
+    }
 
-      if (closeCurlyIndex !== -1) {
-        nestedRuleProp = undefined
-        // Closing brace should be on it's own line, otherwise the rest on that line
-        // will be ignored, so we should warn the user.
-        if (decl.length !== 1) {
-          warning(false, `[JSS] Missing opening curly brace in "${decl}".`)
-        }
-        continue
+    // We are closing a nested rule.
+    if (decl.indexOf('}') !== -1) {
+      rules.pop()
+      // Closing brace should be on it's own line, otherwise the rest on that line
+      // will be ignored, so we should warn the user.
+      if (decl.length !== 1) {
+        warning(false, `[JSS] Missing opening curly brace in "${decl}".`)
       }
+      continue
     }
 
     const colonIndex = decl.indexOf(':')
+
     if (colonIndex === -1) {
       warning(false, `[JSS] Missing colon in "${decl}".`)
       continue
     }
 
     const prop = decl.substring(0, colonIndex).trim()
-    const value = decl.substring(colonIndex + 1, decl.length - 1).trim()
-
-    if (nestedRuleProp) {
-      style[nestedRuleProp][prop] = value
-    } else {
-      style[prop] = value
-    }
+    // We need to remove semicolon from value if there is one.
+    const semi = decl[decl.length - 1] === ';' ? 1 : 0
+    const value = decl.substring(colonIndex + 1, decl.length - semi).trim()
+    rules[rules.length - 1][prop] = value
   }
+
   return style
 }
 

--- a/packages/jss-plugin-template/src/parse.js
+++ b/packages/jss-plugin-template/src/parse.js
@@ -9,7 +9,7 @@ const semiWithNl = /\n/
  * - Requires semicolon and new line after the value (except of last line)
  * - No nested rules support
  */
-export default (cssText: string): Object => {
+const parse = (cssText: string): Object => {
   const style = {}
   const split = cssText.split(semiWithNl)
   let nestedRuleProp
@@ -19,8 +19,9 @@ export default (cssText: string): Object => {
 
     if (!decl) continue
 
+    const ampIndex = decl.indexOf('&')
+
     if (nestedRuleProp === undefined) {
-      const ampIndex = decl.indexOf('&')
       // We have a nested rule.
       if (ampIndex !== -1) {
         const openCurlyIndex = decl.indexOf('{')
@@ -34,8 +35,14 @@ export default (cssText: string): Object => {
       }
     } else {
       const closeCurlyIndex = decl.indexOf('}')
+
       if (closeCurlyIndex !== -1) {
         nestedRuleProp = undefined
+        // Closing brace should be on it's own line, otherwise the rest on that line
+        // will be ignored, so we should warn the user.
+        if (decl.length !== 1) {
+          warning(false, `[JSS] Missing opening curly brace in "${decl}".`)
+        }
         continue
       }
     }
@@ -57,3 +64,5 @@ export default (cssText: string): Object => {
   }
   return style
 }
+
+export default parse

--- a/packages/jss-preset-default/.size-snapshot.json
+++ b/packages/jss-preset-default/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/jss-preset-default.js": {
-    "bundled": 54595,
-    "minified": 19525,
-    "gzipped": 6444
+    "bundled": 55391,
+    "minified": 19764,
+    "gzipped": 6524
   },
   "dist/jss-preset-default.min.js": {
-    "bundled": 53841,
-    "minified": 19066,
-    "gzipped": 6229
+    "bundled": 54554,
+    "minified": 19253,
+    "gzipped": 6297
   },
   "dist/jss-preset-default.cjs.js": {
     "bundled": 1329,

--- a/packages/jss-preset-default/.size-snapshot.json
+++ b/packages/jss-preset-default/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/jss-preset-default.js": {
-    "bundled": 55405,
-    "minified": 19770,
-    "gzipped": 6521
+    "bundled": 55680,
+    "minified": 19846,
+    "gzipped": 6533
   },
   "dist/jss-preset-default.min.js": {
-    "bundled": 54568,
-    "minified": 19259,
-    "gzipped": 6294
+    "bundled": 54745,
+    "minified": 19276,
+    "gzipped": 6301
   },
   "dist/jss-preset-default.cjs.js": {
     "bundled": 1329,

--- a/packages/jss-preset-default/.size-snapshot.json
+++ b/packages/jss-preset-default/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/jss-preset-default.js": {
-    "bundled": 55391,
+    "bundled": 55399,
     "minified": 19764,
-    "gzipped": 6524
+    "gzipped": 6522
   },
   "dist/jss-preset-default.min.js": {
-    "bundled": 54554,
+    "bundled": 54562,
     "minified": 19253,
-    "gzipped": 6297
+    "gzipped": 6296
   },
   "dist/jss-preset-default.cjs.js": {
     "bundled": 1329,

--- a/packages/jss-preset-default/.size-snapshot.json
+++ b/packages/jss-preset-default/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/jss-preset-default.js": {
-    "bundled": 55399,
-    "minified": 19764,
-    "gzipped": 6522
+    "bundled": 55405,
+    "minified": 19770,
+    "gzipped": 6521
   },
   "dist/jss-preset-default.min.js": {
-    "bundled": 54562,
-    "minified": 19253,
-    "gzipped": 6296
+    "bundled": 54568,
+    "minified": 19259,
+    "gzipped": 6294
   },
   "dist/jss-preset-default.cjs.js": {
     "bundled": 1329,

--- a/packages/jss-preset-default/.size-snapshot.json
+++ b/packages/jss-preset-default/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/jss-preset-default.js": {
-    "bundled": 55680,
-    "minified": 19846,
-    "gzipped": 6533
+    "bundled": 55587,
+    "minified": 19860,
+    "gzipped": 6544
   },
   "dist/jss-preset-default.min.js": {
-    "bundled": 54745,
-    "minified": 19276,
-    "gzipped": 6301
+    "bundled": 54658,
+    "minified": 19291,
+    "gzipped": 6313
   },
   "dist/jss-preset-default.cjs.js": {
     "bundled": 1329,

--- a/packages/jss-starter-kit/.size-snapshot.json
+++ b/packages/jss-starter-kit/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/jss-starter-kit.js": {
-    "bundled": 70941,
-    "minified": 29802,
-    "gzipped": 9157
+    "bundled": 70947,
+    "minified": 29808,
+    "gzipped": 9156
   },
   "dist/jss-starter-kit.min.js": {
-    "bundled": 70104,
-    "minified": 29292,
-    "gzipped": 8935
+    "bundled": 70110,
+    "minified": 29298,
+    "gzipped": 8934
   },
   "dist/jss-starter-kit.cjs.js": {
     "bundled": 2592,

--- a/packages/jss-starter-kit/.size-snapshot.json
+++ b/packages/jss-starter-kit/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/jss-starter-kit.js": {
-    "bundled": 70137,
-    "minified": 29563,
-    "gzipped": 9075
+    "bundled": 70933,
+    "minified": 29802,
+    "gzipped": 9159
   },
   "dist/jss-starter-kit.min.js": {
-    "bundled": 69383,
-    "minified": 29105,
-    "gzipped": 8867
+    "bundled": 70096,
+    "minified": 29292,
+    "gzipped": 8937
   },
   "dist/jss-starter-kit.cjs.js": {
     "bundled": 2592,

--- a/packages/jss-starter-kit/.size-snapshot.json
+++ b/packages/jss-starter-kit/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/jss-starter-kit.js": {
-    "bundled": 70933,
+    "bundled": 70941,
     "minified": 29802,
-    "gzipped": 9159
+    "gzipped": 9157
   },
   "dist/jss-starter-kit.min.js": {
-    "bundled": 70096,
+    "bundled": 70104,
     "minified": 29292,
-    "gzipped": 8937
+    "gzipped": 8935
   },
   "dist/jss-starter-kit.cjs.js": {
     "bundled": 2592,

--- a/packages/jss-starter-kit/.size-snapshot.json
+++ b/packages/jss-starter-kit/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/jss-starter-kit.js": {
-    "bundled": 71222,
-    "minified": 29884,
-    "gzipped": 9168
+    "bundled": 71129,
+    "minified": 29899,
+    "gzipped": 9175
   },
   "dist/jss-starter-kit.min.js": {
-    "bundled": 70287,
-    "minified": 29315,
-    "gzipped": 8939
+    "bundled": 70200,
+    "minified": 29330,
+    "gzipped": 8947
   },
   "dist/jss-starter-kit.cjs.js": {
     "bundled": 2592,

--- a/packages/jss-starter-kit/.size-snapshot.json
+++ b/packages/jss-starter-kit/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/jss-starter-kit.js": {
-    "bundled": 70947,
-    "minified": 29808,
-    "gzipped": 9156
+    "bundled": 71222,
+    "minified": 29884,
+    "gzipped": 9168
   },
   "dist/jss-starter-kit.min.js": {
-    "bundled": 70110,
-    "minified": 29298,
-    "gzipped": 8934
+    "bundled": 70287,
+    "minified": 29315,
+    "gzipped": 8939
   },
   "dist/jss-starter-kit.cjs.js": {
     "bundled": 2592,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/react-jss.js": {
-    "bundled": 110714,
-    "minified": 37652,
-    "gzipped": 12150
+    "bundled": 110989,
+    "minified": 37728,
+    "gzipped": 12163
   },
   "dist/react-jss.min.js": {
-    "bundled": 86072,
-    "minified": 30335,
-    "gzipped": 9943
+    "bundled": 86249,
+    "minified": 30352,
+    "gzipped": 9949
   },
   "dist/react-jss.cjs.js": {
     "bundled": 15499,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/react-jss.js": {
-    "bundled": 110700,
+    "bundled": 110708,
     "minified": 37646,
-    "gzipped": 12153
+    "gzipped": 12152
   },
   "dist/react-jss.min.js": {
-    "bundled": 86058,
+    "bundled": 86066,
     "minified": 30329,
-    "gzipped": 9946
+    "gzipped": 9945
   },
   "dist/react-jss.cjs.js": {
     "bundled": 15499,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/react-jss.js": {
-    "bundled": 110989,
-    "minified": 37728,
-    "gzipped": 12163
+    "bundled": 110896,
+    "minified": 37744,
+    "gzipped": 12180
   },
   "dist/react-jss.min.js": {
-    "bundled": 86249,
-    "minified": 30352,
-    "gzipped": 9949
+    "bundled": 86162,
+    "minified": 30368,
+    "gzipped": 9971
   },
   "dist/react-jss.cjs.js": {
     "bundled": 15499,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/react-jss.js": {
-    "bundled": 110708,
-    "minified": 37646,
-    "gzipped": 12152
+    "bundled": 110714,
+    "minified": 37652,
+    "gzipped": 12150
   },
   "dist/react-jss.min.js": {
-    "bundled": 86066,
-    "minified": 30329,
-    "gzipped": 9945
+    "bundled": 86072,
+    "minified": 30335,
+    "gzipped": 9943
   },
   "dist/react-jss.cjs.js": {
     "bundled": 15499,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/react-jss.js": {
-    "bundled": 109904,
-    "minified": 37407,
-    "gzipped": 12068
+    "bundled": 110700,
+    "minified": 37646,
+    "gzipped": 12153
   },
   "dist/react-jss.min.js": {
-    "bundled": 85345,
-    "minified": 30142,
-    "gzipped": 9883
+    "bundled": 86058,
+    "minified": 30329,
+    "gzipped": 9946
   },
   "dist/react-jss.cjs.js": {
     "bundled": 15499,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8979,6 +8979,11 @@ strong-log-transformer@^2.0.0:
     minimist "^1.2.0"
     through "^2.3.4"
 
+stylis@^3.5.4:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
+  integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
+
 supports-color@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"


### PR DESCRIPTION
Implements #837

I think I found a way to implement it without degrading performance, LOC is still pretty small.

The problem it is solving: you can't express a nested rule with a template string. If you used a template string initially to describe the rule, as soon as you want to add nesting, you will have to rewrite it to objects.

```
const styles = {
  btn: `
    float:  left;
    & span: {
      color: red;
    }
  `
}
```