### PR TITLE
Export StyleSheet from jss to facilitate testing

### DIFF
--- a/packages/jss/.size-snapshot.json
+++ b/packages/jss/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/jss.js": {
-    "bundled": 58914,
-    "minified": 21845,
-    "gzipped": 6575
+    "bundled": 58949,
+    "minified": 21860,
+    "gzipped": 6580
   },
   "dist/jss.min.js": {
-    "bundled": 57748,
-    "minified": 20928,
-    "gzipped": 6133
+    "bundled": 57783,
+    "minified": 20943,
+    "gzipped": 6138
   },
   "dist/jss.cjs.js": {
-    "bundled": 54372,
-    "minified": 23761,
-    "gzipped": 6624
+    "bundled": 54405,
+    "minified": 23791,
+    "gzipped": 6630
   },
   "dist/jss.esm.js": {
-    "bundled": 53876,
-    "minified": 23357,
-    "gzipped": 6541,
+    "bundled": 53888,
+    "minified": 23368,
+    "gzipped": 6544,
     "treeshaked": {
       "rollup": {
         "code": 18988,

--- a/packages/jss/src/index.js
+++ b/packages/jss/src/index.js
@@ -7,7 +7,7 @@
  * @license MIT
  */
 import Jss from './Jss'
-import type StyleSheet from './StyleSheet'
+
 import type {
   ConditionalRule,
   KeyframesRule,
@@ -38,16 +38,7 @@ export type {
   ContainerRule
 } from './types'
 
-export type {
-  Jss,
-  StyleSheet,
-  ConditionalRule,
-  KeyframesRule,
-  StyleRule,
-  ViewportRule,
-  SimpleRule,
-  FontFaceRule
-}
+export type {Jss, ConditionalRule, KeyframesRule, StyleRule, ViewportRule, SimpleRule, FontFaceRule}
 
 /**
  * Export a constant indicating if this browser has CSSTOM support.
@@ -95,6 +86,7 @@ export {default as sheets} from './sheets'
  */
 export {default as createGenerateId} from './utils/createGenerateId'
 
+export {default as StyleSheet} from './StyleSheet'
 /**
  * Creates a new instance of Jss.
  */


### PR DESCRIPTION
__What would you like to add/fix?__
By exporting StyleSheet from the package it is now possible to test that functions are executed as expected. e.g. 
```
import { StyleSheet } from 'jss';
...
const attachSpy = jest.spyOn(StyleSheet.prototype, 'attach');
...
expect(attachSpy).toHaveBeenCalledTimes(3);
```


