### PR TITLE
Fix for case where `global` is unset

### DIFF
--- a/packages/jss/src/utils/moduleId.js
+++ b/packages/jss/src/utils/moduleId.js
@@ -1,13 +1,13 @@
-let count = 0
-const ns = '2f1acc6c3a606b082e5eef5e54414ffb'
-
-if (typeof global === 'object') {
-  if (global[ns] != null) count = global[ns]
-  global[ns] = count + 1
+if (typeof global !== 'object') {
+  export default 0
+  return
 }
+
+const ns = '2f1acc6c3a606b082e5eef5e54414ffb'
+if (global[ns] == null) global[ns] = 0
 
 // Bundle may contain multiple JSS versions at the same time. In order to identify
 // the current version with just one short number and use it for classes generation
 // we use a counter. Also it is more accurate, because user can manually reevaluate
 // the module.
-export default count
+export default global[ns]++

--- a/packages/jss/src/utils/moduleId.js
+++ b/packages/jss/src/utils/moduleId.js
@@ -1,8 +1,13 @@
+let count = 0
 const ns = '2f1acc6c3a606b082e5eef5e54414ffb'
-if (global[ns] == null) global[ns] = 0
+
+if (typeof global === 'object') {
+  if (global[ns] != null) count = global[ns]
+  global[ns] = count + 1
+}
 
 // Bundle may contain multiple JSS versions at the same time. In order to identify
 // the current version with just one short number and use it for classes generation
 // we use a counter. Also it is more accurate, because user can manually reevaluate
 // the module.
-export default global[ns]++
+export default count


### PR DESCRIPTION
In line with recent changes to `src/utils/escape.js`, this handles situations where `global` doesn't exist (which is often the case in browsers, depending on the webpack configuration).