### PR TITLE
[react-jss] removed classNamePrefix from getSheetOptions

### DIFF
--- a/docs/react-jss-hoc.md
+++ b/docs/react-jss-hoc.md
@@ -349,6 +349,57 @@ export default function render(req, res) {
 }
 ```
 
+You also can use`classNamePrefix={false}` in `JssProvider` to disable additional prefix that is compiled.
+
+```javascript
+import React from 'react'
+import {renderToString} from 'react-dom/server'
+import {JssProvider, SheetsRegistry, createGenerateId} from 'react-jss'
+import MyApp from './MyApp'
+
+export default function render(req, res) {
+  const sheets = new SheetsRegistry()
+  const generateId = createGenerateId()
+
+  const body = renderToString(
+    <JssProvider classNamePrefix={false} registry={sheets} generateId={generateId}>
+      <MyApp />
+    </JssProvider>
+  )
+
+  // Any instances using `useStyles` within `<MyApp />` will have gotten sheets
+  // from `context` and added their Style Sheets to it by now.
+
+  return res.send(
+    renderToString(
+      <html lang="en">
+        <head>
+          <style type="text/css">{sheets.toString()}</style>
+        </head>
+        <body>{body}</body>
+      </html>
+    )
+  )
+}
+```
+
+```javascript
+import React from 'react'
+import withStyles from 'react-jss'
+
+const styles = {
+  container: {
+    background: 'white'
+  }
+}
+
+const MyApp = ({classes}) => <div className={classes.container}>MyApp</div>
+
+export default withStyles(styles)(MyApp)
+```
+
+Class names will compile to `container-0-1-1` instead of `MyApp-container-0-1-1`
+
 #### React tree traversing
 
 For traversing the React tree outside of the HTML rendering, you should add `disableStylesGeneration` property.

--- a/docs/react-jss.md
+++ b/docs/react-jss.md
@@ -354,6 +354,61 @@ export default function render(req, res) {
 }
 ```
 
+You also can use`classNamePrefix={false}` in `JssProvider` to disable additional prefix that is compiled.
+
+```javascript
+import React from 'react'
+import {renderToString} from 'react-dom/server'
+import {JssProvider, SheetsRegistry, createGenerateId} from 'react-jss'
+import MyApp from './MyApp'
+
+export default function render(req, res) {
+  const sheets = new SheetsRegistry()
+  const generateId = createGenerateId()
+
+  const body = renderToString(
+    <JssProvider classNamePrefix={false} registry={sheets} generateId={generateId}>
+      <MyApp />
+    </JssProvider>
+  )
+
+  // Any instances using `useStyles` within `<MyApp />` will have gotten sheets
+  // from `context` and added their Style Sheets to it by now.
+
+  return res.send(
+    renderToString(
+      <html lang="en">
+        <head>
+          <style type="text/css">{sheets.toString()}</style>
+        </head>
+        <body>{body}</body>
+      </html>
+    )
+  )
+}
+```
+
+```javascript
+import React from 'react'
+import {createUseStyles} from 'react-jss'
+
+const useStyles = {
+  container: {
+    background: 'white'
+  }
+}
+
+const MyApp = () => {
+  const classes = useStyles()
+
+  return <div className={classes.container}>MyApp</div>
+}
+
+export default MyApp
+```
+
+Class names will compile to `container-0-1-1` instead of `Hook-container-0-1-1`
+
 #### React tree traversing
 
 For traversing the React tree outside of the HTML rendering, you should add `disableStylesGeneration` property.

--- a/packages/jss/src/index.d.ts
+++ b/packages/jss/src/index.d.ts
@@ -120,7 +120,7 @@ export interface StyleSheetFactoryOptions {
   link?: boolean
   element?: HTMLStyleElement
   generateId?: GenerateId
-  classNamePrefix?: string
+  classNamePrefix?: string | false
 }
 
 interface StyleSheetOptions extends StyleSheetFactoryOptions {

--- a/packages/jss/src/types/jss.js
+++ b/packages/jss/src/types/jss.js
@@ -173,7 +173,7 @@ export type StyleSheetFactoryOptions = {
   link?: boolean,
   element?: HTMLStyleElement,
   generateId?: GenerateId,
-  classNamePrefix?: string
+  classNamePrefix?: string | false,
 }
 
 export type StyleSheetOptions = {|
@@ -183,7 +183,7 @@ export type StyleSheetOptions = {|
   element?: HTMLStyleElement,
   index: number,
   generateId: GenerateId,
-  classNamePrefix?: string,
+  classNamePrefix?: string | false,
   Renderer?: Class<Renderer> | null,
   insertionPoint?: InsertionPoint,
   jss: Jss
@@ -198,7 +198,7 @@ export type InternalStyleSheetOptions = {|
   insertionPoint?: InsertionPoint,
   Renderer?: Class<Renderer> | null,
   generateId: GenerateId,
-  classNamePrefix?: string,
+  classNamePrefix?: string | false,
   jss: Jss,
   sheet: StyleSheet,
   parent: ConditionalRule | KeyframesRule | StyleSheet,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "dist/react-jss.js": {
-    "bundled": 128721,
-    "minified": 44368,
-    "gzipped": 13868
+    "bundled": 129040,
+    "minified": 44496,
+    "gzipped": 13898
   },
   "dist/react-jss.min.js": {
-    "bundled": 96370,
-    "minified": 34510,
-    "gzipped": 11107
+    "bundled": 96689,
+    "minified": 34638,
+    "gzipped": 11142
   },
   "dist/react-jss.cjs.js": {
-    "bundled": 21123,
-    "minified": 9810,
-    "gzipped": 3182
+    "bundled": 21426,
+    "minified": 9954,
+    "gzipped": 3220
   },
   "dist/react-jss.esm.js": {
-    "bundled": 20272,
-    "minified": 9069,
-    "gzipped": 3062,
+    "bundled": 20575,
+    "minified": 9213,
+    "gzipped": 3099,
     "treeshaked": {
       "rollup": {
-        "code": 2040,
+        "code": 2105,
         "import_statements": 439
       },
       "webpack": {
-        "code": 3470
+        "code": 3539
       }
     }
   }

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/react-jss.js": {
-    "bundled": 128759,
-    "minified": 44373,
-    "gzipped": 13874
+    "bundled": 128721,
+    "minified": 44368,
+    "gzipped": 13868
   },
   "dist/react-jss.min.js": {
-    "bundled": 96372,
-    "minified": 34480,
-    "gzipped": 11091
+    "bundled": 96370,
+    "minified": 34510,
+    "gzipped": 11107
   },
   "dist/react-jss.cjs.js": {
-    "bundled": 21204,
-    "minified": 9854,
-    "gzipped": 3193
+    "bundled": 21123,
+    "minified": 9810,
+    "gzipped": 3182
   },
   "dist/react-jss.esm.js": {
-    "bundled": 20353,
-    "minified": 9113,
-    "gzipped": 3072,
+    "bundled": 20272,
+    "minified": 9069,
+    "gzipped": 3062,
     "treeshaked": {
       "rollup": {
         "code": 2040,

--- a/packages/react-jss/src/JssProvider.js
+++ b/packages/react-jss/src/JssProvider.js
@@ -18,7 +18,7 @@ type Props = {|
   jss?: Jss,
   registry?: SheetsRegistry,
   generateId?: GenerateId,
-  classNamePrefix?: string,
+  classNamePrefix?: string | false,
   disableStylesGeneration?: boolean,
   media?: string,
   children: Node,
@@ -30,7 +30,7 @@ export default class JssProvider extends Component<Props> {
     registry: PropTypes.instanceOf(SheetsRegistry),
     jss: PropTypes.instanceOf(defaultJss.constructor),
     generateId: PropTypes.func,
-    classNamePrefix: PropTypes.string,
+    classNamePrefix: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     disableStylesGeneration: PropTypes.bool,
     children: PropTypes.node.isRequired,
     media: PropTypes.string,
@@ -73,6 +73,9 @@ export default class JssProvider extends Component<Props> {
     // Merge the classname prefix
     if (classNamePrefix) {
       context.sheetOptions.classNamePrefix += classNamePrefix
+    }
+    if (classNamePrefix === false) {
+      context.sheetOptions.classNamePrefix = classNamePrefix
     }
 
     if (media !== undefined) {

--- a/packages/react-jss/src/index.d.ts
+++ b/packages/react-jss/src/index.d.ts
@@ -16,7 +16,7 @@ declare const JssProvider: ComponentType<{
   jss?: Jss
   registry?: SheetsRegistry
   generateId?: GenerateId
-  classNamePrefix?: string
+  classNamePrefix?: string | false
   disableStylesGeneration?: boolean
   children: ReactNode
   id?: CreateGenerateIdOptions

--- a/packages/react-jss/src/types.js
+++ b/packages/react-jss/src/types.js
@@ -9,7 +9,7 @@ export type Managers = {[key: number]: SheetsManager}
 
 type StyleSheetOptions = {
   ...StyleSheetFactoryOptions,
-  classNamePrefix: string
+  classNamePrefix: string | false
 }
 
 export type HookOptions<Theme> = StyleSheetFactoryOptions & {

--- a/packages/react-jss/src/utils/sheets.js
+++ b/packages/react-jss/src/utils/sheets.js
@@ -33,15 +33,15 @@ const getStyles = <Theme>(options: Options<Theme>) => {
 }
 
 function getSheetOptions<Theme>(options: Options<Theme>, link: boolean) {
-  const classNamePrefix =
-    process.env.NODE_ENV === 'production' ? '' : `${options.name.replace(/\s/g, '-')}-`
-
   return {
     ...options.sheetOptions,
     ...options.context.sheetOptions,
     index: options.index,
     meta: `${options.name}, ${typeof options.styles === 'function' ? 'Themed' : 'Unthemed'}`,
-    classNamePrefix: options.context.sheetOptions.classNamePrefix + classNamePrefix,
+    classNamePrefix: `${options.context.sheetOptions.classNamePrefix}${options.name.replace(
+      /\s/g,
+      '-'
+    )}-`,
     link
   }
 }

--- a/packages/react-jss/src/utils/sheets.js
+++ b/packages/react-jss/src/utils/sheets.js
@@ -33,15 +33,19 @@ const getStyles = <Theme>(options: Options<Theme>) => {
 }
 
 function getSheetOptions<Theme>(options: Options<Theme>, link: boolean) {
+  let classNamePrefix
+
+  if (options.context.sheetOptions.classNamePrefix !== false) {
+    const prefix = `${options.name.replace(/\s/g, '-')}-`
+    classNamePrefix = options.context.sheetOptions.classNamePrefix + prefix
+  }
+
   return {
     ...options.sheetOptions,
     ...options.context.sheetOptions,
     index: options.index,
     meta: `${options.name}, ${typeof options.styles === 'function' ? 'Themed' : 'Unthemed'}`,
-    classNamePrefix: `${options.context.sheetOptions.classNamePrefix}${options.name.replace(
-      /\s/g,
-      '-'
-    )}-`,
+    classNamePrefix,
     link
   }
 }


### PR DESCRIPTION
what's new:
- edited tests to fit new requirements

__What would you like to add/fix?__
classNamePrefix hardcoded inside `react-jss` creates inconsistencies between packages and should be managed in inside `jss` or by developer (via `classNamePrefix` prop).

__Corresponding issue (if exists):__
