### PR TITLE
Match ts types to flow types, theming is optional

### DIFF
--- a/packages/react-jss/src/index.d.ts
+++ b/packages/react-jss/src/index.d.ts
@@ -42,7 +42,7 @@ interface Options extends StyleSheetFactoryOptions {
   index?: number
   injectTheme?: boolean
   jss?: Jss
-  theming: Theming<object>
+  theming?: Theming<object>
 }
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>


### PR DESCRIPTION
__What would you like to add/fix?__

Match TypeScript type defs with flow ones, which seems to be the correct one.

`theming` was required in TypeScript defs. 

