### PR TITLE
Export useTheme in TypeScript declaration

### DIFF
--- a/packages/react-jss/src/index.d.ts
+++ b/packages/react-jss/src/index.d.ts
@@ -17,7 +17,9 @@ import {
 } from 'theming'
 
 declare const jss: Jss
+
 declare const createGenerateId: CreateGenerateId
+
 declare const JssProvider: ComponentType<{
   jss?: Jss
   registry?: SheetsRegistry
@@ -27,9 +29,11 @@ declare const JssProvider: ComponentType<{
   children: ReactNode
   id?: CreateGenerateIdOptions
 }>
+
 interface Managers {
   [key: number]: StyleSheet
 }
+
 declare const JssContext: Context<{
   jss?: Jss
   registry?: SheetsRegistry

--- a/packages/react-jss/src/index.d.ts
+++ b/packages/react-jss/src/index.d.ts
@@ -6,9 +6,15 @@ import {
   SheetsRegistry,
   Styles,
   StyleSheetFactoryOptions,
-  CreateGenerateIdOptions
+  CreateGenerateIdOptions,
 } from 'jss'
-import {ThemeProvider, withTheme, createTheming, Theming} from 'theming'
+import {
+  createTheming,
+  useTheme,
+  withTheme,
+  ThemeProvider,
+  Theming,
+} from 'theming'
 
 declare const jss: Jss
 declare const createGenerateId: CreateGenerateId
@@ -63,7 +69,8 @@ export {
   ThemeProvider,
   withTheme,
   createTheming,
-  JssContext
+  useTheme,
+  JssContext,
 }
 
 export default withStyles


### PR DESCRIPTION
__What would you like to add/fix?__

Export `useTheme` in TypeScript declaration.

Still missing: Declaration and export of `createUseStyles` fn.

