### PR TITLE
Fix sheets not rendered during SSR when using hooks API

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "prettier": "^1.13.5",
     "raf": "^3.4.0",
     "react": "^16.8.6",
+    "react-dom": "^16.8.6",
     "react-test-renderer": "^16.8.6",
     "rimraf": "^2.5.4",
     "rollup": "^1.1.2",

--- a/packages/css-jss/.size-snapshot.json
+++ b/packages/css-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/css-jss.js": {
-    "bundled": 56911,
-    "minified": 20186,
-    "gzipped": 6756
+    "bundled": 57147,
+    "minified": 20239,
+    "gzipped": 6783
   },
   "dist/css-jss.min.js": {
-    "bundled": 56157,
-    "minified": 19727,
-    "gzipped": 6538
+    "bundled": 56393,
+    "minified": 19780,
+    "gzipped": 6569
   },
   "dist/css-jss.cjs.js": {
     "bundled": 2505,

--- a/packages/jss-plugin-vendor-prefixer/.size-snapshot.json
+++ b/packages/jss-plugin-vendor-prefixer/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/jss-plugin-vendor-prefixer.js": {
-    "bundled": 17480,
-    "minified": 5616,
-    "gzipped": 2183
+    "bundled": 17716,
+    "minified": 5671,
+    "gzipped": 2211
   },
   "dist/jss-plugin-vendor-prefixer.min.js": {
-    "bundled": 17480,
-    "minified": 5616,
-    "gzipped": 2183
+    "bundled": 17716,
+    "minified": 5671,
+    "gzipped": 2211
   },
   "dist/jss-plugin-vendor-prefixer.cjs.js": {
     "bundled": 1375,

--- a/packages/jss-preset-default/.size-snapshot.json
+++ b/packages/jss-preset-default/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/jss-preset-default.js": {
-    "bundled": 54595,
-    "minified": 19525,
-    "gzipped": 6444
+    "bundled": 54831,
+    "minified": 19578,
+    "gzipped": 6473
   },
   "dist/jss-preset-default.min.js": {
-    "bundled": 53841,
-    "minified": 19066,
-    "gzipped": 6229
+    "bundled": 54077,
+    "minified": 19119,
+    "gzipped": 6260
   },
   "dist/jss-preset-default.cjs.js": {
     "bundled": 1329,

--- a/packages/jss-starter-kit/.size-snapshot.json
+++ b/packages/jss-starter-kit/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/jss-starter-kit.js": {
-    "bundled": 70137,
-    "minified": 29563,
-    "gzipped": 9075
+    "bundled": 70373,
+    "minified": 29617,
+    "gzipped": 9105
   },
   "dist/jss-starter-kit.min.js": {
-    "bundled": 69383,
-    "minified": 29105,
-    "gzipped": 8867
+    "bundled": 69619,
+    "minified": 29159,
+    "gzipped": 8899
   },
   "dist/jss-starter-kit.cjs.js": {
     "bundled": 2592,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/react-jss.js": {
-    "bundled": 142107,
-    "minified": 51017,
-    "gzipped": 16807
+    "bundled": 167552,
+    "minified": 58003,
+    "gzipped": 18880
   },
   "dist/react-jss.min.js": {
-    "bundled": 108586,
-    "minified": 40704,
-    "gzipped": 13875
+    "bundled": 110827,
+    "minified": 41357,
+    "gzipped": 13942
   },
   "dist/react-jss.cjs.js": {
-    "bundled": 26052,
-    "minified": 11426,
-    "gzipped": 3739
+    "bundled": 26174,
+    "minified": 11471,
+    "gzipped": 3751
   },
   "dist/react-jss.esm.js": {
-    "bundled": 25090,
-    "minified": 10591,
-    "gzipped": 3612,
+    "bundled": 25212,
+    "minified": 10636,
+    "gzipped": 3624,
     "treeshaked": {
       "rollup": {
         "code": 1946,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/react-jss.js": {
-    "bundled": 167552,
-    "minified": 58003,
-    "gzipped": 18880
+    "bundled": 142107,
+    "minified": 51017,
+    "gzipped": 16807
   },
   "dist/react-jss.min.js": {
-    "bundled": 110827,
-    "minified": 41357,
-    "gzipped": 13942
+    "bundled": 108586,
+    "minified": 40704,
+    "gzipped": 13875
   },
   "dist/react-jss.cjs.js": {
-    "bundled": 26174,
-    "minified": 11471,
-    "gzipped": 3751
+    "bundled": 26052,
+    "minified": 11426,
+    "gzipped": 3739
   },
   "dist/react-jss.esm.js": {
-    "bundled": 25212,
-    "minified": 10636,
-    "gzipped": 3624,
+    "bundled": 25090,
+    "minified": 10591,
+    "gzipped": 3612,
     "treeshaked": {
       "rollup": {
         "code": 1946,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/react-jss.js": {
-    "bundled": 167552,
-    "minified": 58003,
-    "gzipped": 18880
+    "bundled": 167788,
+    "minified": 58057,
+    "gzipped": 18916
   },
   "dist/react-jss.min.js": {
-    "bundled": 110827,
-    "minified": 41357,
-    "gzipped": 13942
+    "bundled": 111063,
+    "minified": 41411,
+    "gzipped": 13978
   },
   "dist/react-jss.cjs.js": {
     "bundled": 26174,

--- a/packages/react-jss/src/createUseStyles.js
+++ b/packages/react-jss/src/createUseStyles.js
@@ -55,14 +55,11 @@ const createUseStyles = <Theme: {}>(styles: Styles<Theme>, options?: HookOptions
       let dynamicRules
       let classes
       if (sheet) {
+        if (context.registry) {
+          context.registry.add(sheet)
+        }
         dynamicRules = addDynamicRules(sheet, data)
         classes = getSheetClasses(sheet, dynamicRules)
-        manageSheet({
-          index,
-          context,
-          sheet,
-          theme
-        })
       }
 
       return {
@@ -73,20 +70,31 @@ const createUseStyles = <Theme: {}>(styles: Styles<Theme>, options?: HookOptions
     })
 
     useEffectOrLayoutEffect(
-      () => () => {
-        const {sheet, dynamicRules} = state
+      () => {
+        if (state.sheet) {
+          manageSheet({
+            index,
+            context,
+            sheet: state.sheet,
+            theme
+          })
+        }
 
-        if (!sheet) return
+        return () => {
+          const {sheet, dynamicRules} = state
 
-        unmanageSheet({
-          index,
-          context,
-          sheet,
-          theme
-        })
+          if (!sheet) return
 
-        if (dynamicRules) {
-          removeDynamicRules(sheet, dynamicRules)
+          unmanageSheet({
+            index,
+            context,
+            sheet,
+            theme
+          })
+
+          if (dynamicRules) {
+            removeDynamicRules(sheet, dynamicRules)
+          }
         }
       },
       [state.sheet]

--- a/packages/react-jss/src/createUseStyles.js
+++ b/packages/react-jss/src/createUseStyles.js
@@ -55,11 +55,14 @@ const createUseStyles = <Theme: {}>(styles: Styles<Theme>, options?: HookOptions
       let dynamicRules
       let classes
       if (sheet) {
-        if (context.registry) {
-          context.registry.add(sheet)
-        }
         dynamicRules = addDynamicRules(sheet, data)
         classes = getSheetClasses(sheet, dynamicRules)
+        manageSheet({
+          index,
+          context,
+          sheet,
+          theme
+        })
       }
 
       return {
@@ -70,31 +73,20 @@ const createUseStyles = <Theme: {}>(styles: Styles<Theme>, options?: HookOptions
     })
 
     useEffectOrLayoutEffect(
-      () => {
-        if (state.sheet) {
-          manageSheet({
-            index,
-            context,
-            sheet: state.sheet,
-            theme
-          })
-        }
+      () => () => {
+        const {sheet, dynamicRules} = state
 
-        return () => {
-          const {sheet, dynamicRules} = state
+        if (!sheet) return
 
-          if (!sheet) return
+        unmanageSheet({
+          index,
+          context,
+          sheet,
+          theme
+        })
 
-          unmanageSheet({
-            index,
-            context,
-            sheet,
-            theme
-          })
-
-          if (dynamicRules) {
-            removeDynamicRules(sheet, dynamicRules)
-          }
+        if (dynamicRules) {
+          removeDynamicRules(sheet, dynamicRules)
         }
       },
       [state.sheet]

--- a/packages/react-jss/tests/serverSideRendering.js
+++ b/packages/react-jss/tests/serverSideRendering.js
@@ -1,0 +1,41 @@
+import expect from 'expect.js'
+import React from 'react'
+import {renderToString} from 'react-dom/server'
+
+import injectSheet, {createUseStyles, createGenerateId, JssProvider, SheetsRegistry} from '../src'
+
+describe('React-JSS: rendering in an SSR context', () => {
+  const staticStyles = {
+    rule: {
+      color: 'red'
+    }
+  }
+
+  const testServerRender = Component => {
+    const registry = new SheetsRegistry()
+    const generateId = createGenerateId()
+    const html = renderToString(
+      <JssProvider registry={registry} generateId={generateId}>
+        <Component />
+      </JssProvider>
+    )
+    expect(html).to.be('')
+    const css = registry.toString()
+    expect(css).to.be('.Component-rule-1-1-1 {\n  color: red;\n}')
+  }
+
+  it('should render sheet on the server with withStyles', () => {
+    const Component = () => null
+    const StyledComponent = injectSheet(staticStyles)(Component)
+    testServerRender(StyledComponent)
+  })
+
+  it('should render sheet on the server with useStyles', () => {
+    const useStyles = createUseStyles(staticStyles, {name: 'Component'})
+    const Component = props => {
+      useStyles(props)
+      return null
+    }
+    testServerRender(Component)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -7757,6 +7757,16 @@ react-display-name@^0.2.4:
   resolved "https://registry.yarnpkg.com/react-display-name/-/react-display-name-0.2.4.tgz#e2a670b81d79a2204335510c01246f4c92ff12cf"
   integrity sha512-zvU6iouW+SWwHTyThwxGICjJYCMZFk/6r/+jmOdC7ntQoPlS/Pqb81MkxaMf2bHTSq9TN3K3zX2/ayMW/jCtyA==
 
+react-dom@^16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
+  integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.6"
+
 react-is@^16.3.2:
   version "16.6.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.0.tgz#456645144581a6e99f6816ae2bd24ee94bdd0c01"


### PR DESCRIPTION
Stylesheets that use `useStyles()` are omitted when when calling `sheetsRegistry.toString()` during server side rendering.

By comparing `createUseStyles()` with the `withStyles()` HoC API (which does not exhibit this problem) I noticed that the HoC component calls `manageSheet()` from its constructor, whereas `useStyles()` calls it from inside `useEffectOrLayoutEffect()`, i.e. after the component mounts. That means it won't be called at all on the server.

I've moved the `manageSheet()` call to be together with the `addDynamicRules()` and `getSheetClasses()` calls in the `useReducer()` initializer function, in the same order as they are called in the `WithStyles` constructor. This also means I can omit the call to `context.registry.add(sheet)`.

This has fixed the SSR problem for me. However I currently have some failing tests. I’m creating the PR early though because it’ll probably take me a while to figure out what the tests are testing and why they’re failing.