### PR TITLE
Nested function values not working in React

### DIFF
--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/react-jss.js": {
-    "bundled": 167824,
-    "minified": 58073,
-    "gzipped": 18921
+    "bundled": 168299,
+    "minified": 58165,
+    "gzipped": 18957
   },
   "dist/react-jss.min.js": {
-    "bundled": 111099,
-    "minified": 41427,
-    "gzipped": 13983
+    "bundled": 111574,
+    "minified": 41519,
+    "gzipped": 14016
   },
   "dist/react-jss.cjs.js": {
-    "bundled": 26174,
-    "minified": 11471,
-    "gzipped": 3751
+    "bundled": 26643,
+    "minified": 11563,
+    "gzipped": 3789
   },
   "dist/react-jss.esm.js": {
-    "bundled": 25212,
-    "minified": 10636,
-    "gzipped": 3624,
+    "bundled": 25681,
+    "minified": 10728,
+    "gzipped": 3663,
     "treeshaked": {
       "rollup": {
         "code": 1946,

--- a/packages/react-jss/src/utils/sheets.js
+++ b/packages/react-jss/src/utils/sheets.js
@@ -108,12 +108,20 @@ export const addDynamicRules = (sheet: StyleSheet, data: any): ?DynamicRules => 
   // Loop over each dynamic rule and add it to the stylesheet
   for (const key in meta.dynamicStyles) {
     const name = `${key}-${meta.dynamicRuleCounter++}`
-    const rule = sheet.addRule(name, meta.dynamicStyles[key])
+    const initialRuleCount = sheet.rules.index.length
 
-    sheet.update(name, data)
+    const originalRule = sheet.addRule(name, meta.dynamicStyles[key])
 
-    if (rule) {
-      rules[key] = rule
+    // Loop through all created rules, fixes updating dynamic rules
+    for (let i = initialRuleCount; i < sheet.rules.index.length; i++) {
+      const rule = sheet.rules.index[i]
+
+      // $FlowFixMe: Not sure why flow has an issue here
+      sheet.update(rule.key, data)
+
+      // If it's the original rule, we need to add it by the correct key so the hook and hoc
+      // can correctly concat the dynamic class with the static one
+      rules[originalRule === rule ? key : rule.key] = rule
     }
   }
 

--- a/packages/react-jss/test-utils/createDynamicStylesTests.js
+++ b/packages/react-jss/test-utils/createDynamicStylesTests.js
@@ -28,7 +28,11 @@ export default ({createStyledComponent}) => {
         {
           button: {
             color: 'rgb(255, 255, 255)',
-            height: ({height = 1}) => `${height}px`
+            height: ({height = 1}) => `${height}px`,
+            '&::before': {
+              content: '""',
+              height: ({height = 1}) => `${height}px`
+            }
           }
         },
         {name: 'NoRenderer'}
@@ -100,10 +104,19 @@ export default ({createStyledComponent}) => {
         .button-0 {
           color: rgb(255, 255, 255);
         }
+        .button-0::before {
+          content: "";
+        }
         .button-0-1 {
           height: 10px;
         }
+        .button-0-1::before {
+          height: 10px;
+        }
         .button-1-2 {
+          height: 20px;
+        }
+        .button-1-2::before {
           height: 20px;
         }
       `)
@@ -124,10 +137,19 @@ export default ({createStyledComponent}) => {
         .button-0 {
           color: rgb(255, 255, 255);
         }
+        .button-0::before {
+          content: "";
+        }
         .button-0-1 {
           height: 10px;
         }
+        .button-0-1::before {
+          height: 10px;
+        }
         .button-1-2 {
+          height: 20px;
+        }
+        .button-1-2::before {
           height: 20px;
         }
       `)
@@ -138,10 +160,19 @@ export default ({createStyledComponent}) => {
         .button-0 {
           color: rgb(255, 255, 255);
         }
+        .button-0::before {
+          content: "";
+        }
         .button-0-1 {
           height: 20px;
         }
+        .button-0-1::before {
+          height: 20px;
+        }
         .button-1-2 {
+          height: 40px;
+        }
+        .button-1-2::before {
           height: 40px;
         }
       `)


### PR DESCRIPTION
I've found that code like this:

```javascript
injectSheet({
  button: {
    '&::before': {
      content: '""',
      height: () => 1
    }
  }
})(Component)
```

Results in CSS like this:

```css
.Component-button-0-2-31 {}
.Component-button-0-2-31::before {
 content: "";
}
.Component-button-0-0-2-32 {}
.Component-button-0-0-2-32::before {}
```

That is, the result of the function value, `height: 1px;`, is missing.

This feature works in `react-jss` v8.6.1 so seems like a regression somewhere between then and v10.

This seems to be specific to `react-jss` because the test in [plugin-nested.test.js#L180](https://github.com/cssinjs/jss/blob/master/packages/jss-plugin-rule-value-function/src/plugin-nested.test.js#L180) does something very similar and passes.

This PR adds failing tests to `react-jss`. I haven't figured out the cause of the issue yet.

