### PR TITLE
Add support hint to the changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 ## Next
 
+Since you are interested in what happens next, in case, you work for a for-profit company that benefits from using the project, please consider supporting it on https://opencollective.com/jss.
+
+---
+
+## 10.0.0-alpha.20 (2019-6-21)
+
 ### Bug fixes
 
 - [jss-plugin-vendor-prefixer] Upgrade css-vendor package to v2.0.5 ([#1142](https://github.com/cssinjs/jss/pull/1142))

--- a/scripts/update-changelog.js
+++ b/scripts/update-changelog.js
@@ -11,11 +11,11 @@ const content = fs.readFileSync(changelogPath, 'utf-8')
 const lines = content
   .split('\n')
   .map(line => {
-    if (line === '## Next') {
+    if (line === '---') {
       const today = new Date()
       const date = `${today.getUTCFullYear()}-${today.getUTCMonth() + 1}-${today.getUTCDate()}`
 
-      return `## ${lerna.version} (${date})`
+      return `---\n\n## ${lerna.version} (${date})`
     }
 
     return line


### PR DESCRIPTION
I think it's worth trying because the changelog is the ultimate place where people look into who care and use the project directly, not as part of some other library.


Hopefully, this won't be perceived as some annoying ad or spam.