### PR TITLE
HOC should not attach sheets until mount

### DIFF
--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/react-jss.js": {
-    "bundled": 168618,
-    "minified": 58289,
-    "gzipped": 19024
+    "bundled": 168553,
+    "minified": 58228,
+    "gzipped": 19013
   },
   "dist/react-jss.min.js": {
-    "bundled": 111950,
-    "minified": 41684,
-    "gzipped": 14108
+    "bundled": 111885,
+    "minified": 41618,
+    "gzipped": 14107
   },
   "dist/react-jss.cjs.js": {
-    "bundled": 26503,
-    "minified": 11560,
-    "gzipped": 3807
+    "bundled": 26442,
+    "minified": 11509,
+    "gzipped": 3810
   },
   "dist/react-jss.esm.js": {
-    "bundled": 25541,
-    "minified": 10725,
-    "gzipped": 3684,
+    "bundled": 25480,
+    "minified": 10674,
+    "gzipped": 3689,
     "treeshaked": {
       "rollup": {
         "code": 1841,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/react-jss.js": {
-    "bundled": 168553,
-    "minified": 58228,
-    "gzipped": 19013
+    "bundled": 168524,
+    "minified": 58221,
+    "gzipped": 19011
   },
   "dist/react-jss.min.js": {
-    "bundled": 111885,
-    "minified": 41618,
-    "gzipped": 14107
+    "bundled": 111856,
+    "minified": 41611,
+    "gzipped": 14104
   },
   "dist/react-jss.cjs.js": {
-    "bundled": 26442,
-    "minified": 11509,
-    "gzipped": 3810
+    "bundled": 26415,
+    "minified": 11502,
+    "gzipped": 3809
   },
   "dist/react-jss.esm.js": {
-    "bundled": 25480,
-    "minified": 10674,
-    "gzipped": 3689,
+    "bundled": 25453,
+    "minified": 10667,
+    "gzipped": 3688,
     "treeshaked": {
       "rollup": {
         "code": 1841,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/react-jss.js": {
-    "bundled": 168307,
-    "minified": 58158,
-    "gzipped": 18997
+    "bundled": 168618,
+    "minified": 58289,
+    "gzipped": 19024
   },
   "dist/react-jss.min.js": {
-    "bundled": 111639,
-    "minified": 41553,
-    "gzipped": 14082
+    "bundled": 111950,
+    "minified": 41684,
+    "gzipped": 14108
   },
   "dist/react-jss.cjs.js": {
-    "bundled": 26210,
-    "minified": 11429,
-    "gzipped": 3784
+    "bundled": 26503,
+    "minified": 11560,
+    "gzipped": 3807
   },
   "dist/react-jss.esm.js": {
-    "bundled": 25248,
-    "minified": 10594,
-    "gzipped": 3662,
+    "bundled": 25541,
+    "minified": 10725,
+    "gzipped": 3684,
     "treeshaked": {
       "rollup": {
         "code": 1841,

--- a/packages/react-jss/src/withStyles.js
+++ b/packages/react-jss/src/withStyles.js
@@ -1,5 +1,6 @@
 // @flow
 import React, {Component, type ComponentType, type Node} from 'react'
+import isInBrowser from 'is-in-browser'
 import hoistNonReactStatics from 'hoist-non-react-statics'
 import {type StyleSheet, type Classes} from 'jss'
 import {ThemeContext} from 'theming'
@@ -113,16 +114,14 @@ const withStyles = <Theme>(styles: Styles<Theme>, options?: HOCOptions<Theme> = 
         super(props)
 
         this.state = WithStyles.createState(props)
-        const context = props.jssContext
-        const {sheet} = this.state
-        if (sheet && context.registry) {
-          context.registry.add(sheet)
-        }
-      }
-
-      componentDidMount() {
-        if (this.state.sheet) {
-          WithStyles.manage(this.props, this.state)
+        if (isInBrowser) {
+          WithStyles.manage(props, this.state)
+        } else {
+          const {registry} = props.jssContext
+          const {sheet} = this.state
+          if (sheet && registry) {
+            registry.add(sheet)
+          }
         }
       }
 

--- a/packages/react-jss/src/withStyles.js
+++ b/packages/react-jss/src/withStyles.js
@@ -113,7 +113,17 @@ const withStyles = <Theme>(styles: Styles<Theme>, options?: HOCOptions<Theme> = 
         super(props)
 
         this.state = WithStyles.createState(props)
-        WithStyles.manage(props, this.state)
+        const context = props.jssContext
+        const {sheet} = this.state
+        if (sheet && context.registry) {
+          context.registry.add(sheet)
+        }
+      }
+
+      componentDidMount() {
+        if (this.state.sheet) {
+          WithStyles.manage(this.props, this.state)
+        }
       }
 
       componentDidUpdate(prevProps: HOCProps<Theme, Props>, prevState: State) {

--- a/packages/react-jss/src/withStyles.js
+++ b/packages/react-jss/src/withStyles.js
@@ -114,14 +114,13 @@ const withStyles = <Theme>(styles: Styles<Theme>, options?: HOCOptions<Theme> = 
         super(props)
 
         this.state = WithStyles.createState(props)
+        const {registry} = props.jssContext
+        const {sheet} = this.state
+        if (sheet && registry) {
+          registry.add(sheet)
+        }
         if (isInBrowser) {
           WithStyles.manage(props, this.state)
-        } else {
-          const {registry} = props.jssContext
-          const {sheet} = this.state
-          if (sheet && registry) {
-            registry.add(sheet)
-          }
         }
       }
 


### PR DESCRIPTION
Fixes #1143.

Per the discussion in #1140 and, prior to that, #1089, sheets should not be attached during server-side rendering.

Now that #1148 has been merged, server rendering is working for the hook API (`createUseStyles()`) but the HOC (`withStyles()`) hasn't been updated yet so still warns (incorrectly) `Rule is not linked. Missing sheet option "link: true"` on the server.

This PR brings the HOC implementation into line with the hook implementation - adding the sheet to the `SheetsRegistry` when the component is constructed, and not attaching (managing) it until the component is mounted (which never occurs on the server).