### PR TITLE
Fix/warning adjustment

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Since you are interested in what happens next, in case, you work for a for-profi
 
 - [react-jss] Improve TypeScript definitions and add missing definition for `createUseStyles` ([1155](https://github.com/cssinjs/jss/pull/1155))
 - [jss-plugin-default-unit] Consistent usage of the CSS browser API ([1168](https://github.com/cssinjs/jss/pull/1168))
+- [jss-plugin-nested] Better warning text ([1170](https://github.com/cssinjs/jss/pull/1170))
 
 ### Bug fixes
 

--- a/packages/css-jss/.size-snapshot.json
+++ b/packages/css-jss/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/css-jss.js": {
-    "bundled": 57601,
-    "minified": 20268,
-    "gzipped": 6824
+    "bundled": 57609,
+    "minified": 20272,
+    "gzipped": 6826
   },
   "dist/css-jss.min.js": {
     "bundled": 56847,

--- a/packages/jss-plugin-nested/.size-snapshot.json
+++ b/packages/jss-plugin-nested/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/jss-plugin-nested.js": {
-    "bundled": 4512,
-    "minified": 1552,
-    "gzipped": 852
+    "bundled": 4520,
+    "minified": 1556,
+    "gzipped": 857
   },
   "dist/jss-plugin-nested.min.js": {
     "bundled": 4082,
@@ -10,14 +10,14 @@
     "gzipped": 726
   },
   "dist/jss-plugin-nested.cjs.js": {
-    "bundled": 3643,
-    "minified": 1412,
-    "gzipped": 762
+    "bundled": 3651,
+    "minified": 1416,
+    "gzipped": 768
   },
   "dist/jss-plugin-nested.esm.js": {
-    "bundled": 3409,
-    "minified": 1233,
-    "gzipped": 681,
+    "bundled": 3417,
+    "minified": 1237,
+    "gzipped": 685,
     "treeshaked": {
       "rollup": {
         "code": 64,

--- a/packages/jss-plugin-nested/src/index.js
+++ b/packages/jss-plugin-nested/src/index.js
@@ -25,8 +25,8 @@ export default function jssNested(): Plugin {
 
       warning(
         false,
-        `[JSS] Could not find the referenced rule ${key} in ${container.options.meta ||
-          container.toString()}.`
+        `[JSS] Could not find the referenced rule "${key}" in "${container.options.meta ||
+          container.toString()}".`
       )
       return key
     }

--- a/packages/jss-plugin-nested/src/index.test.js
+++ b/packages/jss-plugin-nested/src/index.test.js
@@ -405,7 +405,7 @@ describe('jss-plugin-nested', () => {
       expect(spy.callCount).to.be(1)
       expect(
         spy.calledWithExactly(
-          'Warning: [JSS] Could not find the referenced rule b in .a-id {\n  & $b: [object Object];\n}.'
+          'Warning: [JSS] Could not find the referenced rule "b" in ".a-id {\n  & $b: [object Object];\n}."'
         )
       ).to.be(true)
     })

--- a/packages/jss-plugin-nested/src/index.test.js
+++ b/packages/jss-plugin-nested/src/index.test.js
@@ -405,7 +405,7 @@ describe('jss-plugin-nested', () => {
       expect(spy.callCount).to.be(1)
       expect(
         spy.calledWithExactly(
-          'Warning: [JSS] Could not find the referenced rule "b" in ".a-id {\n  & $b: [object Object];\n}."'
+          'Warning: [JSS] Could not find the referenced rule "b" in ".a-id {\n  & $b: [object Object];\n}".'
         )
       ).to.be(true)
     })

--- a/packages/jss-preset-default/.size-snapshot.json
+++ b/packages/jss-preset-default/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/jss-preset-default.js": {
-    "bundled": 54845,
-    "minified": 19502,
-    "gzipped": 6476
+    "bundled": 54853,
+    "minified": 19506,
+    "gzipped": 6479
   },
   "dist/jss-preset-default.min.js": {
     "bundled": 54091,

--- a/packages/jss-starter-kit/.size-snapshot.json
+++ b/packages/jss-starter-kit/.size-snapshot.json
@@ -1,7 +1,7 @@
 {
   "dist/jss-starter-kit.js": {
-    "bundled": 70387,
-    "minified": 29542,
+    "bundled": 70395,
+    "minified": 29546,
     "gzipped": 9102
   },
   "dist/jss-starter-kit.min.js": {

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/react-jss.js": {
-    "bundled": 169122,
-    "minified": 58281,
-    "gzipped": 19045
+    "bundled": 169130,
+    "minified": 58285,
+    "gzipped": 19051
   },
   "dist/react-jss.min.js": {
     "bundled": 112454,


### PR DESCRIPTION
Currently, it is confusing to parse it because investigation pointers (rule, Component)
are in the same flow as warning's text itself. This subtle change aims
to put focus on important parts of the warning.

Before:
  Warning: [JSS] Could not find the referenced rule icon in Button, Themed, Static.

After
  Warning: [JSS] Could not find the referenced rule "icon" in "Button, Themed, Static".