### PR TITLE
jss-plugin-nested docs fix

### DIFF
--- a/docs/jss-plugin-nested.md
+++ b/docs/jss-plugin-nested.md
@@ -72,7 +72,7 @@ const styles = {
 Compiles to:
 
 ```css
-.button-0 {
+.button-1 {
   color: grey;
 }
 .container-0 .button-1 {


### PR DESCRIPTION
Just a small fix that resolves the confusion around how referencing local rules works.