### PR TITLE
Change Plugin to JSSPlugin

### DIFF
--- a/packages/jss-plugin-global/src/index.d.ts
+++ b/packages/jss-plugin-global/src/index.d.ts
@@ -1,3 +1,3 @@
-import {Plugin} from 'jss'
+import {JSSPlugin} from 'jss'
 
-export default function jssPluginSyntaxGlobal(): Plugin
+export default function jssPluginSyntaxGlobal(): JSSPlugin


### PR DESCRIPTION
__What would you like to add/fix?__
Currently @types/jss exports JSSPlugin and not Plugin, so we need to refactor to JSSPlugin otherwise tsc raises error.

__Corresponding issue (if exists):__
