### PR TITLE
fix: Cannot read property rules of undefined

### DIFF
--- a/packages/jss/src/RuleList.js
+++ b/packages/jss/src/RuleList.js
@@ -187,7 +187,7 @@ export default class RuleList {
     } = this.options
 
     // It is a rules container like for e.g. ConditionalRule.
-    if (rule.rules instanceof RuleList) {
+    if (rule && rule.rules instanceof RuleList) {
       rule.rules.update(data, options)
       return
     }


### PR DESCRIPTION
Not sure if it works for you, but I guess we shouldn't come into this condition if `rule` is undefined

![image](https://user-images.githubusercontent.com/32247411/64635614-c0bdc580-d408-11e9-8812-a9360d273f84.png)
