### PR TITLE
Bugfix/dynamic rules redeploy

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ Since you are interested in what happens next, in case, you work for a for-profi
 
 - [react-jss] Fix nested dynamic rule updating ([1144](https://github.com/cssinjs/jss/pull/1144))
 - [jss] Support falsy value from fn rule ([1164](https://github.com/cssinjs/jss/pull/1164))
+- [jss] Fix dynamic rule updating after sheet re-attach ([1190](https://github.com/cssinjs/jss/pull/1190))
 
 ---
 

--- a/packages/jss/.size-snapshot.json
+++ b/packages/jss/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "dist/jss.js": {
-    "bundled": 60646,
-    "minified": 22473,
-    "gzipped": 6782
+    "bundled": 60686,
+    "minified": 22507,
+    "gzipped": 6791
   },
   "dist/jss.min.js": {
-    "bundled": 59269,
-    "minified": 21704,
-    "gzipped": 6422
+    "bundled": 59309,
+    "minified": 21738,
+    "gzipped": 6431
   },
   "dist/jss.cjs.js": {
-    "bundled": 55435,
-    "minified": 24373,
-    "gzipped": 6775
+    "bundled": 55475,
+    "minified": 24407,
+    "gzipped": 6784
   },
   "dist/jss.esm.js": {
-    "bundled": 54903,
-    "minified": 23938,
-    "gzipped": 6686,
+    "bundled": 54943,
+    "minified": 23972,
+    "gzipped": 6694,
     "treeshaked": {
       "rollup": {
-        "code": 19701,
+        "code": 19735,
         "import_statements": 352
       },
       "webpack": {
-        "code": 21168
+        "code": 21202
       }
     }
   }

--- a/packages/jss/.size-snapshot.json
+++ b/packages/jss/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "dist/jss.js": {
-    "bundled": 60686,
-    "minified": 22507,
+    "bundled": 60687,
+    "minified": 22508,
     "gzipped": 6791
   },
   "dist/jss.min.js": {
-    "bundled": 59309,
-    "minified": 21738,
-    "gzipped": 6431
+    "bundled": 59310,
+    "minified": 21739,
+    "gzipped": 6432
   },
   "dist/jss.cjs.js": {
-    "bundled": 55475,
-    "minified": 24407,
-    "gzipped": 6784
+    "bundled": 55476,
+    "minified": 24408,
+    "gzipped": 6785
   },
   "dist/jss.esm.js": {
-    "bundled": 54943,
-    "minified": 23972,
-    "gzipped": 6694,
+    "bundled": 54944,
+    "minified": 23973,
+    "gzipped": 6695,
     "treeshaked": {
       "rollup": {
-        "code": 19735,
+        "code": 19736,
         "import_statements": 352
       },
       "webpack": {
-        "code": 21202
+        "code": 21203
       }
     }
   }

--- a/packages/jss/src/DomRenderer.js
+++ b/packages/jss/src/DomRenderer.js
@@ -338,7 +338,7 @@ export default class DomRenderer {
     // browsers remove those rules.
     // TODO figure out if its a bug and if it is known.
     // Workaround is to redeploy the sheet.
-    if (this.hasInsertedRules) {
+    if (this.hasInsertedRules && !(this.sheet && this.sheet.deployed)) {
       this.hasInsertedRules = false
       this.deploy()
     }

--- a/packages/jss/src/DomRenderer.js
+++ b/packages/jss/src/DomRenderer.js
@@ -338,7 +338,7 @@ export default class DomRenderer {
     // browsers remove those rules.
     // TODO figure out if its a bug and if it is known.
     // Workaround is to redeploy the sheet.
-    if (this.hasInsertedRules && !(this.sheet && this.sheet.deployed)) {
+    if (this.hasInsertedRules && !(this.sheet && !this.sheet.deployed)) {
       this.hasInsertedRules = false
       this.deploy()
     }

--- a/packages/jss/tests/functional/sheet.js
+++ b/packages/jss/tests/functional/sheet.js
@@ -257,18 +257,15 @@ describe('Functional: sheet', () => {
     })
 
     it('should not duplicate cssRules when adding rules to a detached sheet with link: true', () => {
+      sheet.detach()
       sheet = jss.createStyleSheet(null, {link: true}).attach()
       sheet.addRule('a', {float: 'left'})
-      expect(sheet.rules.index.length).to.equal(1)
-      expect(sheet.renderer.element.sheet.cssRules.length).to.equal(1)
       sheet.detach()
-
       sheet.addRule('b', {float: 'right'})
-      expect(sheet.rules.index.length).to.equal(2)
       sheet.attach()
-
-      expect(sheet.rules.index.length).to.equal(2)
-      expect(sheet.renderer.element.sheet.cssRules.length).to.equal(2)
+      style = getStyle()
+      expect(getCss(style)).to.be(removeWhitespace(sheet.toString()))
+      expect(getCss(style)).to.be('.a-id{float:left;}.b-id{float:right;}')
     })
   })
 

--- a/packages/jss/tests/functional/sheet.js
+++ b/packages/jss/tests/functional/sheet.js
@@ -255,6 +255,21 @@ describe('Functional: sheet', () => {
     it('should link sheet in rules options', () => {
       expect(sheet.getRule('a').options.sheet).to.be(sheet)
     })
+
+    it('should not duplicate cssRules when adding rules to a detached sheet with link: true', () => {
+      sheet = jss.createStyleSheet(null, {link: true}).attach()
+      sheet.addRule('a', {float: 'left'})
+      expect(sheet.rules.index.length).to.equal(1)
+      expect(sheet.renderer.element.sheet.cssRules.length).to.equal(1)
+      sheet.detach()
+
+      sheet.addRule('b', {float: 'right'})
+      expect(sheet.rules.index.length).to.equal(2)
+      sheet.attach()
+
+      expect(sheet.rules.index.length).to.equal(2)
+      expect(sheet.renderer.element.sheet.cssRules.length).to.equal(2)
+    })
   })
 
   describe('.addRule() with .addRule() call within a plugin and attached sheet', () => {

--- a/packages/react-jss/test-utils/createDynamicStylesTests.js
+++ b/packages/react-jss/test-utils/createDynamicStylesTests.js
@@ -277,6 +277,38 @@ export default ({createStyledComponent}) => {
       expect(passedProps.color).to.equal('rgb(255, 0, 0)')
       expect(passedProps.height).to.equal(20)
     })
+
+    it('should update dynamic values after attaching and detaching a sheet', () => {
+      // Reproduces cssinjs/jss#1187
+      const generateId = createGenerateId()
+      function Container({height, mounted}) {
+        return (
+          <JssProvider registry={registry} generateId={generateId}>
+            {mounted && <MyComponent height={height} />}
+          </JssProvider>
+        )
+      }
+
+      const renderer = TestRenderer.create(<Container height={10} mounted />)
+      expect(registry.registry[0].rules.index.length).to.equal(4)
+      expect(registry.registry[0].renderer.element.sheet.cssRules.length).to.equal(4)
+
+      expect(registry.registry.length).to.equal(1)
+      expect(registry.registry[0].attached).to.equal(true)
+
+      renderer.update(<Container height={10} mounted={false} />)
+      expect(registry.registry[0].attached).to.equal(false)
+
+      renderer.update(<Container height={10} mounted />)
+      expect(registry.registry.length).to.equal(1)
+      expect(registry.registry[0].attached).to.equal(true)
+      expect(registry.registry[0].rules.index.length).to.equal(4)
+      expect(registry.registry[0].renderer.element.sheet.cssRules.length).to.equal(4)
+
+      renderer.update(<Container height={20} mounted />)
+      expect(registry.registry[0].rules.index.length).to.equal(4)
+      expect(registry.registry[0].renderer.element.sheet.cssRules.length).to.equal(4)
+    })
   })
 
   describe('function rules', () => {

--- a/packages/react-jss/test-utils/createDynamicStylesTests.js
+++ b/packages/react-jss/test-utils/createDynamicStylesTests.js
@@ -277,38 +277,6 @@ export default ({createStyledComponent}) => {
       expect(passedProps.color).to.equal('rgb(255, 0, 0)')
       expect(passedProps.height).to.equal(20)
     })
-
-    it('should update dynamic values after attaching and detaching a sheet', () => {
-      // Reproduces cssinjs/jss#1187
-      const generateId = createGenerateId()
-      function Container({height, mounted}) {
-        return (
-          <JssProvider registry={registry} generateId={generateId}>
-            {mounted && <MyComponent height={height} />}
-          </JssProvider>
-        )
-      }
-
-      const renderer = TestRenderer.create(<Container height={10} mounted />)
-      expect(registry.registry[0].rules.index.length).to.equal(4)
-      expect(registry.registry[0].renderer.element.sheet.cssRules.length).to.equal(4)
-
-      expect(registry.registry.length).to.equal(1)
-      expect(registry.registry[0].attached).to.equal(true)
-
-      renderer.update(<Container height={10} mounted={false} />)
-      expect(registry.registry[0].attached).to.equal(false)
-
-      renderer.update(<Container height={10} mounted />)
-      expect(registry.registry.length).to.equal(1)
-      expect(registry.registry[0].attached).to.equal(true)
-      expect(registry.registry[0].rules.index.length).to.equal(4)
-      expect(registry.registry[0].renderer.element.sheet.cssRules.length).to.equal(4)
-
-      renderer.update(<Container height={20} mounted />)
-      expect(registry.registry[0].rules.index.length).to.equal(4)
-      expect(registry.registry[0].renderer.element.sheet.cssRules.length).to.equal(4)
-    })
   })
 
   describe('function rules', () => {


### PR DESCRIPTION
__What would you like to add/fix?__

Dynamic rules stop working after sheet re-attach via React component unmount/mount.

__Corresponding issue (if exists):__

cssinjs/jss#1187

__Details__

I’ve added a check in `DomRenderer` so that the `this.hasInsertedRules` workaround doesn’t force a redeploy if the sheet was going to redeploy too, by checking `this.sheet.deployed`.