### PR TITLE
Fix(withStyles): HOC return component with standard displayName

### DIFF
--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/react-jss.js": {
-    "bundled": 169391,
-    "minified": 58384,
+    "bundled": 169398,
+    "minified": 58389,
     "gzipped": 19101
   },
   "dist/react-jss.min.js": {
-    "bundled": 112715,
-    "minified": 41775,
+    "bundled": 112722,
+    "minified": 41780,
     "gzipped": 14178
   },
   "dist/react-jss.cjs.js": {
-    "bundled": 27041,
-    "minified": 11651,
-    "gzipped": 3862
+    "bundled": 27048,
+    "minified": 11656,
+    "gzipped": 3863
   },
   "dist/react-jss.esm.js": {
-    "bundled": 26079,
-    "minified": 10816,
-    "gzipped": 3740,
+    "bundled": 26086,
+    "minified": 10821,
+    "gzipped": 3741,
     "treeshaked": {
       "rollup": {
         "code": 1841,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,22 +1,22 @@
 {
   "dist/react-jss.js": {
-    "bundled": 169377,
-    "minified": 58382,
-    "gzipped": 19100
+    "bundled": 169391,
+    "minified": 58384,
+    "gzipped": 19101
   },
   "dist/react-jss.min.js": {
-    "bundled": 112701,
-    "minified": 41773,
-    "gzipped": 14177
+    "bundled": 112715,
+    "minified": 41775,
+    "gzipped": 14178
   },
   "dist/react-jss.cjs.js": {
-    "bundled": 27027,
-    "minified": 11649,
-    "gzipped": 3861
+    "bundled": 27041,
+    "minified": 11651,
+    "gzipped": 3862
   },
   "dist/react-jss.esm.js": {
-    "bundled": 26065,
-    "minified": 10814,
+    "bundled": 26079,
+    "minified": 10816,
     "gzipped": 3740,
     "treeshaked": {
       "rollup": {

--- a/packages/react-jss/src/withStyles.js
+++ b/packages/react-jss/src/withStyles.js
@@ -178,7 +178,7 @@ const withStyles = <Theme>(styles: Styles<Theme>, options?: HOCOptions<Theme> = 
       </JssContext.Consumer>
     ))
 
-    JssContextSubscriber.displayName = 'JssContextSubscriber'
+    JssContextSubscriber.displayName = `JssContextSubscriber${displayName}`
     // $FlowFixMe - React's types should allow custom static properties on component.
     JssContextSubscriber.InnerComponent = InnerComponent
 

--- a/packages/react-jss/src/withStyles.js
+++ b/packages/react-jss/src/withStyles.js
@@ -178,7 +178,7 @@ const withStyles = <Theme>(styles: Styles<Theme>, options?: HOCOptions<Theme> = 
       </JssContext.Consumer>
     ))
 
-    JssContextSubscriber.displayName = `JssContextSubscriber${displayName}`
+    JssContextSubscriber.displayName = `JssContextSubscriber(${displayName})`
     // $FlowFixMe - React's types should allow custom static properties on component.
     JssContextSubscriber.InnerComponent = InnerComponent
 


### PR DESCRIPTION
__What would you like to add/fix?__
react-jss withStyles HOC returns component that has non-conventional naming.
Each styled component had the displayName "JssContextSubscriber" that makes hard jest snapshot testing (shallow)

__Corresponding issue (if exists):__
#1211 

@HenriBeck Here is the possible solution I have mentioned before.