### PR TITLE
Fix: Cannot read property rules of undefined #1189

### DIFF
--- a/packages/jss/src/RuleList.js
+++ b/packages/jss/src/RuleList.js
@@ -180,7 +180,10 @@ export default class RuleList {
   /**
    * Execute plugins, update rule props.
    */
-  onUpdate(data: Object, rule: Rule, options?: Object = defaultUpdateOptions) {
+  onUpdate(data: Object, rule?: Rule, options?: Object = defaultUpdateOptions) {
+    // Should be undefined during hot-reloading
+    if (!rule) return
+
     const {
       jss: {plugins},
       sheet


### PR DESCRIPTION
## Corresponding issue (if exists):
https://github.com/cssinjs/jss/issues/1188

## What would you like to add/fix?
Prevent onUpdate execution when `rule` instance doesn't exist yet.

## Todo
- [ ] Add tests if possible
  - can't execute tests following `contributing.md` (seems outdated)
- [ ] Add changelog if users should know about the change
  - it's a simple bugfix
- [ ] Add documentation
  - it's a simple bugfix
 
