### PR TITLE
refactor createUseStyles to work with react-hot-loader

### DIFF
--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/react-jss.js": {
-    "bundled": 169853,
-    "minified": 58651,
-    "gzipped": 19195
+    "bundled": 168727,
+    "minified": 58230,
+    "gzipped": 19069
   },
   "dist/react-jss.min.js": {
-    "bundled": 113177,
-    "minified": 42042,
-    "gzipped": 14261
+    "bundled": 112051,
+    "minified": 41621,
+    "gzipped": 14141
   },
   "dist/react-jss.cjs.js": {
-    "bundled": 27048,
-    "minified": 11656,
-    "gzipped": 3863
+    "bundled": 25998,
+    "minified": 11164,
+    "gzipped": 3739
   },
   "dist/react-jss.esm.js": {
-    "bundled": 26086,
-    "minified": 10821,
-    "gzipped": 3741,
+    "bundled": 25036,
+    "minified": 10329,
+    "gzipped": 3619,
     "treeshaked": {
       "rollup": {
         "code": 1841,


### PR DESCRIPTION
`isFirstRender` is broken when using react-hot-loader, as it unmounts and remounts the components, but preserves hook state all the way through, including `isFirstRender`.

The `removeDynamicRules` hook runs first, and an error is thrown once `updateDynamicRules` runs as the rules have been removed.

With those changes everything should run in the proper order.