### PR TITLE
feat: export defaultJss and add createJss

### DIFF
--- a/packages/react-jss/src/index.js
+++ b/packages/react-jss/src/index.js
@@ -1,15 +1,16 @@
 // @flow
+import defaultJss from 'jss'
 import withStyles from './withStyles'
 
 export {ThemeProvider, withTheme, createTheming, useTheme} from 'theming'
 export {default as createUseStyles} from './createUseStyles'
 export {default as JssProvider} from './JssProvider'
-export {default as jss} from './jss'
+export {default as jss, createJss} from './jss'
 export {SheetsRegistry, createGenerateId} from 'jss'
 export {default as JssContext} from './JssContext'
 export {default as styled} from './styled'
 export {default as jsx, create as createJsx} from './jsx'
-export {withStyles}
+export {withStyles, defaultJss}
 
 // Kept for backwards compatibility.
 export default withStyles

--- a/packages/react-jss/src/jss.js
+++ b/packages/react-jss/src/jss.js
@@ -1,5 +1,12 @@
 // @flow
-import {create} from 'jss'
+import {create, type JssOptions} from 'jss'
 import preset from 'jss-preset-default'
+
+export const createJss = (options?: Partial<JssOptions>) => {
+  return create({
+    ...preset(),
+    ...(options || {})
+  })
+}
 
 export default create(preset())


### PR DESCRIPTION
## Corresponding issue (if exists):
1.why export `defaultJss`?

Sometimes, we need to use the type from jss, such as `import { StyleSheet, JssOptions } from 'jss'` 

But we cannot `npm install jss`, since it will brings two versions of jss (one from jss itself, one from react-jss's dependency)

The solution is to export the original jss to avoid two versions

2.why add `createJss`?

Sometime, we want to customize the `create(preset())`, such as `create({...preset(), createGenerateId})`, but the jss from react-jss/src/jss.js doesn't support.

So add a function named `createJss`, the usage is:
```
import { createJss } from 'react-jss';

// `createGenerateId` is a customize function to solve the 'Server-side rendering' problem within a component library, just like material design.
//  In which, we cannot use `<JssProvider generateId={generateId}><MyApp /></JssProvider>` solution.
const jss = createJss({
  createGenerateId
})
```

## What would you like to add/fix? Yes

## Todo

- [ ] Add tests if possible
- [ ] Add changelog if users should know about the change
- [ ] Add documentation
