### PR TITLE
Fixed compatibility issue with jss-plugin-rule-value-function

### DIFF
--- a/packages/jss-plugin-template/src/index.js
+++ b/packages/jss-plugin-template/src/index.js
@@ -9,6 +9,13 @@ const onProcessRule = rule => {
   }
 }
 
+const onProcessStyle = style => {
+    if (typeof style === 'string') {
+        return parse(style);
+    }
+    return style;
+}
+
 export default function templatePlugin(): Plugin {
-  return {onProcessRule}
+  return {onProcessRule, onProcessStyle}
 }


### PR DESCRIPTION
When using jss-plugin-template with a function rule, the style string would not be parsed.
Example:
```js
const styles = (props) => `
    background-color: ${props.bgColor};
`;
```

By also checking for a string value in onProcessStyle, this will work properly.