### PR TITLE
[react-jss] fixed ts typings for hook, created common interface for options

### DIFF
--- a/packages/react-jss/src/index.d.ts
+++ b/packages/react-jss/src/index.d.ts
@@ -45,16 +45,17 @@ interface WithStylesProps<S extends Styles | ((theme: unknown) => Styles)> {
  */
 type WithStyles<S extends Styles | ((theme: unknown) => Styles)> = WithStylesProps<S>
 
-interface WithStylesOptions extends StyleSheetFactoryOptions {
+interface BaseOptions extends StyleSheetFactoryOptions {
   index?: number
-  injectTheme?: boolean
-  jss?: Jss
   theming?: Theming<object>
 }
 
-type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
+interface WithStylesOptions extends BaseOptions {
+  injectTheme?: boolean
+  jss?: Jss
+}
 
-interface CreateUseStylesOptions extends StyleSheetFactoryOptions {
+interface CreateUseStylesOptions extends BaseOptions {
   name?: string
 }
 
@@ -83,6 +84,8 @@ declare function withStyles<
 >(
   comp: ComponentType<Props>
 ) => ComponentType<Omit<Props, 'classes'> & {classes?: Partial<Props['classes']>}>
+
+type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
 
 export {
   SheetsRegistry,


### PR DESCRIPTION
## What would you like to add/fix?
Fix

## Description
TS-error in this case:
```ts
import React from 'react'
import { createUseStyles } from 'react-jss'
import { createTheming } from 'theming'

const context = React.createContext({})
const theming = createTheming(context)

const styles = {
  container: {
    backgroundColor: 'green'
  }
}
const useWithoutThemeStyles = createUseStyles(styles, { theming })

export { useWithoutThemeStyles }
```
Error:
```
Argument of type '{ theming: Theming<{}>; }' is not assignable to parameter of type 'CreateUseStylesOptions'.
  Object literal may only specify known properties, and 'theming' does not exist in type 'CreateUseStylesOptions'.
```
