### PR TITLE
Fix when declaring multiple @font-face

### DIFF
--- a/packages/jss/.size-snapshot.json
+++ b/packages/jss/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "dist/jss.js": {
-    "bundled": 61836,
-    "minified": 22817,
-    "gzipped": 6879
+    "bundled": 61880,
+    "minified": 22840,
+    "gzipped": 6887
   },
   "dist/jss.min.js": {
-    "bundled": 60459,
-    "minified": 22048,
-    "gzipped": 6519
+    "bundled": 60503,
+    "minified": 22072,
+    "gzipped": 6529
   },
   "dist/jss.cjs.js": {
-    "bundled": 56577,
-    "minified": 24717,
-    "gzipped": 6872
+    "bundled": 56619,
+    "minified": 24757,
+    "gzipped": 6882
   },
   "dist/jss.esm.js": {
-    "bundled": 56045,
-    "minified": 24282,
-    "gzipped": 6782,
+    "bundled": 56087,
+    "minified": 24322,
+    "gzipped": 6791,
     "treeshaked": {
       "rollup": {
-        "code": 20045,
+        "code": 20067,
         "import_statements": 352
       },
       "webpack": {
-        "code": 21512
+        "code": 21534
       }
     }
   }

--- a/packages/jss/src/plugins/fontFaceRule.js
+++ b/packages/jss/src/plugins/fontFaceRule.js
@@ -40,8 +40,10 @@ export class FontFaceRule implements BaseRule {
   }
 }
 
+const keyRegExp = /@font-face/
+
 export default {
   onCreateRule(key: string, style: JssStyle, options: RuleOptions): FontFaceRule | null {
-    return key === '@font-face' ? new FontFaceRule(key, style, options) : null
+    return keyRegExp.test(key) ? new FontFaceRule('@font-face', style, options) : null
   }
 }

--- a/packages/jss/tests/integration/rules.js
+++ b/packages/jss/tests/integration/rules.js
@@ -274,7 +274,7 @@ describe('Integration: rules', () => {
         `)
       }
 
-      function checkMulti(options) {
+      function checkArray(options) {
         const rule = jss.createRule(
           '@font-face',
           [
@@ -303,11 +303,37 @@ describe('Integration: rules', () => {
         `)
       }
 
+      function checkMulti() {
+        const sheet = jss.createStyleSheet()
+        sheet.addRule('@font-face', {
+          'font-family': 'MyHelvetica',
+          src: 'local("Helvetica")'
+        })
+        sheet.addRule('@font-face', {
+          'font-family': 'MyComicSans',
+          src: 'local("ComicSans")'
+        })
+        expect(sheet.toString()).to.be(stripIndent`
+          @font-face {
+            font-family: MyHelvetica;
+            src: local("Helvetica");
+          }
+          @font-face {
+            font-family: MyComicSans;
+            src: local("ComicSans");
+          }
+        `)
+      }
+
       it('should return CSS', () => {
         checkSingle()
       })
 
-      it('should handle multiple font-faces', () => {
+      it('should handle when @font-face is an array', () => {
+        checkArray()
+      })
+
+      it('should handle multiple @font-face', () => {
         checkMulti()
       })
     })


### PR DESCRIPTION
## Corresponding issue (if exists):
#1262 

## What would you like to add/fix?
When adding multiple `@font-face` the key passed to `FontFaceRule` after the first entry follows the pattern: `@font-face-dX`. This was causing the 2nd rule to be ignored since this is not a valid CSS declaration. My solution checks if the key starts with `@font-face`.

## Todo

- [x] Add tests if possible
- [ ] Add changelog if users should know about the change
- [ ] Add documentation
