### PR TITLE
Allow a Comment node as insertion point

### DIFF
--- a/packages/jss/src/index.d.ts
+++ b/packages/jss/src/index.d.ts
@@ -34,7 +34,7 @@ export type JssValue =
   | null
   | false
 
-export type InsertionPoint = string | HTMLElement
+export type InsertionPoint = string | HTMLElement | Comment
 
 export interface UpdateOptions {
   process?: boolean


### PR DESCRIPTION
## Corresponding issue (if exists):

--

## What would you like to add/fix?

The `InsertionPoint` typings only allow `string`s and `HTMLElement`s. The following code currently results in a type error, but works fine:

```ts
import { create } from "jss";

const comment = document.createComment("hi");
// ... add comment to the DOM ...

const jss = create({ insertionPoint: comment });
```

## Todo

- [ ] Add tests if possible
- [ ] Add changelog if users should know about the change
- [ ] Add documentation

^- Not sure if any of them are needed for this PR.