### PR TITLE
typescript support for createUseStyles theme

### DIFF
--- a/packages/react-jss/src/index.d.ts
+++ b/packages/react-jss/src/index.d.ts
@@ -58,8 +58,10 @@ interface WithStylesOptions extends BaseOptions {
 interface CreateUseStylesOptions extends BaseOptions {
   name?: string
 }
-
-declare function createUseStyles<Theme extends object, C extends string = string>(
+                   
+export interface DefaultTheme {}
+                   
+declare function createUseStyles<Theme = DefaultTheme, C extends string = string>(
   styles: Record<C, any> | ((theme: Theme) => Record<C, any>),
   options?: CreateUseStylesOptions
 ): (data?: unknown) => Classes<C>


### PR DESCRIPTION
## Corresponding issue (if exists):

## What would you like to add/fix?

Let createUseStyles have the default theme type. Like this:
![image](https://user-images.githubusercontent.com/7029338/75950517-4a5cd480-5f0e-11ea-90b4-b0d1883041a8.png)

Just add this to your project to work
```typescript
declare module 'react-jss' {
  interface DefaultTheme {
    ...
  }
}
```
## Todo

- [ ] Add tests if possible
- [ ] Add changelog if users should know about the change
- [ ] Add documentation
