### PR TITLE
Fix generateId ignored by JssProvider when there is an id prop (#1297)

### DIFF
--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "dist/react-jss.js": {
-    "bundled": 169027,
-    "minified": 58353,
+    "bundled": 169023,
+    "minified": 58350,
     "gzipped": 19101
   },
   "dist/react-jss.min.js": {
-    "bundled": 112062,
-    "minified": 41612,
+    "bundled": 112058,
+    "minified": 41609,
     "gzipped": 14132
   },
   "dist/react-jss.cjs.js": {
-    "bundled": 25875,
-    "minified": 11133,
+    "bundled": 25873,
+    "minified": 11130,
     "gzipped": 3722
   },
   "dist/react-jss.esm.js": {
-    "bundled": 24913,
-    "minified": 10298,
+    "bundled": 24911,
+    "minified": 10295,
     "gzipped": 3600,
     "treeshaked": {
       "rollup": {
-        "code": 1841,
+        "code": 1838,
         "import_statements": 538
       },
       "webpack": {
-        "code": 3439
+        "code": 3436
       }
     }
   }

--- a/packages/react-jss/src/JssProvider.js
+++ b/packages/react-jss/src/JssProvider.js
@@ -74,9 +74,7 @@ export default class JssProvider extends Component<Props> {
 
     if (generateId !== undefined) {
       context.generateId = generateId
-    }
-
-    if (!context.generateId || !prevContext || context.id !== prevContext.id) {
+    } else if (!context.generateId || !prevContext || context.id !== prevContext.id) {
       context.generateId = createGenerateId(context.id)
     }
 

--- a/packages/react-jss/src/JssProvider.test.js
+++ b/packages/react-jss/src/JssProvider.test.js
@@ -363,4 +363,26 @@ describe('React-JSS: JssProvider', () => {
       expect(result1.length > 0).to.be(true)
     })
   })
+
+  describe('with id prop', () => {
+    describe('generateId prop', () => {
+      it('should forward from context', () => {
+        const generateId = () => 'a'
+        const id = {minify: true}
+        const MyComponent = withStyles({a: {color: 'red'}})()
+
+        TestRenderer.create(
+          <JssProvider registry={registry} generateId={generateId} id={id}>
+            <MyComponent />
+          </JssProvider>
+        )
+
+        expect(registry.toString()).to.be(stripIndent`
+          .a {
+            color: red;
+          }
+        `)
+      })
+    })
+  })
 })


### PR DESCRIPTION
## Corresponding issue (if exists):
#1297 

## What would you like to add/fix?
Avoid overwriting custom `generateId` when there is also an `id` prop.

## Todo

- [x] Add tests if possible
- [ ] Add changelog if users should know about the change
- [ ] Add documentation
