### PR TITLE
TypeScript fixes for #1308 and #1309

### DIFF
--- a/packages/react-jss/src/index.d.ts
+++ b/packages/react-jss/src/index.d.ts
@@ -45,9 +45,11 @@ interface WithStylesProps<S extends Styles | ((theme: unknown) => Styles)> {
  */
 type WithStyles<S extends Styles | ((theme: unknown) => Styles)> = WithStylesProps<S>
 
-interface BaseOptions extends StyleSheetFactoryOptions {
+export interface DefaultTheme {}
+
+interface BaseOptions<Theme = DefaultTheme> extends StyleSheetFactoryOptions {
   index?: number
-  theming?: Theming<object>
+  theming?: Theming<Theme>
 }
 
 interface WithStylesOptions extends BaseOptions {
@@ -55,15 +57,13 @@ interface WithStylesOptions extends BaseOptions {
   jss?: Jss
 }
 
-interface CreateUseStylesOptions extends BaseOptions {
+interface CreateUseStylesOptions<Theme = DefaultTheme> extends BaseOptions<Theme> {
   name?: string
 }
 
-export interface DefaultTheme {}
-
 declare function createUseStyles<Theme = DefaultTheme, C extends string = string>(
   styles: Record<C, any> | ((theme: Theme) => Record<C, any>),
-  options?: CreateUseStylesOptions
+  options?: CreateUseStylesOptions<Theme>
 ): (data?: unknown) => Classes<C>
 
 declare function withStyles<
@@ -93,6 +93,7 @@ export {
   ThemeProvider,
   withTheme,
   createTheming,
+  Theming,
   useTheme,
   JssContext,
   createUseStyles,


### PR DESCRIPTION
## Corresponding issue (if exists):

#1308
#1309

## What would you like to add/fix?

This PR changes the type definition of `createUseStyles<Theme>(styles, options?: CreateUseStyles)` so it passes the `Theme` type parameters to the options type: `createUseStyles<Theme>(styles, options?: CreateUseStyles<Theme>)`.

It also re-exports the `Theming` type, so users of `createTheming` can do explicit typing of the result: `const theming : Theming = createTheming(...` without having to add the `theming` package to the direct dependencies.

## Todo

- [ ] Add tests if possible
- [ ] Add changelog if users should know about the change
- [ ] Add documentation
