### PR TITLE
add styled to type exports in 'react-jss'

### DIFF
--- a/packages/react-jss/src/index.d.ts
+++ b/packages/react-jss/src/index.d.ts
@@ -10,6 +10,7 @@ import {
   Classes
 } from 'jss'
 import {createTheming, useTheme, withTheme, ThemeProvider, Theming} from 'theming'
+import {styled} from './styled'
 
 declare const jss: Jss
 
@@ -97,7 +98,8 @@ export {
   useTheme,
   JssContext,
   createUseStyles,
-  Styles
+  Styles,
+  styled
 }
 
 export default withStyles


### PR DESCRIPTION
for some reason, react-jss's index.d.ts does not export the styled function. these 2 lines of code fix that (only changed react-jss/index.d.ts , NOT the index.js file)