### PR TITLE
add tiny-warning to deps

### DIFF
--- a/packages/jss-plugin-rule-value-function/package.json
+++ b/packages/jss-plugin-rule-value-function/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",
-    "jss": "10.1.1"
+    "jss": "10.1.1",
+    "tiny-warning": "^1.0.2"
   }
 }


### PR DESCRIPTION
## Corresponding issue (if exists): #1313

## What would you like to add/fix? add tiny-warning to deps for jss-plugin-rule-value-function to avoid yarn PnP errors

## Todo

- [ ] Add tests if possible
- [ ] Add changelog if users should know about the change
- [ ] Add documentation
