### PR TITLE
Convert plugin examples to codesandbox

### DIFF
--- a/docs/jss-plugin-camel-case.md
+++ b/docs/jss-plugin-camel-case.md
@@ -19,3 +19,7 @@ Compiles to:
   font-size: 12px;
 }
 ```
+
+### Demo
+
+[CodeSandbox](//codesandbox.io/s/github/cssinjs/jss/tree/master/examples/plugins/jss-plugin-camel-case?fontsize=14)

--- a/docs/jss-plugin-compose.md
+++ b/docs/jss-plugin-compose.md
@@ -179,3 +179,7 @@ It renders to:
 - It doesn't work within [global Style Sheets](https://github.com/cssinjs/jss/tree/master/packages/jss-plugin-global).
 - It does not work inside of [nested rules](https://github.com/cssinjs/jss/tree/master/packages/jss-plugin-nested).
 - When composing local rules, they need to be defined first. Otherwise, you get wrong CSS selector order and specificity.
+
+### Demo
+
+[CodeSandbox](//codesandbox.io/s/github/cssinjs/jss/tree/master/examples/plugins/jss-plugin-compose?fontsize=14)

--- a/docs/jss-plugin-default-unit.md
+++ b/docs/jss-plugin-default-unit.md
@@ -60,3 +60,7 @@ Compiles to:
   z-index: 1;
 }
 ```
+
+### Demo
+
+[CodeSandbox](//codesandbox.io/s/github/cssinjs/jss/tree/master/examples/plugins/jss-plugin-default-unit?fontsize=14)

--- a/docs/jss-plugin-expand.md
+++ b/docs/jss-plugin-expand.md
@@ -400,3 +400,7 @@ const styles = {
   }
 }
 ```
+
+### Demo
+
+[CodeSandbox](//codesandbox.io/s/github/cssinjs/jss/tree/master/examples/plugins/jss-plugin-expand?fontsize=14)

--- a/docs/jss-plugin-extend.md
+++ b/docs/jss-plugin-extend.md
@@ -76,5 +76,4 @@ const styles = {
 
 ### Demo
 
-[Simple demo](http://cssinjs.github.io/examples/plugins/jss-extend/simple/)
-[Multi objects demo](http://cssinjs.github.io/examples/plugins/jss-extend/multi/)
+[CodeSandbox](//codesandbox.io/s/github/cssinjs/jss/tree/master/examples/plugins/jss-plugin-extend?fontsize=14)

--- a/docs/jss-plugin-global.md
+++ b/docs/jss-plugin-global.md
@@ -73,3 +73,7 @@ Compiles to:
   color: red;
 }
 ```
+
+### Demo
+
+[CodeSandbox](//codesandbox.io/s/github/cssinjs/jss/tree/master/examples/plugins/jss-plugin-global?fontsize=14)

--- a/docs/jss-plugin-isolate.md
+++ b/docs/jss-plugin-isolate.md
@@ -183,7 +183,7 @@ jss.use(
 
 ### Demo
 
-[Simple](http://cssinjs.github.io/examples/plugins/jss-plugin-isolate/simple/index.html)
+[CodeSandbox](//codesandbox.io/s/github/cssinjs/jss/tree/master/examples/plugins/jss-plugin-isolate?fontsize=14)
 
 ### Reseted properties
 

--- a/docs/jss-plugin-nested.md
+++ b/docs/jss-plugin-nested.md
@@ -142,3 +142,7 @@ Compiles to:
   background: red;
 }
 ```
+
+### Demo
+
+[CodeSandbox](//codesandbox.io/s/github/cssinjs/jss/tree/master/examples/plugins/jss-plugin-nested?fontsize=14)

--- a/docs/jss-plugin-props-sort.md
+++ b/docs/jss-plugin-props-sort.md
@@ -19,3 +19,7 @@ Compiles to:
   border-left: 1px solid red;
 }
 ```
+
+### Demo
+
+[CodeSandbox](//codesandbox.io/s/github/cssinjs/jss/tree/master/examples/plugins/jss-plugin-props-sort?fontsize=14)

--- a/docs/jss-plugin-rule-value-function.md
+++ b/docs/jss-plugin-rule-value-function.md
@@ -66,3 +66,7 @@ const sheet = jss
 
 sheet.update({color: 'red'})
 ```
+
+### Demo
+
+[CodeSandbox](//codesandbox.io/s/github/cssinjs/jss/tree/master/examples/plugins/jss-plugin-rule-value-function?fontsize=14)

--- a/docs/jss-plugin-rule-value-observable.md
+++ b/docs/jss-plugin-rule-value-observable.md
@@ -71,3 +71,7 @@ jss.setup(
   })
 )
 ```
+
+### Demo
+
+[CodeSandbox](//codesandbox.io/s/github/cssinjs/jss/tree/master/examples/plugins/jss-plugin-rule-value-observable?fontsize=14)

--- a/docs/jss-plugin-template.md
+++ b/docs/jss-plugin-template.md
@@ -24,3 +24,7 @@ const styles = {
   }
 }
 ```
+
+### Demo
+
+[CodeSandbox](//codesandbox.io/s/github/cssinjs/jss/tree/master/examples/plugins/jss-plugin-template?fontsize=14)

--- a/docs/jss-plugin-vendor-prefixer.md
+++ b/docs/jss-plugin-vendor-prefixer.md
@@ -19,3 +19,7 @@ Compiles to:
   transform: -webkit-translateX(100px);
 }
 ```
+
+### Demo
+
+[CodeSandbox](//codesandbox.io/s/github/cssinjs/jss/tree/master/examples/plugins/jss-plugin-vendor-prefixer?fontsize=14)

--- a/examples/plugins/jss-plugin-camel-case/app.js
+++ b/examples/plugins/jss-plugin-camel-case/app.js
@@ -1,0 +1,18 @@
+import jss from 'jss'
+import jssPluginCamelCase from 'jss-plugin-camel-case'
+
+const styles = {
+  button: {
+    fontSize: '50px',
+    zIndex: 1,
+    lineHeight: 1.2
+  }
+}
+
+// JSS Setup
+jss.use(jssPluginCamelCase())
+const {classes} = jss.createStyleSheet(styles).attach()
+
+// Application logic.
+const div = document.body.appendChild(document.createElement('div'))
+div.innerHTML = `<button class="${classes.button}">Button</button>`

--- a/examples/plugins/jss-plugin-camel-case/index.html
+++ b/examples/plugins/jss-plugin-camel-case/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Example - jss-plugin-camel-case</title>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/examples/plugins/jss-plugin-camel-case/package.json
+++ b/examples/plugins/jss-plugin-camel-case/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "jss-plugin-camel-case-example",
+  "license": "ISC",
+  "dependencies": {
+    "jss": "^10.0.3",
+    "jss-plugin-camel-case": "10.1.1"
+  },
+  "devDependencies": {
+    "parcel-bundler": "^1.6.1"
+  }
+}

--- a/examples/plugins/jss-plugin-compose/app.js
+++ b/examples/plugins/jss-plugin-compose/app.js
@@ -1,0 +1,29 @@
+import jss from 'jss'
+import jssPluginCompose from 'jss-plugin-compose'
+
+const styles = {
+  button: {
+    composes: 'btn btn-primary',
+    color: 'red'
+  },
+  buttonActive: {
+    composes: ['btn', 'btn-primary'],
+    color: 'blue'
+  },
+  buttonActiveDisabled: {
+    composes: '$buttonActive',
+    opacity: 0.5
+  }
+}
+
+// JSS Setup
+jss.use(jssPluginCompose())
+const {classes} = jss.createStyleSheet(styles).attach()
+
+// Application logic.
+const div = document.body.appendChild(document.createElement('div'))
+div.innerHTML = `
+  <button class="${classes.button}">Button</button>
+  <button class="${classes.buttonActive}">Active Button</button>
+  <button class="${classes.buttonActiveDisabled}">Disabled Active Button</button>
+`

--- a/examples/plugins/jss-plugin-compose/index.html
+++ b/examples/plugins/jss-plugin-compose/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Example - jss-plugin-compose</title>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/examples/plugins/jss-plugin-compose/package.json
+++ b/examples/plugins/jss-plugin-compose/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "jss-plugin-compose-example",
+  "license": "ISC",
+  "dependencies": {
+    "jss": "^10.0.3",
+    "jss-plugin-compose": "10.1.1"
+  },
+  "devDependencies": {
+    "parcel-bundler": "^1.6.1"
+  }
+}

--- a/examples/plugins/jss-plugin-default-unit/app.js
+++ b/examples/plugins/jss-plugin-default-unit/app.js
@@ -1,0 +1,18 @@
+import jss from 'jss'
+import jssPluginDefaultUnit from 'jss-plugin-default-unit'
+
+const styles = {
+  button: {
+    'font-size': 2,
+    'z-index': 1,
+    'line-height': 2
+  }
+}
+
+// JSS Setup
+jss.use(jssPluginDefaultUnit())
+const {classes} = jss.createStyleSheet(styles).attach()
+
+// Application logic.
+const div = document.body.appendChild(document.createElement('div'))
+div.innerHTML = `<button class="${classes.button}">Button</button>`

--- a/examples/plugins/jss-plugin-default-unit/app.js
+++ b/examples/plugins/jss-plugin-default-unit/app.js
@@ -3,7 +3,7 @@ import jssPluginDefaultUnit from 'jss-plugin-default-unit'
 
 const styles = {
   button: {
-    'font-size': 2,
+    'font-size': 20,
     'z-index': 1,
     'line-height': 2
   }

--- a/examples/plugins/jss-plugin-default-unit/index.html
+++ b/examples/plugins/jss-plugin-default-unit/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Example - jss-plugin-default-unit</title>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/examples/plugins/jss-plugin-default-unit/package.json
+++ b/examples/plugins/jss-plugin-default-unit/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "jss-plugin-default-unit-example",
+  "license": "ISC",
+  "dependencies": {
+    "jss": "^10.0.3",
+    "jss-plugin-default-unit": "10.1.1"
+  },
+  "devDependencies": {
+    "parcel-bundler": "^1.6.1"
+  }
+}

--- a/examples/plugins/jss-plugin-expand/app.js
+++ b/examples/plugins/jss-plugin-expand/app.js
@@ -1,0 +1,20 @@
+import jss from 'jss'
+import jssPluginExpand from 'jss-plugin-expand'
+
+const styles = {
+  button: {
+    border: {
+      color: 'black',
+      width: 1,
+      style: 'solid'
+    }
+  }
+}
+
+// JSS Setup
+jss.use(jssPluginExpand())
+const {classes} = jss.createStyleSheet(styles).attach()
+
+// Application logic.
+const div = document.body.appendChild(document.createElement('div'))
+div.innerHTML = `<button class="${classes.button}">Button</button>`

--- a/examples/plugins/jss-plugin-expand/index.html
+++ b/examples/plugins/jss-plugin-expand/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Example - jss-plugin-expand</title>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/examples/plugins/jss-plugin-expand/package.json
+++ b/examples/plugins/jss-plugin-expand/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "jss-plugin-expand-example",
+  "license": "ISC",
+  "dependencies": {
+    "jss": "^10.0.3",
+    "jss-plugin-expand": "10.1.1"
+  },
+  "devDependencies": {
+    "parcel-bundler": "^1.6.1"
+  }
+}

--- a/examples/plugins/jss-plugin-extend/app.js
+++ b/examples/plugins/jss-plugin-extend/app.js
@@ -1,0 +1,30 @@
+import jss from 'jss'
+import jssPluginExtend from 'jss-plugin-extend'
+
+const button0 = {
+  padding: '20px',
+  background: 'blue'
+}
+
+const redButton = {
+  background: 'red'
+}
+
+const styles = {
+  button0,
+  button1: {
+    extend: [button0, redButton],
+    'font-size': '20px'
+  }
+}
+
+// JSS Setup
+jss.use(jssPluginExtend())
+const {classes} = jss.createStyleSheet(styles).attach()
+
+// Application logic.
+const div = document.body.appendChild(document.createElement('div'))
+div.innerHTML = `\
+  <button class="${classes.button0}">Button 1</button>\
+  <button class="${classes.button1}">Button 2</button>\
+`

--- a/examples/plugins/jss-plugin-extend/index.html
+++ b/examples/plugins/jss-plugin-extend/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Example - jss-plugin-extend</title>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/examples/plugins/jss-plugin-extend/package.json
+++ b/examples/plugins/jss-plugin-extend/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "jss-plugin-extend-example",
+  "license": "ISC",
+  "dependencies": {
+    "jss": "^10.0.3",
+    "jss-plugin-extend": "10.1.1"
+  },
+  "devDependencies": {
+    "parcel-bundler": "^1.6.1"
+  }
+}

--- a/examples/plugins/jss-plugin-global/app.js
+++ b/examples/plugins/jss-plugin-global/app.js
@@ -1,0 +1,21 @@
+import jss from 'jss'
+import jssPluginGlobal from 'jss-plugin-global'
+
+const styles = {
+  '@global': {
+    body: {
+      background: 'green'
+    },
+    button: {
+      background: 'yellow'
+    }
+  }
+}
+
+// JSS Setup
+jss.use(jssPluginGlobal())
+jss.createStyleSheet(styles).attach()
+
+// Application logic.
+const div = document.body.appendChild(document.createElement('div'))
+div.innerHTML = `<button>Button</button>`

--- a/examples/plugins/jss-plugin-global/index.html
+++ b/examples/plugins/jss-plugin-global/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Example - jss-plugin-global</title>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/examples/plugins/jss-plugin-global/package.json
+++ b/examples/plugins/jss-plugin-global/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "jss-plugin-global-example",
+  "license": "ISC",
+  "dependencies": {
+    "jss": "^10.0.3",
+    "jss-plugin-global": "10.1.1"
+  },
+  "devDependencies": {
+    "parcel-bundler": "^1.6.1"
+  }
+}

--- a/examples/plugins/jss-plugin-isolate/app.js
+++ b/examples/plugins/jss-plugin-isolate/app.js
@@ -1,0 +1,20 @@
+import jss from 'jss'
+import jssPluginIsolate from 'jss-plugin-isolate'
+
+const styles = {
+  button: {
+    'background-color': '#50ee50',
+    color: '#fff',
+    'border-radius': '3px',
+    padding: '10px 20px',
+    'font-family': 'sans-serif'
+  }
+}
+
+// JSS Setup
+jss.use(jssPluginIsolate())
+const {classes} = jss.createStyleSheet(styles).attach()
+
+// Application logic.
+const div = document.body.appendChild(document.createElement('div'))
+div.innerHTML = `<button class="${classes.button}">Button</button>`

--- a/examples/plugins/jss-plugin-isolate/index.html
+++ b/examples/plugins/jss-plugin-isolate/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Example - jss-plugin-isolate</title>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/examples/plugins/jss-plugin-isolate/package.json
+++ b/examples/plugins/jss-plugin-isolate/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "jss-plugin-isolate-example",
+  "license": "ISC",
+  "dependencies": {
+    "jss": "^10.0.3",
+    "jss-plugin-isolate": "10.1.1"
+  },
+  "devDependencies": {
+    "parcel-bundler": "^1.6.1"
+  }
+}

--- a/examples/plugins/jss-plugin-nested/app.js
+++ b/examples/plugins/jss-plugin-nested/app.js
@@ -1,0 +1,26 @@
+import jss from 'jss'
+import jssPluginNested from 'jss-plugin-nested'
+
+const styles = {
+  square: {
+    float: 'left',
+    width: '100px',
+    height: '100px',
+    '&:hover': {
+      background: 'yellow'
+    },
+    // Use whatever selector you want.
+    '& button': {
+      padding: '20px',
+      background: 'blue'
+    }
+  }
+}
+
+// JSS Setup
+jss.use(jssPluginNested())
+const {classes} = jss.createStyleSheet(styles).attach()
+
+// Application logic.
+const div = document.body.appendChild(document.createElement('div'))
+div.innerHTML = `<button class="${classes.square}">Button</button>`

--- a/examples/plugins/jss-plugin-nested/app.js
+++ b/examples/plugins/jss-plugin-nested/app.js
@@ -6,6 +6,7 @@ const styles = {
     float: 'left',
     width: '100px',
     height: '100px',
+    background: 'red',
     '&:hover': {
       background: 'yellow'
     },
@@ -23,4 +24,4 @@ const {classes} = jss.createStyleSheet(styles).attach()
 
 // Application logic.
 const div = document.body.appendChild(document.createElement('div'))
-div.innerHTML = `<button class="${classes.square}">Button</button>`
+div.innerHTML = `<div class="${classes.square}"><button>Button</button></div>`

--- a/examples/plugins/jss-plugin-nested/index.html
+++ b/examples/plugins/jss-plugin-nested/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Example - jss-plugin-nested</title>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/examples/plugins/jss-plugin-nested/package.json
+++ b/examples/plugins/jss-plugin-nested/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "jss-plugin-nested-example",
+  "license": "ISC",
+  "dependencies": {
+    "jss": "^10.0.3",
+    "jss-plugin-nested": "10.1.1"
+  },
+  "devDependencies": {
+    "parcel-bundler": "^1.6.1"
+  }
+}

--- a/examples/plugins/jss-plugin-props-sort/app.js
+++ b/examples/plugins/jss-plugin-props-sort/app.js
@@ -1,5 +1,5 @@
 import jss from 'jss'
-import jssPluginPropsSort from 'jss-plugins-props-sort'
+import jssPluginPropsSort from 'jss-plugin-props-sort'
 
 // Styles
 const styles = {

--- a/examples/plugins/jss-plugin-props-sort/app.js
+++ b/examples/plugins/jss-plugin-props-sort/app.js
@@ -1,0 +1,18 @@
+import jss from 'jss'
+import jssPluginPropsSort from 'jss-plugins-props-sort'
+
+// Styles
+const styles = {
+  button: {
+    'border-left': '3px solid red',
+    border: '3px solid green'
+  }
+}
+
+// JSS Setup
+jss.use(jssPluginPropsSort())
+const {classes} = jss.createStyleSheet(styles).attach()
+
+// Application logic.
+const div = document.body.appendChild(document.createElement('div'))
+div.innerHTML = `<button class="${classes.button}">Button</button>`

--- a/examples/plugins/jss-plugin-props-sort/index.html
+++ b/examples/plugins/jss-plugin-props-sort/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Example - jss-plugin-props-sort</title>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/examples/plugins/jss-plugin-props-sort/package.json
+++ b/examples/plugins/jss-plugin-props-sort/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "jss-plugin-props-sort-example",
+  "license": "ISC",
+  "dependencies": {
+    "jss": "^10.0.3",
+    "jss-plugin-props-sort": "10.1.1"
+  },
+  "devDependencies": {
+    "parcel-bundler": "^1.6.1"
+  }
+}

--- a/examples/plugins/jss-plugin-rule-value-function/app.js
+++ b/examples/plugins/jss-plugin-rule-value-function/app.js
@@ -1,0 +1,18 @@
+import jss from 'jss'
+import jssPluginRuleValueFunction from 'jss-plugin-rule-value-function'
+
+const styles = {
+  button: {
+    color: data => data.color
+  }
+}
+
+// JSS Setup
+jss.use(jssPluginRuleValueFunction())
+const sheet = jss.createStyleSheet(styles, {link: true}).attach()
+
+sheet.update({color: 'red'})
+
+// Application logic.
+const div = document.body.appendChild(document.createElement('div'))
+div.innerHTML = `<button class="${sheet.classes.button}">Button</button>`

--- a/examples/plugins/jss-plugin-rule-value-function/index.html
+++ b/examples/plugins/jss-plugin-rule-value-function/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Example - jss-plugin-rule-value-function</title>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/examples/plugins/jss-plugin-rule-value-function/package.json
+++ b/examples/plugins/jss-plugin-rule-value-function/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "jss-plugin-rule-value-function-example",
+  "license": "ISC",
+  "dependencies": {
+    "jss": "^10.0.3",
+    "jss-plugin-rule-value-function": "10.1.1"
+  },
+  "devDependencies": {
+    "parcel-bundler": "^1.6.1"
+  }
+}

--- a/examples/plugins/jss-plugin-rule-value-observable/app.js
+++ b/examples/plugins/jss-plugin-rule-value-observable/app.js
@@ -1,0 +1,19 @@
+import jss from 'jss'
+import {Observable} from 'rxjs'
+import jssPluginRuleValueObservable from 'jss-plugin-rule-value-observable'
+
+const styles = {
+  button: {
+    color: new Observable(observer => {
+      observer.next('red')
+    })
+  }
+}
+
+// JSS Setup
+jss.use(jssPluginRuleValueObservable())
+const {classes} = jss.createStyleSheet(styles, {link: true}).attach()
+
+// Application logic.
+const div = document.body.appendChild(document.createElement('div'))
+div.innerHTML = `<button class="${classes.button}">Button</button>`

--- a/examples/plugins/jss-plugin-rule-value-observable/index.html
+++ b/examples/plugins/jss-plugin-rule-value-observable/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Example - jss-plugin-rule-value-observable</title>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/examples/plugins/jss-plugin-rule-value-observable/package.json
+++ b/examples/plugins/jss-plugin-rule-value-observable/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "jss-plugin-rule-value-observable-example",
+  "license": "ISC",
+  "dependencies": {
+    "jss": "^10.0.3",
+    "jss-plugin-rule-value-observable": "10.1.1",
+    "rxjs": "6.5.4"
+  },
+  "devDependencies": {
+    "parcel-bundler": "^1.6.1"
+  }
+}

--- a/examples/plugins/jss-plugin-template/app.js
+++ b/examples/plugins/jss-plugin-template/app.js
@@ -1,0 +1,29 @@
+import jss from 'jss'
+import jssPluginTemplate from 'jss-plugin-template'
+
+// Styles
+const styles = {
+  '@keyframes rotate': {
+    from: `transform: rotateZ(0deg)`,
+    to: `transform: rotateZ(360deg)`
+  },
+  button: `
+    border-radius: 3px;
+    background-color: green;
+    color: red;
+    margin: 20px 40px;
+    padding: 10px;
+    animation: $rotate 2s linear infinite;
+  `,
+  '@media print': {
+    button: `color: black`
+  }
+}
+
+// JSS Setup
+jss.use(jssPluginTemplate())
+const {classes} = jss.createStyleSheet(styles).attach()
+
+// Application logic.
+const div = document.body.appendChild(document.createElement('div'))
+div.innerHTML = `<button class="${classes.button}">Button</button>`

--- a/examples/plugins/jss-plugin-template/index.html
+++ b/examples/plugins/jss-plugin-template/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Example - jss-plugin-template</title>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/examples/plugins/jss-plugin-template/package.json
+++ b/examples/plugins/jss-plugin-template/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "jss-plugin-template-example",
+  "license": "ISC",
+  "dependencies": {
+    "jss": "^10.0.3",
+    "jss-plugin-template": "10.1.1"
+  },
+  "devDependencies": {
+    "parcel-bundler": "^1.6.1"
+  }
+}

--- a/examples/plugins/jss-plugin-vendor-prefixer/app.js
+++ b/examples/plugins/jss-plugin-vendor-prefixer/app.js
@@ -1,0 +1,16 @@
+import jss from 'jss'
+import jssPluginVendorPrefixer from 'jss-plugin-vendor-prefixer'
+
+const styles = {
+  button: {
+    transform: 'translateX(100px)'
+  }
+}
+
+// JSS Setup
+jss.use(jssPluginVendorPrefixer())
+const {classes} = jss.createStyleSheet(styles).attach()
+
+// Application logic.
+const div = document.body.appendChild(document.createElement('div'))
+div.innerHTML = `<button class="${classes.button}">Button</button>`

--- a/examples/plugins/jss-plugin-vendor-prefixer/index.html
+++ b/examples/plugins/jss-plugin-vendor-prefixer/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Example - jss-plugin-vendor-prefixer</title>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/examples/plugins/jss-plugin-vendor-prefixer/package.json
+++ b/examples/plugins/jss-plugin-vendor-prefixer/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "jss-plugin-vendor-prefixer-example",
+  "license": "ISC",
+  "dependencies": {
+    "jss": "^10.0.3",
+    "jss-plugin-vendor-prefixer": "10.1.1"
+  },
+  "devDependencies": {
+    "parcel-bundler": "^1.6.1"
+  }
+}


### PR DESCRIPTION
This PR complements #1306 by migrating to codesandbox the plugin examples in the docs.