### PR TITLE
Fix types

### DIFF
--- a/packages/jss/src/index.d.ts
+++ b/packages/jss/src/index.d.ts
@@ -4,7 +4,7 @@ import * as css from 'csstype'
 type FnValue<R> = R | ((data: any) => R)
 
 type NormalCssProperties = css.Properties<string | number>
-type CssProperties = {[K in keyof NormalCssProperties]: FnValue<NormalCssProperties[K]>}
+type CssProperties = {[K in keyof NormalCssProperties]: FnValue<NormalCssProperties[K] | JssValue>}
 
 // Jss Style definitions
 type JssStyleP = {

--- a/packages/jss/src/index.d.ts
+++ b/packages/jss/src/index.d.ts
@@ -7,13 +7,11 @@ type NormalCssProperties = css.Properties<string | number>
 type CssProperties = {[K in keyof NormalCssProperties]: FnValue<NormalCssProperties[K]>}
 
 // Jss Style definitions
-type JssStyleP<S> = CssProperties & {
-  [key: string]: FnValue<JssValue | S>
+type JssStyleP = {
+  [key: string]: FnValue<JssValue | JssStyleP>
 }
 
-export type JssStyle = JssStyleP<
-  JssStyleP<JssStyleP<JssStyleP<JssStyleP<JssStyleP<JssStyleP<void>>>>>>
->
+export type JssStyle = CssProperties & JssStyleP;
 
 export type Styles<Name extends string | number | symbol = string> = Record<Name, JssStyle | string>
 export type Classes<Name extends string | number | symbol = string> = Record<Name, string>


### PR DESCRIPTION
## Corresponding issue (if exists):
- perfomance issue in VSCode because of deep nesting type JssStyle = JssStyleP<
  JssStyleP<JssStyleP<JssStyleP<JssStyleP<JssStyleP<JssStyleP<void>>>>>>
>
- wrong types for css values
## What would you like to add/fix?
- use recursive types (TS 3.7+)
- allow using arrays in css values
