### PR TITLE
fix(react-jss): fix react-jss theme types

### DIFF
--- a/packages/react-jss/src/index.d.ts
+++ b/packages/react-jss/src/index.d.ts
@@ -37,13 +37,13 @@ declare const JssContext: Context<{
   disableStylesGeneration: boolean
 }>
 
-interface WithStylesProps<S extends Styles | ((theme: unknown) => Styles)> {
-  classes: Classes<S extends ((theme: unknown) => Styles) ? keyof ReturnType<S> : keyof S>
+interface WithStylesProps<S extends Styles | ((theme: any) => Styles)> {
+  classes: Classes<S extends (theme: any) => Styles ? keyof ReturnType<S> : keyof S>
 }
 /**
  * @deprecated Please use `WithStylesProps` instead
  */
-type WithStyles<S extends Styles | ((theme: unknown) => Styles)> = WithStylesProps<S>
+type WithStyles<S extends Styles | ((theme: any) => Styles)> = WithStylesProps<S>
 
 export interface DefaultTheme {}
 


### PR DESCRIPTION
# What would you like to add/fix?

The problem is that my app `Theme` interface didn't match to `unknown` theme type.
So I think `any` type would be better in this case.