### PR TITLE
fix `createUseStyles` types

### DIFF
--- a/packages/jss/src/index.d.ts
+++ b/packages/jss/src/index.d.ts
@@ -4,16 +4,21 @@ import * as css from 'csstype'
 type FnValue<R> = R | ((data: any) => R)
 
 type NormalCssProperties = css.Properties<string | number>
-type CssProperties = {[K in keyof NormalCssProperties]: FnValue<NormalCssProperties[K] | JssValue>}
+type NormalCssValues<K> = K extends keyof NormalCssProperties
+  ? NormalCssProperties[K] | JssValue
+  : JssValue
 
-// Jss Style definitions
-type JssStyleP = {
-  [key: string]: FnValue<JssValue | JssStyleP>
+export type JssStyle = {
+  [K in keyof NormalCssProperties | string]:
+    | NormalCssValues<K>
+    | JssStyle
+    | ((data: any) => NormalCssValues<K> | JssStyle)
 }
 
-export type JssStyle = CssProperties & JssStyleP
-
-export type Styles<Name extends string | number | symbol = string> = Record<Name, JssStyle | string>
+export type Styles<Name extends string | number | symbol = string> = Record<
+  Name,
+  FnValue<JssStyle | string>
+>
 export type Classes<Name extends string | number | symbol = string> = Record<Name, string>
 export type Keyframes<Name extends string = string> = Record<Name, string>
 

--- a/packages/jss/tests/types/Styles.ts
+++ b/packages/jss/tests/types/Styles.ts
@@ -1,0 +1,56 @@
+import {Styles} from '../../src'
+
+interface Props {
+  flag?: boolean
+}
+
+const styles: Styles = {
+  basic: {
+    textAlign: 'center',
+    display: 'flex',
+    width: 500,
+    justifyContent: 'center'
+  },
+  property: {
+    textAlign: 'center',
+    display: 'flex',
+    width: '100%',
+    justifyContent: (props: Props) => (props.flag ? 'center' : 'left')
+  },
+  inner: {
+    textAlign: 'center',
+    display: 'flex',
+    width: '100%',
+
+    '&.foo': {
+      fontSize: 12
+    }
+  },
+  func: (props: Props) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: '96px',
+    cursor: 'pointer',
+    position: 'relative',
+    pointerEvents: props.flag ? 'none' : null
+  }),
+  funcWithTerm: (props: Props) => ({
+    width: props.flag ? 377 : 272,
+    height: props.flag ? 330 : 400,
+    boxShadow: '0px 2px 20px rgba(0, 0, 0, 0.08)',
+    borderRadius: '8px',
+    position: 'relative',
+    color: '#222222',
+    background: '#fff',
+    animation: '$fadeIn 300ms ease-in-out 300ms both',
+    ...(props.flag && {
+      height: 288
+    })
+  }),
+  '@keyframes fadeIn': {
+    from: {opacity: 0},
+    to: {opacity: 1}
+  }
+}

--- a/packages/react-jss/src/index.d.ts
+++ b/packages/react-jss/src/index.d.ts
@@ -62,7 +62,7 @@ interface CreateUseStylesOptions<Theme = DefaultTheme> extends BaseOptions<Theme
 }
 
 declare function createUseStyles<Theme = DefaultTheme, C extends string = string>(
-  styles: Record<C, any> | ((theme: Theme) => Record<C, any>),
+  styles: Styles<C> | ((theme: Theme) => Styles<C>),
   options?: CreateUseStylesOptions<Theme>
 ): (data?: unknown) => Classes<C>
 


### PR DESCRIPTION
## Corresponding issue (if exists): https://github.com/cssinjs/jss/issues/1351

## What would you like to add/fix?
Fixing TypeScript types for `createUseStyles` and `JssStyle`

## Todo

- [x] Add tests if possible - new test file under `packages/jss/tests/types/Styles.ts`
- [ ] Add changelog if users should know about the change
- [ ] Add documentation
