### PR TITLE
fix(react-jss/types): fix react default props types support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ Since you are interested in what happens next, in case, you work for a for-profi
 
 ---
 
+### Improvements
+
+- [react-jss] add properly react default props types calculation (https://github.com/cssinjs/jss/pull/1353)
+
 ## 10.2.0 (2020-6-3)
 
 ### Improvements

--- a/packages/react-jss/src/index.d.ts
+++ b/packages/react-jss/src/index.d.ts
@@ -66,21 +66,19 @@ declare function createUseStyles<Theme = DefaultTheme, C extends string = string
   options?: CreateUseStylesOptions<Theme>
 ): (data?: unknown) => Classes<C>
 
+type GetProps<C> = C extends ComponentType<infer P> ? P : never
+
 declare function withStyles<
   ClassNames extends string | number | symbol,
   S extends Styles<ClassNames> | ((theme: any) => Styles<ClassNames>)
 >(
   styles: S,
   options?: WithStylesOptions
-): <
-  Props extends {
-    classes: S extends (theme: any) => Styles<ClassNames>
-      ? Classes<keyof ReturnType<S>>
-      : Classes<ClassNames>
-  }
->(
-  comp: ComponentType<Props>
-) => ComponentType<Omit<Props, 'classes'> & {classes?: Partial<Props['classes']>}>
+): <C>(
+  comp: C
+) => ComponentType<
+  JSX.LibraryManagedAttributes<C, Omit<GetProps<C>, 'classes'> & Partial<WithStylesProps<S>>>
+>
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
 

--- a/packages/react-jss/src/index.test.tsx
+++ b/packages/react-jss/src/index.test.tsx
@@ -1,0 +1,24 @@
+import React, {Component} from 'react'
+
+import WithStyles from '.'
+
+interface Props {
+  testProp: string
+}
+
+class TestComponent extends Component<Props> {
+  static defaultProps: Props = {
+    testProp: 'hello'
+  }
+
+  render() {
+    return <div>{this.props.testProp}</div>
+  }
+}
+
+const TestComponentWitStyles = WithStyles({})(TestComponent)
+
+function testRender() {
+  // component shouldn't ask to pass `testProp`
+  return <TestComponentWitStyles />
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,5 @@
     "moduleResolution": "node",
     "jsx": "react"
   },
-  "include": ["packages/**/*.ts"]
+  "include": ["packages/**/*.ts", "packages/**/*.tsx"]
 }


### PR DESCRIPTION
## What would you like to add/fix?
Hello, dear colleagues!
I fixed an issue connected with react default props in typescript.
You can read more about processing of react default props in typescript here: 
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-0.html#support-for-defaultprops-in-jsx
In short, they calculate resulted props with help of `JSX. LibraryManagedAttributes` small function.

So, as you can see, in PR I used this helper to calculate component props types according official documentation.

Thanks for your attention!

## Todo

- [x] Add tests if possible
- [x] Add changelog if users should know about the change
- [x] Add documentation
