### PR TITLE
[react-jss] TypeScript: Added support for innerRef prop

### DIFF
--- a/packages/react-jss/src/index.d.ts
+++ b/packages/react-jss/src/index.d.ts
@@ -39,7 +39,6 @@ declare const JssContext: Context<{
 
 interface WithStylesProps<S extends Styles | ((theme: any) => Styles)> {
   classes: Classes<S extends (theme: any) => Styles ? keyof ReturnType<S> : keyof S>
-  innerRef?: RefObject<any> | ((instance: any) => void)
 }
 /**
  * @deprecated Please use `WithStylesProps` instead
@@ -78,10 +77,12 @@ declare function withStyles<
 ): <C>(
   comp: C
 ) => ComponentType<
-  JSX.LibraryManagedAttributes<C, Omit<GetProps<C>, 'classes'> & Partial<WithStylesProps<S>>>
+  JSX.LibraryManagedAttributes<
+    C,
+    Omit<GetProps<C>, 'classes'> &
+      Partial<WithStylesProps<S>> & {innerRef?: RefObject<any> | ((instance: any) => void)}
+  >
 >
-
-type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
 
 export {
   SheetsRegistry,

--- a/packages/react-jss/src/index.d.ts
+++ b/packages/react-jss/src/index.d.ts
@@ -1,4 +1,4 @@
-import {ComponentType, ReactNode, Context} from 'react'
+import {ComponentType, ReactNode, Context, RefObject} from 'react'
 import {
   CreateGenerateId,
   GenerateId,
@@ -39,6 +39,7 @@ declare const JssContext: Context<{
 
 interface WithStylesProps<S extends Styles | ((theme: any) => Styles)> {
   classes: Classes<S extends (theme: any) => Styles ? keyof ReturnType<S> : keyof S>
+  innerRef?: RefObject<any> | ((instance: any) => void)
 }
 /**
  * @deprecated Please use `WithStylesProps` instead

--- a/packages/react-jss/src/index.test.tsx
+++ b/packages/react-jss/src/index.test.tsx
@@ -11,18 +11,26 @@ class TestComponent extends Component<Props> {
     testProp: 'hello'
   }
 
+  state = {message: ''}
+
   render() {
-    return <div>{this.props.testProp}</div>
+    return (
+      <div>
+        <span>{this.props.testProp}</span>
+        <span>{this.state.message}</span>
+      </div>
+    )
   }
 }
-
+const cc = new TestComponent({testProp: ''})
+cc.render()
 const TestComponentWitStyles = WithStyles({})(TestComponent)
 
 function testRender() {
-  const ref = useRef<any>()
+  const ref = useRef<TestComponent>()
 
-  function refFunction(instance: any) {
-    // do smth with instance
+  function refFunction(instance: TestComponent) {
+    instance.setState({message: 'From ref'})
   }
 
   // component shouldn't ask to pass `testProp`

--- a/packages/react-jss/src/index.test.tsx
+++ b/packages/react-jss/src/index.test.tsx
@@ -1,4 +1,4 @@
-import React, {Component} from 'react'
+import React, {Component, useRef} from 'react'
 
 import WithStyles from '.'
 
@@ -19,6 +19,19 @@ class TestComponent extends Component<Props> {
 const TestComponentWitStyles = WithStyles({})(TestComponent)
 
 function testRender() {
+  const ref = useRef<any>()
+
+  function refFunction(instance: any) {
+    // do smth with instance
+  }
+
   // component shouldn't ask to pass `testProp`
-  return <TestComponentWitStyles />
+  // component can accept innerRef prop
+  return (
+    <>
+      <TestComponentWitStyles />
+      <TestComponentWitStyles innerRef={ref} />
+      <TestComponentWitStyles innerRef={refFunction} />
+    </>
+  )
 }


### PR DESCRIPTION
## Corresponding issue (if exists):
Can't pass innerRef prop

## What would you like to add/fix?
Add support for innerRef in types

## Todo

- [x] Add tests if possible
- [x] Add changelog if users should know about the change
- [x] Add documentation
