### PR TITLE
fix(extend): extends multiple named styles (fix #1345)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ Since you are interested in what happens next, in case, you work for a for-profi
 
 ---
 
+### Bug fixes
+
+- [jss-plugin-extend] Fix can not extend rule name is array [1357](https://github.com/cssinjs/jss/pull/1357)
+
 ### Improvements
 
 - [react-jss] add properly react default props types calculation (https://github.com/cssinjs/jss/pull/1353)

--- a/docs/jss-plugin-extend.md
+++ b/docs/jss-plugin-extend.md
@@ -36,7 +36,7 @@ const styles = {
 }
 ```
 
-### Use an array of style objects
+### Use an array of style objects or rule names
 
 ```javascript
 const styles = {
@@ -52,8 +52,11 @@ const background = {background: 'red'}
 const color = {color: 'green'}
 
 const styles = {
+  basePadding: {
+    padding: '10px'
+  },
   button: {
-    extend: [background, color],
+    extend: [background, color, 'basePadding'],
     fontSize: '20px'
   }
 }

--- a/packages/css-jss/.size-snapshot.json
+++ b/packages/css-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/css-jss.js": {
-    "bundled": 59356,
-    "minified": 21187,
-    "gzipped": 7207
+    "bundled": 59488,
+    "minified": 21244,
+    "gzipped": 7230
   },
   "dist/css-jss.min.js": {
-    "bundled": 58281,
-    "minified": 20592,
-    "gzipped": 6939
+    "bundled": 58413,
+    "minified": 20649,
+    "gzipped": 6964
   },
   "dist/css-jss.cjs.js": {
     "bundled": 2907,

--- a/packages/jss-plugin-extend/.size-snapshot.json
+++ b/packages/jss-plugin-extend/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "dist/jss-plugin-extend.js": {
-    "bundled": 4138,
-    "minified": 1420,
-    "gzipped": 703
+    "bundled": 4682,
+    "minified": 1684,
+    "gzipped": 816
   },
   "dist/jss-plugin-extend.min.js": {
-    "bundled": 3764,
-    "minified": 1235,
-    "gzipped": 594
+    "bundled": 4308,
+    "minified": 1499,
+    "gzipped": 706
   },
   "dist/jss-plugin-extend.cjs.js": {
-    "bundled": 3566,
-    "minified": 1457,
-    "gzipped": 660
+    "bundled": 3767,
+    "minified": 1589,
+    "gzipped": 716
   },
   "dist/jss-plugin-extend.esm.js": {
-    "bundled": 3348,
-    "minified": 1289,
-    "gzipped": 592,
+    "bundled": 3533,
+    "minified": 1410,
+    "gzipped": 654,
     "treeshaked": {
       "rollup": {
-        "code": 21,
-        "import_statements": 21
+        "code": 64,
+        "import_statements": 64
       },
       "webpack": {
-        "code": 1016
+        "code": 1092
       }
     }
   }

--- a/packages/jss-plugin-extend/src/index.js
+++ b/packages/jss-plugin-extend/src/index.js
@@ -25,10 +25,13 @@ function mergeExtend(style, rule, sheet, newStyle) {
     return
   }
 
-  // Extend using an array of objects.
+  // Extend using an array.
   if (Array.isArray(style.extend)) {
     for (let index = 0; index < style.extend.length; index++) {
-      extend(style.extend[index], rule, sheet, newStyle)
+      const singleExtend = style.extend[index]
+      const singleStyle =
+        typeof singleExtend === 'string' ? {...style, extend: singleExtend} : style.extend[index]
+      extend(singleStyle, rule, sheet, newStyle)
     }
     return
   }

--- a/packages/jss-plugin-extend/src/index.test.js
+++ b/packages/jss-plugin-extend/src/index.test.js
@@ -132,6 +132,35 @@ describe('jss-plugin-extend', () => {
     })
   })
 
+  describe('multi mixed rule name and style objects extend', () => {
+    let sheet
+
+    beforeEach(() => {
+      const a = {float: 'left'}
+      sheet = jss.createStyleSheet({
+        b: {position: 'absolute'},
+        c: {
+          extend: [a, 'b'],
+          width: '1px'
+        }
+      })
+    })
+
+    it('should have correct output', () => {
+      expect(sheet.getRule('c')).to.not.be(undefined)
+      expect(sheet.toString()).to.be(
+        '.b-id {\n' +
+          '  position: absolute;\n' +
+          '}\n' +
+          '.c-id {\n' +
+          '  float: left;\n' +
+          '  position: absolute;\n' +
+          '  width: 1px;\n' +
+          '}'
+      )
+    })
+  })
+
   describe('nested extend 1', () => {
     let sheet
 

--- a/packages/jss-plugin-extend/src/index.test.js
+++ b/packages/jss-plugin-extend/src/index.test.js
@@ -100,6 +100,38 @@ describe('jss-plugin-extend', () => {
     })
   })
 
+  describe('multi rule name extend', () => {
+    let sheet
+
+    beforeEach(() => {
+      sheet = jss.createStyleSheet({
+        a: {float: 'left'},
+        b: {position: 'absolute'},
+        c: {
+          extend: ['a', 'b'],
+          width: '1px'
+        }
+      })
+    })
+
+    it('should have correct output', () => {
+      expect(sheet.getRule('c')).to.not.be(undefined)
+      expect(sheet.toString()).to.be(
+        '.a-id {\n' +
+          '  float: left;\n' +
+          '}\n' +
+          '.b-id {\n' +
+          '  position: absolute;\n' +
+          '}\n' +
+          '.c-id {\n' +
+          '  float: left;\n' +
+          '  width: 1px;\n' +
+          '  position: absolute;\n' +
+          '}'
+      )
+    })
+  })
+
   describe('nested extend 1', () => {
     let sheet
 

--- a/packages/jss-preset-default/.size-snapshot.json
+++ b/packages/jss-preset-default/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/jss-preset-default.js": {
-    "bundled": 56612,
-    "minified": 20421,
-    "gzipped": 6861
+    "bundled": 56744,
+    "minified": 20478,
+    "gzipped": 6885
   },
   "dist/jss-preset-default.min.js": {
-    "bundled": 55537,
-    "minified": 19826,
-    "gzipped": 6591
+    "bundled": 55669,
+    "minified": 19883,
+    "gzipped": 6616
   },
   "dist/jss-preset-default.cjs.js": {
     "bundled": 1329,

--- a/packages/jss-starter-kit/.size-snapshot.json
+++ b/packages/jss-starter-kit/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/jss-starter-kit.js": {
-    "bundled": 72402,
-    "minified": 30615,
-    "gzipped": 9501
+    "bundled": 72534,
+    "minified": 30672,
+    "gzipped": 9522
   },
   "dist/jss-starter-kit.min.js": {
-    "bundled": 71327,
-    "minified": 30019,
-    "gzipped": 9240
+    "bundled": 71459,
+    "minified": 30076,
+    "gzipped": 9267
   },
   "dist/jss-starter-kit.cjs.js": {
     "bundled": 2790,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/react-jss.js": {
-    "bundled": 169946,
-    "minified": 58911,
-    "gzipped": 19311
+    "bundled": 170078,
+    "minified": 58968,
+    "gzipped": 19335
   },
   "dist/react-jss.min.js": {
-    "bundled": 112923,
-    "minified": 42170,
-    "gzipped": 14335
+    "bundled": 113055,
+    "minified": 42227,
+    "gzipped": 14356
   },
   "dist/react-jss.cjs.js": {
     "bundled": 26398,


### PR DESCRIPTION
## Corresponding issue (if exists):

#1345

## What would you like to add/fix?

Now plugin can extend both named and object in the array.

## Todo

- [x] Add tests if possible
- [ ] Add changelog if users should know about the change
- [ ] Add documentation
