### PR TITLE
Fix Flow typing for CreateGenerateId

### DIFF
--- a/packages/jss/src/utils/createGenerateId.js
+++ b/packages/jss/src/utils/createGenerateId.js
@@ -11,7 +11,7 @@ export type CreateGenerateIdOptions = {|
 |}
 export type GenerateId = (rule: Rule, sheet?: StyleSheet) => string
 
-export type CreateGenerateId = (options: CreateGenerateIdOptions) => GenerateId
+export type CreateGenerateId = (options?: CreateGenerateIdOptions) => GenerateId
 
 /**
  * Returns a function which generates unique class names based on counters.


### PR DESCRIPTION
Brings this into alignment with the Typescript annotation for this same function:
```
export type CreateGenerateId = (options?: CreateGenerateIdOptions) => GenerateId
```

## Corresponding issue (if exists):
I didn't open an issue, but can if that would be helpful for tracking

## What would you like to add/fix?
The TS and Flow types for GreateGenerateId disagree on the optionality of the options parameter. It *appears* to me that options is meant to be optional and thus the TS annotation is more correct. I've made the corresponding update to the flow type.

