### PR TITLE
fix: Made it possible for windows to run yarn build

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,7 +31,8 @@ Object.keys(pkg.peerDependencies || {}).forEach(key => {
   }
 })
 
-const external = id => !id.startsWith('.') && !id.startsWith('/')
+const external = id =>
+  !id.startsWith('.') && !id.startsWith(process.platform === 'win32' ? process.cwd() : '/')
 
 const getBabelOptions = ({useESModules}) => ({
   exclude: /node_modules/,


### PR DESCRIPTION
## Corresponding issue (if exists):
Running `yarn build` on windows machines causes errors due to the way external modules are calculated. This is the error message:

```
(plugin size-snapshot) Error: ModuleNotFoundError: Module not found: Error: Can't resolve './Jss.js' in '/'
```

## What would you like to add/fix?

I found another library that had the exact same problem. This PR mirrors the fix that they created.

https://github.com/doczjs/docz/issues/783

