### PR TITLE
feat: Bump csstype to 3.0.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Since you are interested in what happens next, in case, you work for a for-profi
 
 ### Improvements
 
+- [jss] Bump `csstype` to 3.0.2 (https://github.com/cssinjs/jss/pull/1379)
 - [react-jss] add properly react default props types calculation (https://github.com/cssinjs/jss/pull/1353)
 
 ## 10.3.0 (2020-6-10)

--- a/packages/jss/package.json
+++ b/packages/jss/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",
-    "csstype": "^2.6.5",
+    "csstype": "^3.0.2",
     "is-in-browser": "^1.1.3",
     "tiny-warning": "^1.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3177,10 +3177,10 @@ csstype@^2.2.0:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.7.tgz#bf9235d5872141eccfb2d16d82993c6b149179ff"
   integrity sha512-Nt5VDyOTIIV4/nRFswoCKps1R5CD1hkiyjBE9/thNaNZILLEviVw9yWQw15+O+CpNjQKB/uvdcxFFOrSflY3Yw==
 
-csstype@^2.6.5:
-  version "2.6.5"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.5.tgz#1cd1dff742ebf4d7c991470ae71e12bb6751e034"
-  integrity sha512-JsTaiksRsel5n7XwqPAfB0l3TFKdpjW/kgAELf9vrb5adGA7UCPLajKK5s3nFrcFm3Rkyp/Qkgl73ENc1UY3cA==
+csstype@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.2.tgz#ee5ff8f208c8cd613b389f7b222c9801ca62b3f7"
+  integrity sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
## Corresponding issue (if exists):

None

## What would you like to add/fix?

Bump csstype to avoid possible type conflicts. All `@types/*` packages have already switched: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46435

## Todo

- ~[ ] Add tests if possible~
- [x] Add changelog if users should know about the change
- ~[ ] Add documentation~
