### PR TITLE
Upgrade flow-bin to 0.131.0 and migrate types

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -7,5 +7,3 @@
 [options]
 include_warnings=true
 esproposal.export_star_as=enable
-suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
-suppress_comment= \\(.\\|\n\\)*\\$FlowIgnore

--- a/changelog.md
+++ b/changelog.md
@@ -10,8 +10,10 @@ Since you are interested in what happens next, in case, you work for a for-profi
 
 ### Improvements
 
-- [jss] Bump `csstype` to 3.0.2 (https://github.com/cssinjs/jss/pull/1379)
-- [react-jss] add properly react default props types calculation (https://github.com/cssinjs/jss/pull/1353)
+- [jss] Bump `csstype` to 3.0.2 [1379](https://github.com/cssinjs/jss/pull/1379)
+- [react-jss] Add properly react default props types calculation [1353](https://github.com/cssinjs/jss/pull/1353)
+- [react-jss] Upgrade Theming to 3.3.0 [1382](https://github.com/cssinjs/jss/pull/1382)
+- [*] Upgrade flowtype to 0.131.0 [1382](https://github.com/cssinjs/jss/pull/1382)
 
 ## 10.3.0 (2020-6-10)
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "eslint-config-jss": "^5.0.1",
     "eslint-config-prettier": "^2.9.0",
     "expect.js": "^0.3.1",
-    "flow-bin": "^0.98.0",
+    "flow-bin": "^0.131.0",
     "json-loader": "^0.5.4",
     "karma": "^1.3.0",
     "karma-benchmark": "^0.6.0",

--- a/packages/css-jss/.size-snapshot.json
+++ b/packages/css-jss/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "dist/css-jss.js": {
-    "bundled": 59488,
-    "minified": 21244,
-    "gzipped": 7230
+    "bundled": 59599,
+    "minified": 21252,
+    "gzipped": 7233
   },
   "dist/css-jss.min.js": {
-    "bundled": 58413,
-    "minified": 20649,
-    "gzipped": 6964
+    "bundled": 58524,
+    "minified": 20657,
+    "gzipped": 6968
   },
   "dist/css-jss.cjs.js": {
-    "bundled": 2907,
-    "minified": 1125,
-    "gzipped": 643
+    "bundled": 2968,
+    "minified": 1133,
+    "gzipped": 646
   },
   "dist/css-jss.esm.js": {
-    "bundled": 2693,
-    "minified": 961,
-    "gzipped": 573,
+    "bundled": 2754,
+    "minified": 969,
+    "gzipped": 575,
     "treeshaked": {
       "rollup": {
         "code": 70,
         "import_statements": 63
       },
       "webpack": {
-        "code": 1833
+        "code": 1841
       }
     }
   }

--- a/packages/css-jss/src/createCss.js
+++ b/packages/css-jss/src/createCss.js
@@ -54,8 +54,9 @@ const createCss = (jss: Jss = defaultJss): Css => {
     const labels = []
 
     for (let i = 0; i < flatArgs.length; i++) {
-      let style = flatArgs[i]
+      const style = flatArgs[i]
       if (!style) continue
+      let styleObject = style
       // It can be a class name that css() has previously generated.
       if (typeof style === 'string') {
         // eslint-disable-next-line no-shadow
@@ -63,11 +64,12 @@ const createCss = (jss: Jss = defaultJss): Css => {
         if (cached) {
           // eslint-disable-next-line prefer-spread
           if (cached.labels.length) labels.push.apply(labels, cached.labels)
-          style = cached.style
+          styleObject = cached.style
         }
       }
-      if (style.label && labels.indexOf(style.label) === -1) labels.push(style.label)
-      Object.assign(mergedStyle, style)
+      if (styleObject.label && labels.indexOf(styleObject.label) === -1)
+        labels.push(styleObject.label)
+      Object.assign(mergedStyle, styleObject)
     }
     delete mergedStyle.label
     const label = labels.length === 0 ? 'css' : labels.join('-')

--- a/packages/css-jss/src/createCss.test.js
+++ b/packages/css-jss/src/createCss.test.js
@@ -3,7 +3,7 @@ import expect from 'expect.js'
 import {stripIndent} from 'common-tags'
 import {create as createJss, type StyleSheet} from 'jss'
 import {createGenerateId} from '../../../tests/utils'
-import {create as createCss, type Css} from './index'
+import {create as createCss} from './index'
 import {type StyleArg} from './types'
 
 type CssTestType = {|

--- a/packages/css-jss/src/createCss.test.js
+++ b/packages/css-jss/src/createCss.test.js
@@ -10,7 +10,7 @@ describe('css-jss', () => {
 
   beforeEach(() => {
     const jss = createJss({createGenerateId})
-    css = createCss(jss)
+    css = ((createCss(jss): any): Function)
   })
 
   it('should accept a single style object argument', () => {

--- a/packages/css-jss/src/createCss.test.js
+++ b/packages/css-jss/src/createCss.test.js
@@ -1,16 +1,22 @@
 // @flow
 import expect from 'expect.js'
 import {stripIndent} from 'common-tags'
-import {create as createJss} from 'jss'
+import {create as createJss, type StyleSheet} from 'jss'
 import {createGenerateId} from '../../../tests/utils'
-import {create as createCss} from './index'
+import {create as createCss, type Css} from './index'
+import {type StyleArg} from './types'
+
+type CssTestType = {|
+  (...args: StyleArg[]): string,
+  getSheet: () => StyleSheet
+|}
 
 describe('css-jss', () => {
   let css
 
   beforeEach(() => {
     const jss = createJss({createGenerateId})
-    css = ((createCss(jss): any): Function)
+    css = (createCss(jss): CssTestType)
   })
 
   it('should accept a single style object argument', () => {

--- a/packages/jss-plugin-extend/.size-snapshot.json
+++ b/packages/jss-plugin-extend/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "dist/jss-plugin-extend.js": {
-    "bundled": 4682,
+    "bundled": 4730,
     "minified": 1684,
     "gzipped": 816
   },
   "dist/jss-plugin-extend.min.js": {
-    "bundled": 4308,
+    "bundled": 4356,
     "minified": 1499,
     "gzipped": 706
   },
   "dist/jss-plugin-extend.cjs.js": {
-    "bundled": 3767,
+    "bundled": 3813,
     "minified": 1589,
     "gzipped": 716
   },
   "dist/jss-plugin-extend.esm.js": {
-    "bundled": 3533,
+    "bundled": 3579,
     "minified": 1410,
     "gzipped": 654,
     "treeshaked": {

--- a/packages/jss-plugin-extend/src/index.js
+++ b/packages/jss-plugin-extend/src/index.js
@@ -107,6 +107,7 @@ export default function jssExtend(): Plugin {
     if (typeof value === 'object') {
       // $FlowFixMe: This will be an object
       for (const key in value) {
+        // $FlowFixMe: This will be an object
         rule.prop(key, value[key])
       }
 

--- a/packages/jss-preset-default/.size-snapshot.json
+++ b/packages/jss-preset-default/.size-snapshot.json
@@ -1,11 +1,11 @@
 {
   "dist/jss-preset-default.js": {
-    "bundled": 56744,
+    "bundled": 56792,
     "minified": 20478,
     "gzipped": 6885
   },
   "dist/jss-preset-default.min.js": {
-    "bundled": 55669,
+    "bundled": 55717,
     "minified": 19883,
     "gzipped": 6616
   },

--- a/packages/jss-starter-kit/.size-snapshot.json
+++ b/packages/jss-starter-kit/.size-snapshot.json
@@ -1,11 +1,11 @@
 {
   "dist/jss-starter-kit.js": {
-    "bundled": 72534,
+    "bundled": 72582,
     "minified": 30672,
     "gzipped": 9522
   },
   "dist/jss-starter-kit.min.js": {
-    "bundled": 71459,
+    "bundled": 71507,
     "minified": 30076,
     "gzipped": 9267
   },

--- a/packages/jss/.size-snapshot.json
+++ b/packages/jss/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "dist/jss.js": {
-    "bundled": 61863,
-    "minified": 22827,
-    "gzipped": 6888
+    "bundled": 61966,
+    "minified": 22868,
+    "gzipped": 6898
   },
   "dist/jss.min.js": {
-    "bundled": 60466,
-    "minified": 22059,
-    "gzipped": 6535
+    "bundled": 60569,
+    "minified": 22100,
+    "gzipped": 6545
   },
   "dist/jss.cjs.js": {
-    "bundled": 56580,
-    "minified": 24744,
-    "gzipped": 6886
+    "bundled": 56677,
+    "minified": 24785,
+    "gzipped": 6896
   },
   "dist/jss.esm.js": {
-    "bundled": 56048,
-    "minified": 24309,
-    "gzipped": 6795,
+    "bundled": 56145,
+    "minified": 24350,
+    "gzipped": 6805,
     "treeshaked": {
       "rollup": {
-        "code": 20040,
+        "code": 20081,
         "import_statements": 345
       },
       "webpack": {
-        "code": 21521
+        "code": 21562
       }
     }
   }

--- a/packages/jss/src/Jss.js
+++ b/packages/jss/src/Jss.js
@@ -110,12 +110,14 @@ export default class Jss {
    * Create a rule without a Style Sheet.
    * [Deprecated] will be removed in the next major version.
    */
-  createRule(name?: string, style?: JssStyle = {}, options?: RuleFactoryOptions = {}): Rule | null {
+  createRule(name: string, style?: JssStyle = {}, options?: RuleFactoryOptions = {}): Rule | null {
     // Enable rule without name for inline styles.
     if (typeof name === 'object') {
+      // $FlowIgnore
       return this.createRule(undefined, name, style)
     }
 
+    // $FlowIgnore
     const ruleOptions: RuleOptions = {...options, name, jss: this, Renderer: this.options.Renderer}
 
     if (!ruleOptions.generateId) ruleOptions.generateId = this.generateId

--- a/packages/jss/src/Jss.js
+++ b/packages/jss/src/Jss.js
@@ -79,7 +79,7 @@ export default class Jss {
   /**
    * Create a Style Sheet.
    */
-  createStyleSheet(styles: Object, options: StyleSheetFactoryOptions = {}): StyleSheet {
+  createStyleSheet(styles: Object, options: StyleSheetFactoryOptions = ({}: any)): StyleSheet {
     let {index} = options
     if (typeof index !== 'number') {
       index = sheets.index === 0 ? 0 : sheets.index + 1

--- a/packages/jss/src/RuleList.js
+++ b/packages/jss/src/RuleList.js
@@ -68,6 +68,8 @@ export default class RuleList {
       generateId,
       scoped,
       name,
+      keyframes: this.keyframes,
+      selector: undefined,
       ...ruleOptions
     }
 

--- a/packages/jss/src/SheetsRegistry.js
+++ b/packages/jss/src/SheetsRegistry.js
@@ -56,7 +56,7 @@ export default class SheetsRegistry {
   /**
    * Convert all attached sheets to a CSS string.
    */
-  toString({attached, ...options}: {|attached?: boolean|} & ToCssOptions = {}): string {
+  toString({attached, ...options}: {|attached?: boolean, ...ToCssOptions|} = {}): string {
     let css = ''
     for (let i = 0; i < this.registry.length; i++) {
       const sheet = this.registry[i]

--- a/packages/jss/src/SheetsRegistry.js
+++ b/packages/jss/src/SheetsRegistry.js
@@ -56,7 +56,7 @@ export default class SheetsRegistry {
   /**
    * Convert all attached sheets to a CSS string.
    */
-  toString({attached, ...options}: {attached?: boolean, ...ToCssOptions} = {}): string {
+  toString({attached, ...options}: {|attached?: boolean|} & ToCssOptions = {}): string {
     let css = ''
     for (let i = 0; i < this.registry.length; i++) {
       const sheet = this.registry[i]

--- a/packages/jss/src/types/jss.js
+++ b/packages/jss/src/types/jss.js
@@ -111,7 +111,7 @@ export interface ContainerRule extends BaseRule {
 export type RuleOptions = {
   selector?: string,
   scoped?: boolean,
-  sheet?: StyleSheet,
+  sheet: StyleSheet,
   index?: number,
   parent?: ContainerRule | StyleSheet,
   classes: Classes,
@@ -177,7 +177,7 @@ export type StyleSheetFactoryOptions = {
   classNamePrefix?: string
 }
 
-export type StyleSheetOptions = {|
+export type StyleSheetOptions = {
   media?: string,
   meta?: string,
   link?: boolean,
@@ -188,9 +188,9 @@ export type StyleSheetOptions = {|
   Renderer?: Class<Renderer> | null,
   insertionPoint?: InsertionPoint,
   jss: Jss
-|}
+}
 
-export type InternalStyleSheetOptions = {|
+export type InternalStyleSheetOptions = {
   media?: string,
   meta?: string,
   link?: boolean,
@@ -205,4 +205,4 @@ export type InternalStyleSheetOptions = {|
   parent: ConditionalRule | KeyframesRule | StyleSheet,
   classes: Classes,
   keyframes: KeyframesMap
-|}
+}

--- a/packages/jss/src/types/jss.js
+++ b/packages/jss/src/types/jss.js
@@ -18,11 +18,11 @@ export type Classes = {[string]: string}
 
 export type KeyframesMap = {[string]: string}
 
-export type ToCssOptions = {
+export type ToCssOptions = {|
   indent?: number,
   allowEmpty?: boolean,
   children?: boolean
-}
+|}
 
 export type UpdateOptions = {
   process?: boolean,
@@ -167,7 +167,7 @@ export type InternalJssOptions = {|
   Renderer?: Class<Renderer> | null
 |}
 
-export type StyleSheetFactoryOptions = {
+export type StyleSheetFactoryOptions = {|
   media?: string,
   meta?: string,
   index?: number,
@@ -175,9 +175,9 @@ export type StyleSheetFactoryOptions = {
   element?: HTMLStyleElement,
   generateId?: GenerateId,
   classNamePrefix?: string
-}
+|}
 
-export type StyleSheetOptions = {
+export type StyleSheetOptions = {|
   media?: string,
   meta?: string,
   link?: boolean,
@@ -188,7 +188,7 @@ export type StyleSheetOptions = {
   Renderer?: Class<Renderer> | null,
   insertionPoint?: InsertionPoint,
   jss: Jss
-}
+|}
 
 export type InternalStyleSheetOptions = {
   media?: string,

--- a/packages/jss/src/utils/toCss.js
+++ b/packages/jss/src/utils/toCss.js
@@ -18,7 +18,7 @@ function indentStr(str: string, indent: number): string {
 export default function toCss(
   selector?: string,
   style: JssStyle,
-  options: ToCssOptions = {}
+  options: ToCssOptions = ({}: any)
 ): string {
   let result = ''
 

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "dist/react-jss.js": {
-    "bundled": 170078,
-    "minified": 58968,
-    "gzipped": 19335
+    "bundled": 170153,
+    "minified": 59050,
+    "gzipped": 19361
   },
   "dist/react-jss.min.js": {
-    "bundled": 113055,
-    "minified": 42227,
-    "gzipped": 14356
+    "bundled": 113130,
+    "minified": 42309,
+    "gzipped": 14382
   },
   "dist/react-jss.cjs.js": {
-    "bundled": 26398,
-    "minified": 11532,
-    "gzipped": 3759
+    "bundled": 26358,
+    "minified": 11638,
+    "gzipped": 3786
   },
   "dist/react-jss.esm.js": {
-    "bundled": 24901,
-    "minified": 10301,
-    "gzipped": 3602,
+    "bundled": 24861,
+    "minified": 10407,
+    "gzipped": 3629,
     "treeshaked": {
       "rollup": {
-        "code": 1838,
+        "code": 1861,
         "import_statements": 538
       },
       "webpack": {
-        "code": 3436
+        "code": 3459
       }
     }
   }

--- a/packages/react-jss/package.json
+++ b/packages/react-jss/package.json
@@ -47,7 +47,7 @@
     "jss-preset-default": "^10.3.0",
     "prop-types": "^15.6.0",
     "shallow-equal": "^1.2.0",
-    "theming": "^3.2.1",
+    "theming": "^3.3.0",
     "tiny-warning": "^1.0.2"
   },
   "devDependencies": {

--- a/packages/react-jss/src/JssProvider.js
+++ b/packages/react-jss/src/JssProvider.js
@@ -79,7 +79,7 @@ export default class JssProvider extends Component<Props> {
     }
 
     if (classNamePrefix) {
-      context.classNamePrefix += classNamePrefix
+      context.classNamePrefix = (context.classNamePrefix || '') + classNamePrefix
     }
 
     if (media !== undefined) {

--- a/packages/react-jss/src/createUseStyles.js
+++ b/packages/react-jss/src/createUseStyles.js
@@ -20,7 +20,10 @@ const useEffectOrLayoutEffect = isInBrowser ? React.useLayoutEffect : React.useE
 
 const noTheme = {}
 
-const createUseStyles = <Theme: {}>(styles: Styles<Theme>, options?: HookOptions<Theme> = {}) => {
+const createUseStyles = <Theme: {}>(
+  styles: Styles<Theme>,
+  options?: HookOptions<Theme> = ({}: any)
+) => {
   const {index = getSheetIndex(), theming, name, ...sheetOptions} = options
   const ThemeContext = (theming && theming.context) || DefaultThemeContext
   const useTheme =

--- a/packages/react-jss/src/jsx.js
+++ b/packages/react-jss/src/jsx.js
@@ -4,8 +4,7 @@ import React from 'react'
 import defaultCss, {type Css} from 'css-jss'
 
 export const create = (css: Css = defaultCss) =>
-  // $FlowIgnore we don't care about the types here, since this is going to be called by the build tool.
-  function createElement(type, props) {
+  function createElement(type: string, props: Object | null /* :: , ..._args: any */) {
     const args = arguments
     if (props && props.css) {
       const className = css(props.css)

--- a/packages/react-jss/src/styled-props-filter.test.js
+++ b/packages/react-jss/src/styled-props-filter.test.js
@@ -182,6 +182,7 @@ describe('React-JSS: styled props filter', () => {
     })
   })
 
+  // $FlowIgnore
   it.skip('no prop filtering on string tags started with upper case', () => {
     const Link = styled('SomeCustomLink')({color: 'green'})
 

--- a/packages/react-jss/src/styled.js
+++ b/packages/react-jss/src/styled.js
@@ -130,7 +130,6 @@ const configureStyled = <Theme: {}>(
 
     const Styled = (props: StyledProps) => {
       const {as, className} = props
-      // $FlowFixMe theming ThemeContext types need to be fixed.
       const theme = React.useContext(ThemeContext)
       const propsWithTheme: StyledProps = Object.assign(({theme}: any), props)
       const classes = useStyles(propsWithTheme)

--- a/packages/react-jss/src/styled.js
+++ b/packages/react-jss/src/styled.js
@@ -106,25 +106,27 @@ const getChildProps = (props, shouldForwardProp, isTag) => {
   return childProps
 }
 
-type StyledOptions<Theme> = HookOptions<Theme> & {
+type StyledOptions<Theme> = {|
+  ...HookOptions<Theme>,
   shouldForwardProp?: ShouldForwardProp
-}
+|}
 
 const configureStyled = <Theme: {}>(
   tagOrComponent: string | StatelessFunctionalComponent<StyledProps> | ComponentType<StyledProps>,
-  options?: StyledOptions<Theme> = {}
+  options?: StyledOptions<Theme> = ({}: any)
 ) => {
   const {theming} = options
   const isTag = typeof tagOrComponent === 'string'
   const ThemeContext = theming ? theming.context : DefaultThemeContext
   const shouldForwardProp = getShouldForwardProp(tagOrComponent, options)
+  const {shouldForwardProp: _, ...hookOptions} = options
 
   return function createStyledComponent(/* :: ...args: StyleArg<Theme>[] */): StatelessFunctionalComponent<
     StyledProps
   > {
     // eslint-disable-next-line prefer-rest-params
     const {styles, label} = parseStyles(arguments)
-    const useStyles = createUseStyles(styles, options)
+    const useStyles = createUseStyles(styles, hookOptions)
 
     const Styled = (props: StyledProps) => {
       const {as, className} = props

--- a/packages/react-jss/src/styled.test.js
+++ b/packages/react-jss/src/styled.test.js
@@ -300,6 +300,7 @@ describe('React-JSS: styled', () => {
     })
   })
 
+  // $FlowIgnore
   it.skip('should target another styled component (not sure if we really need this)', () => {
     const Span = styled('span')({color: 'red'})
     const Div = styled('div')({
@@ -340,6 +341,7 @@ describe('React-JSS: styled', () => {
     `)
   })
 
+  // $FlowIgnore
   it.skip('should override theme over props', () => {})
 
   it('should render label', () => {

--- a/packages/react-jss/src/types.js
+++ b/packages/react-jss/src/types.js
@@ -13,17 +13,19 @@ import type {Theming} from 'theming'
 
 export type Managers = {[key: number]: SheetsManager}
 
-export type HookOptions<Theme> = StyleSheetFactoryOptions & {
+export type HookOptions<Theme> = {|
+  ...StyleSheetFactoryOptions,
   index?: number,
   name?: string,
   theming?: Theming<Theme>
-}
+|}
 
-export type HOCOptions<Theme> = StyleSheetFactoryOptions & {
+export type HOCOptions<Theme> = {|
+  ...StyleSheetFactoryOptions,
   index?: number,
   theming?: Theming<Theme>,
   injectTheme?: boolean
-}
+|}
 
 export type Context = {|
   jss?: Jss,

--- a/packages/react-jss/src/utils/sheetsMeta.js
+++ b/packages/react-jss/src/utils/sheetsMeta.js
@@ -1,16 +1,16 @@
 // @flow
 import type {StyleSheet} from 'jss'
-import type {StaticStyles} from '../types'
+import type {StaticStyles, DynamicStyle} from '../types'
 
-type SheetMeta = {|
-  styles: StaticStyles,
-  dynamicStyles: StaticStyles
+type SheetMeta<Theme> = {|
+  styles: $ReadOnly<StaticStyles>,
+  dynamicStyles: $ReadOnly<{[key: string]: DynamicStyle<Theme>}>
 |}
 
-const sheetsMeta = new WeakMap<StyleSheet, SheetMeta>()
+const sheetsMeta = new WeakMap<StyleSheet, SheetMeta<any>>()
 
-export const getMeta = (sheet: StyleSheet): SheetMeta | void => sheetsMeta.get(sheet)
+export const getMeta = <Theme>(sheet: StyleSheet): SheetMeta<Theme> | void => sheetsMeta.get(sheet)
 
-export const addMeta = (sheet: StyleSheet, meta: SheetMeta) => {
+export const addMeta = <Theme>(sheet: StyleSheet, meta: SheetMeta<Theme>) => {
   sheetsMeta.set(sheet, meta)
 }

--- a/packages/react-jss/src/withStyles.js
+++ b/packages/react-jss/src/withStyles.js
@@ -34,7 +34,7 @@ const noTheme = {}
  *
  * `withStyles(styles, [options])(Component)`
  */
-const withStyles = <Theme>(styles: Styles<Theme>, options?: HOCOptions<Theme> = {}) => {
+const withStyles = <Theme>(styles: Styles<Theme>, options?: HOCOptions<Theme> = ({}: any)) => {
   const {index = getSheetIndex(), theming, injectTheme, ...sheetOptions} = options
   const isThemingEnabled = typeof styles === 'function'
   const ThemeConsumer = (theming && theming.context.Consumer) || ThemeContext.Consumer

--- a/packages/react-jss/tests/styledSystem.js
+++ b/packages/react-jss/tests/styledSystem.js
@@ -180,7 +180,8 @@ describe('React-JSS: styled-system', () => {
     expect(className).to.be('css-0 css-d0-1')
     expect(classes).to.be(undefined)
   })
-
+  // $FlowIgnore
   it.skip('should handle the propTypes/meta for validation from function rules', () => {})
+  // $FlowIgnore
   it.skip('should do compose() automatically', () => {})
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -9131,10 +9131,10 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-theming@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/theming/-/theming-3.2.1.tgz#dc14b98d9f66303248cbbdba1d29cd44c5ac82ab"
-  integrity sha512-Lm7cv547nuulQQQHGLd2VmSiiXibkdjv414tyABZOW2XCeBhdLNBfOeVBgFHRp4hztUVoP+Nox1WTlUrqkpgkw==
+theming@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/theming/-/theming-3.3.0.tgz#dacabf04aa689edde35f1e1c117ec6de73fbf870"
+  integrity sha512-u6l4qTJRDaWZsqa8JugaNt7Xd8PPl9+gonZaIe28vAhqgHMIG/DOyFPqiKN/gQLQYj05tHv+YQdNILL4zoiAVA==
   dependencies:
     hoist-non-react-statics "^3.3.0"
     prop-types "^15.5.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4267,10 +4267,10 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.98.0:
-  version "0.98.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.98.1.tgz#a8d781621c91703df69928acc83c9777e2fcbb49"
-  integrity sha512-y1YzQgbFUX4EG6h2EO8PhyJeS0VxNgER8XsTwU8IXw4KozfneSmGVgw8y3TwAOza7rVhTlHEoli1xNuNW1rhPw==
+flow-bin@^0.131.0:
+  version "0.131.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.131.0.tgz#d4228b6070afdf3b2a76acdee77a7f3f8e8f5133"
+  integrity sha512-fZmoIBcDrtLhy/NNMxwJysSYzMr1ksRcAOMi3AHSoYXfcuQqTvhGJx+wqjlIOqIwz8RRYm8J4V4JrSJbIKP+Xg==
 
 flush-write-stream@^1.0.0:
   version "1.0.3"


### PR DESCRIPTION
## Todo

- [x] Upgrade theming package

```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ node_modules/theming/src/create-with-theme.js:23:18

Cannot spread props because Flow cannot determine a type for props [1]. object type [2] is
inexact, so it may contain ref with a type that conflicts with ref's definition in props [1].
Try making object type [2] exact. [cannot-spread-inexact]

     node_modules/theming/src/create-with-theme.js
      20│             '[theming] Please use withTheme only with the ThemeProvider'
      21│           );
      22│
 [1]  23│           return <Component theme={theme} ref={ref} {...props} />;
      24│         }}
      25│       </context.Consumer>
      26│     ));

     /private/tmp/flow/flowlib_36a9420e/react.js
 [2] 159│ declare type React$ComponentType<-Config> = React$AbstractComponent<Config, mixed>;
```