### PR TITLE
docs(csp): update style-loader config

### DIFF
--- a/docs/csp.md
+++ b/docs/csp.md
@@ -99,7 +99,7 @@ const config = {
         use: [
           {
             loader: 'style-loader',
-            options: {attrs: {nonce: '{{ styleNonce }}'}}
+            options: {attributes: {nonce: '{{ styleNonce }}'}}
           },
           'css-loader'
         ]
@@ -109,7 +109,7 @@ const config = {
         use: [
           {
             loader: 'style-loader',
-            options: {attrs: {nonce: '{{ styleNonce }}'}}
+            options: {attributes: {nonce: '{{ styleNonce }}'}}
           },
           'css-loader',
           'sass-loader'


### PR DESCRIPTION
## Corresponding issue (if exists):
The doc is using old style-loader API.

## What would you like to add/fix?
Based on the new API, `attrs` has been changed to `attributes` https://webpack.js.org/loaders/style-loader/#attributes
