### PR TITLE
Restore TypeScript support for Observable styles

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 Since you are interested in what happens next, in case, you work for a for-profit company that benefits from using the project, please consider supporting it on https://opencollective.com/jss.
 
+### Bug fixes
+
+- [jss] Restores TypeScript support for Observable styles [1402](https://github.com/cssinjs/jss/pull/1402)
+
 ---
 
 ## 10.4.0 (2020-8-14)

--- a/packages/jss/package.json
+++ b/packages/jss/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@babel/runtime": "^7.3.1",
     "csstype": "^3.0.2",
+    "indefinite-observable": "^2.0.1",
     "is-in-browser": "^1.1.3",
     "tiny-warning": "^1.0.2"
   },

--- a/packages/jss/src/index.d.ts
+++ b/packages/jss/src/index.d.ts
@@ -1,5 +1,12 @@
 import * as css from 'csstype'
 
+// Observable support is included as a plugin.  Including it here allows
+// TypeScript users to use Observables, which could be confusing if a user
+// hasn't installed that plugin.
+//
+// TODO: refactor to only include Observable types if plugin is installed.
+import {Observable} from 'indefinite-observable'
+
 // TODO: Type data better, currently typed as any for allowing to override it
 type Func<R> = ((data: any) => R)
 
@@ -13,11 +20,15 @@ export type JssStyle = {
     | NormalCssValues<K>
     | JssStyle
     | Func<NormalCssValues<K> | JssStyle | undefined>
+    | Observable<NormalCssValues<K> | JssStyle | undefined>
 }
 
 export type Styles<Name extends string | number | symbol = string> = Record<
   Name,
-  JssStyle | string | Func<JssStyle | string | null | undefined>
+  | JssStyle
+  | string
+  | Func<JssStyle | string | null | undefined>
+  | Observable<JssStyle | string | null | undefined>
 >
 export type Classes<Name extends string | number | symbol = string> = Record<Name, string>
 export type Keyframes<Name extends string = string> = Record<Name, string>

--- a/packages/jss/tests/jss-tests.ts
+++ b/packages/jss/tests/jss-tests.ts
@@ -10,7 +10,7 @@ import {
 import {NextChannel} from 'indefinite-observable'
 
 const jss = createJSS().setup({createGenerateId})
-jss.use({}, {}) // $ExpectType JSS
+jss.use({}, {})
 
 const styleSheet = jss.createStyleSheet<string>(
   {
@@ -18,10 +18,6 @@ const styleSheet = jss.createStyleSheet<string>(
       subscribe: (observer: {next: NextChannel<JssStyle | string | null | undefined>}) => {
         const next = typeof observer === 'function' ? observer : observer.next
         next({background: 'blue', display: 'flex'})
-
-        // These tests are ported over from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/de655960b603d6b47f7030674f084780c76e045f/types/jss/jss-tests.ts
-        // where there were $ExpectError cases; however, those don't seem to be
-        // enforced in JSS's current testing harness.
 
         return {
           unsubscribe() {}
@@ -49,11 +45,11 @@ const styleSheet = jss.createStyleSheet<string>(
 
 const attachedStyleSheet = styleSheet.attach()
 
-attachedStyleSheet.classes.container // $ExpectType string
-attachedStyleSheet.classes.ruleWithMockObservable // $ExpectType string
+attachedStyleSheet.classes.container
+attachedStyleSheet.classes.ruleWithMockObservable
 
 const rule = attachedStyleSheet.addRule('dynamicRule', {color: 'indigo'})
-attachedStyleSheet.classes.dynamicRule // $ExpectType string
+attachedStyleSheet.classes.dynamicRule
 
 attachedStyleSheet.deleteRule('dynamicRule')
 
@@ -89,7 +85,7 @@ const styleSheet2 = sharedInstance.createStyleSheet({
   }
 })
 
-styleSheet2.classes.container // $ExpectType string
+styleSheet2.classes.container
 // @ts-ignore
 styleSheet2.classes.notAValidKey
 
@@ -113,9 +109,9 @@ const secondStyleSheet = jss.createStyleSheet(
 sheetsRegistry.add(secondStyleSheet)
 sheetsRegistry.remove(secondStyleSheet)
 
-sheetsRegistry.index // $ExpectType number
-sheetsRegistry.toString() // $ExpectType string
+sheetsRegistry.index
+sheetsRegistry.toString()
 // With css options
-sheetsRegistry.toString({indent: 5}) // $ExpectType string
+sheetsRegistry.toString({indent: 5})
 
 sheetsRegistry.reset()

--- a/packages/jss/tests/types/Styles.ts
+++ b/packages/jss/tests/types/Styles.ts
@@ -1,8 +1,15 @@
 import {Styles} from '../../src'
+import {Observable} from 'indefinite-observable'
 
 interface Props {
   flag?: boolean
 }
+
+declare const color$: Observable<'cyan'>
+declare const style$: Observable<{
+  backgroundColor: 'fuchsia'
+  transform: 'translate(0px, 205px)'
+}>
 
 const styles: Styles = {
   basic: {
@@ -50,6 +57,11 @@ const styles: Styles = {
       height: 288
     })
   }),
+  observable: style$,
+  observableRule: {
+    backgroundColor: color$,
+    color: 'lime'
+  },
   '@keyframes fadeIn': {
     from: {opacity: 0},
     to: {opacity: 1}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4967,6 +4967,13 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
+indefinite-observable@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/indefinite-observable/-/indefinite-observable-2.0.1.tgz#574af29bfbc17eb5947793797bddc94c9d859400"
+  integrity sha512-G8vgmork+6H9S8lUAg1gtXEj2JxIQTo0g2PbFiYOdjkziSI0F7UYBiVwhZRuixhBCNGczAls34+5HJPyZysvxQ==
+  dependencies:
+    symbol-observable "1.2.0"
+
 indent-string@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"


### PR DESCRIPTION
## Corresponding issue (if exists):

## What would you like to add/fix?

```typescript
const jss = createJSS(createDefaultJSSPreset());
jss.createStyleSheet(
  {
    myClassName: someObservable$,
  },
  {
    link: true,
  },
).attach();
```

should work in TypeScript, and [used to work with `@types/jss`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/de655960b603d6b47f7030674f084780c76e045f/types/jss/css.d.ts).  JSS now supplies its own types, which don't include `Observable` support.  This PR adds them back.

As @worudso alluded to in #1035, a better solution would only include the `Observable` type if users had installed the Observable plugin.  Otherwise, users could be frustrated if the typecheck passes for `createStyleSheet(someObservables)` but it fails at runtime.

However, that solution would require bigger and more thoughtful changes to the typings.  This PR is a quick fix that addresses the regression from `@types/jss`, while leaving the work of a refactor to a future PR.


## Todo

- [x] Add tests if possible
- [x] Add changelog if users should know about the change
- [ ] ~Add documentation~
