### PR TITLE
perf: remove test files from the package

### DIFF
--- a/packages/css-jss/package.json
+++ b/packages/css-jss/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test.*)",
+    "src",
+    "!*.test.*",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/css-jss/package.json
+++ b/packages/css-jss/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/cssinjs/jss/issues/new"
   },
   "files": [
+    "!*.test.js",
     "dist",
     "src",
     "LICENSE"

--- a/packages/css-jss/package.json
+++ b/packages/css-jss/package.json
@@ -19,8 +19,7 @@
   "files": [
     "dist",
     "src",
-    "!*.test.*",
-    "LICENSE"
+    "!*.test.*"
   ],
   "keywords": [
     "jss",

--- a/packages/css-jss/package.json
+++ b/packages/css-jss/package.json
@@ -17,9 +17,8 @@
     "url": "https://github.com/cssinjs/jss/issues/new"
   },
   "files": [
-    "!*.test.js",
     "dist",
-    "src",
+    "src/**/!(*.test).js",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/css-jss/package.json
+++ b/packages/css-jss/package.json
@@ -18,7 +18,7 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test).js",
+    "src/**/!(*.test.*)",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-cache/package.json
+++ b/packages/jss-plugin-cache/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test.*)",
+    "src",
+    "!*.test.*",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-cache/package.json
+++ b/packages/jss-plugin-cache/package.json
@@ -19,8 +19,7 @@
   "files": [
     "dist",
     "src",
-    "!*.test.*",
-    "LICENSE"
+    "!*.test.*"
   ],
   "keywords": [
     "cssinjs",

--- a/packages/jss-plugin-cache/package.json
+++ b/packages/jss-plugin-cache/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-cache]"
   },
   "files": [
+    "!*.test.js",
     "dist",
     "src",
     "LICENSE"

--- a/packages/jss-plugin-cache/package.json
+++ b/packages/jss-plugin-cache/package.json
@@ -17,9 +17,8 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-cache]"
   },
   "files": [
-    "!*.test.js",
     "dist",
-    "src",
+    "src/**/!(*.test).js",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-cache/package.json
+++ b/packages/jss-plugin-cache/package.json
@@ -18,7 +18,7 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test).js",
+    "src/**/!(*.test.*)",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-camel-case/package.json
+++ b/packages/jss-plugin-camel-case/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test.*)",
+    "src",
+    "!*.test.*",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-camel-case/package.json
+++ b/packages/jss-plugin-camel-case/package.json
@@ -19,8 +19,7 @@
   "files": [
     "dist",
     "src",
-    "!*.test.*",
-    "LICENSE"
+    "!*.test.*"
   ],
   "keywords": [
     "cssinjs",

--- a/packages/jss-plugin-camel-case/package.json
+++ b/packages/jss-plugin-camel-case/package.json
@@ -17,9 +17,8 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-camel-case]"
   },
   "files": [
-    "!*.test.js",
     "dist",
-    "src",
+    "src/**/!(*.test).js",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-camel-case/package.json
+++ b/packages/jss-plugin-camel-case/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-camel-case]"
   },
   "files": [
+    "!*.test.js",
     "dist",
     "src",
     "LICENSE"

--- a/packages/jss-plugin-camel-case/package.json
+++ b/packages/jss-plugin-camel-case/package.json
@@ -18,7 +18,7 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test).js",
+    "src/**/!(*.test.*)",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-compose/package.json
+++ b/packages/jss-plugin-compose/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test.*)",
+    "src",
+    "!*.test.*",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-compose/package.json
+++ b/packages/jss-plugin-compose/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-compose]"
   },
   "files": [
+    "!*.test.js",
     "dist",
     "src",
     "LICENSE"

--- a/packages/jss-plugin-compose/package.json
+++ b/packages/jss-plugin-compose/package.json
@@ -17,9 +17,8 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-compose]"
   },
   "files": [
-    "!*.test.js",
     "dist",
-    "src",
+    "src/**/!(*.test).js",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-compose/package.json
+++ b/packages/jss-plugin-compose/package.json
@@ -19,8 +19,7 @@
   "files": [
     "dist",
     "src",
-    "!*.test.*",
-    "LICENSE"
+    "!*.test.*"
   ],
   "keywords": [
     "cssinnjs",

--- a/packages/jss-plugin-compose/package.json
+++ b/packages/jss-plugin-compose/package.json
@@ -18,7 +18,7 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test).js",
+    "src/**/!(*.test.*)",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-default-unit/package.json
+++ b/packages/jss-plugin-default-unit/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test.*)",
+    "src",
+    "!*.test.*",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-default-unit/package.json
+++ b/packages/jss-plugin-default-unit/package.json
@@ -19,8 +19,7 @@
   "files": [
     "dist",
     "src",
-    "!*.test.*",
-    "LICENSE"
+    "!*.test.*"
   ],
   "keywords": [
     "cssinjs",

--- a/packages/jss-plugin-default-unit/package.json
+++ b/packages/jss-plugin-default-unit/package.json
@@ -17,9 +17,8 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-default-unit]"
   },
   "files": [
-    "!*.test.js",
     "dist",
-    "src",
+    "src/**/!(*.test).js",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-default-unit/package.json
+++ b/packages/jss-plugin-default-unit/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-default-unit]"
   },
   "files": [
+    "!*.test.js",
     "dist",
     "src",
     "LICENSE"

--- a/packages/jss-plugin-default-unit/package.json
+++ b/packages/jss-plugin-default-unit/package.json
@@ -18,7 +18,7 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test).js",
+    "src/**/!(*.test.*)",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-expand/package.json
+++ b/packages/jss-plugin-expand/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test.*)",
+    "src",
+    "!*.test.*",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-expand/package.json
+++ b/packages/jss-plugin-expand/package.json
@@ -19,8 +19,7 @@
   "files": [
     "dist",
     "src",
-    "!*.test.*",
-    "LICENSE"
+    "!*.test.*"
   ],
   "keywords": [
     "cssinjs",

--- a/packages/jss-plugin-expand/package.json
+++ b/packages/jss-plugin-expand/package.json
@@ -17,9 +17,8 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-expand]"
   },
   "files": [
-    "!*.test.js",
     "dist",
-    "src",
+    "src/**/!(*.test).js",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-expand/package.json
+++ b/packages/jss-plugin-expand/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-expand]"
   },
   "files": [
+    "!*.test.js",
     "dist",
     "src",
     "LICENSE"

--- a/packages/jss-plugin-expand/package.json
+++ b/packages/jss-plugin-expand/package.json
@@ -18,7 +18,7 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test).js",
+    "src/**/!(*.test.*)",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-extend/package.json
+++ b/packages/jss-plugin-extend/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test.*)",
+    "src",
+    "!*.test.*",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-extend/package.json
+++ b/packages/jss-plugin-extend/package.json
@@ -17,9 +17,8 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-extend]"
   },
   "files": [
-    "!*.test.js",
     "dist",
-    "src",
+    "src/**/!(*.test).js",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-extend/package.json
+++ b/packages/jss-plugin-extend/package.json
@@ -19,8 +19,7 @@
   "files": [
     "dist",
     "src",
-    "!*.test.*",
-    "LICENSE"
+    "!*.test.*"
   ],
   "keywords": [
     "jss",

--- a/packages/jss-plugin-extend/package.json
+++ b/packages/jss-plugin-extend/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-extend]"
   },
   "files": [
+    "!*.test.js",
     "dist",
     "src",
     "LICENSE"

--- a/packages/jss-plugin-extend/package.json
+++ b/packages/jss-plugin-extend/package.json
@@ -18,7 +18,7 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test).js",
+    "src/**/!(*.test.*)",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-global/package.json
+++ b/packages/jss-plugin-global/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test.*)",
+    "src",
+    "!*.test.*",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-global/package.json
+++ b/packages/jss-plugin-global/package.json
@@ -19,8 +19,7 @@
   "files": [
     "dist",
     "src",
-    "!*.test.*",
-    "LICENSE"
+    "!*.test.*"
   ],
   "keywords": [
     "cssinjs",

--- a/packages/jss-plugin-global/package.json
+++ b/packages/jss-plugin-global/package.json
@@ -17,9 +17,8 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-global]"
   },
   "files": [
-    "!*.test.js",
     "dist",
-    "src",
+    "src/**/!(*.test).js",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-global/package.json
+++ b/packages/jss-plugin-global/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-global]"
   },
   "files": [
+    "!*.test.js",
     "dist",
     "src",
     "LICENSE"

--- a/packages/jss-plugin-global/package.json
+++ b/packages/jss-plugin-global/package.json
@@ -18,7 +18,7 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test).js",
+    "src/**/!(*.test.*)",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-isolate/package.json
+++ b/packages/jss-plugin-isolate/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test.*)",
+    "src",
+    "!*.test.*",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-isolate/package.json
+++ b/packages/jss-plugin-isolate/package.json
@@ -19,8 +19,7 @@
   "files": [
     "dist",
     "src",
-    "!*.test.*",
-    "LICENSE"
+    "!*.test.*"
   ],
   "keywords": [
     "cssinjs",

--- a/packages/jss-plugin-isolate/package.json
+++ b/packages/jss-plugin-isolate/package.json
@@ -17,9 +17,8 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-isolate]"
   },
   "files": [
-    "!*.test.js",
     "dist",
-    "src",
+    "src/**/!(*.test).js",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-isolate/package.json
+++ b/packages/jss-plugin-isolate/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-isolate]"
   },
   "files": [
+    "!*.test.js",
     "dist",
     "src",
     "LICENSE"

--- a/packages/jss-plugin-isolate/package.json
+++ b/packages/jss-plugin-isolate/package.json
@@ -18,7 +18,7 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test).js",
+    "src/**/!(*.test.*)",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-nested/package.json
+++ b/packages/jss-plugin-nested/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test.*)",
+    "src",
+    "!*.test.*",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-nested/package.json
+++ b/packages/jss-plugin-nested/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-nested]"
   },
   "files": [
+    "!*.test.js",
     "dist",
     "src",
     "LICENSE"

--- a/packages/jss-plugin-nested/package.json
+++ b/packages/jss-plugin-nested/package.json
@@ -19,8 +19,7 @@
   "files": [
     "dist",
     "src",
-    "!*.test.*",
-    "LICENSE"
+    "!*.test.*"
   ],
   "keywords": [
     "cssinjs",

--- a/packages/jss-plugin-nested/package.json
+++ b/packages/jss-plugin-nested/package.json
@@ -17,9 +17,8 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-nested]"
   },
   "files": [
-    "!*.test.js",
     "dist",
-    "src",
+    "src/**/!(*.test).js",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-nested/package.json
+++ b/packages/jss-plugin-nested/package.json
@@ -18,7 +18,7 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test).js",
+    "src/**/!(*.test.*)",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-props-sort/package.json
+++ b/packages/jss-plugin-props-sort/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test.*)",
+    "src",
+    "!*.test.*",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-props-sort/package.json
+++ b/packages/jss-plugin-props-sort/package.json
@@ -19,8 +19,7 @@
   "files": [
     "dist",
     "src",
-    "!*.test.*",
-    "LICENSE"
+    "!*.test.*"
   ],
   "keywords": [
     "cssinjs",

--- a/packages/jss-plugin-props-sort/package.json
+++ b/packages/jss-plugin-props-sort/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-props-sort]"
   },
   "files": [
+    "!*.test.js",
     "dist",
     "src",
     "LICENSE"

--- a/packages/jss-plugin-props-sort/package.json
+++ b/packages/jss-plugin-props-sort/package.json
@@ -17,9 +17,8 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-props-sort]"
   },
   "files": [
-    "!*.test.js",
     "dist",
-    "src",
+    "src/**/!(*.test).js",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-props-sort/package.json
+++ b/packages/jss-plugin-props-sort/package.json
@@ -18,7 +18,7 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test).js",
+    "src/**/!(*.test.*)",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-rule-value-function/package.json
+++ b/packages/jss-plugin-rule-value-function/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-rule-value-function]"
   },
   "files": [
+    "!*.test.js",
     "dist",
     "src",
     "LICENSE"

--- a/packages/jss-plugin-rule-value-function/package.json
+++ b/packages/jss-plugin-rule-value-function/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test.*)",
+    "src",
+    "!*.test.*",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-rule-value-function/package.json
+++ b/packages/jss-plugin-rule-value-function/package.json
@@ -19,8 +19,7 @@
   "files": [
     "dist",
     "src",
-    "!*.test.*",
-    "LICENSE"
+    "!*.test.*"
   ],
   "keywords": [
     "jss",

--- a/packages/jss-plugin-rule-value-function/package.json
+++ b/packages/jss-plugin-rule-value-function/package.json
@@ -18,7 +18,7 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test).js",
+    "src/**/!(*.test.*)",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-rule-value-function/package.json
+++ b/packages/jss-plugin-rule-value-function/package.json
@@ -17,9 +17,8 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-rule-value-function]"
   },
   "files": [
-    "!*.test.js",
     "dist",
-    "src",
+    "src/**/!(*.test).js",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-rule-value-observable/package.json
+++ b/packages/jss-plugin-rule-value-observable/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test.*)",
+    "src",
+    "!*.test.*",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-rule-value-observable/package.json
+++ b/packages/jss-plugin-rule-value-observable/package.json
@@ -17,9 +17,8 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-rule-value-observable]"
   },
   "files": [
-    "!*.test.js",
     "dist",
-    "src",
+    "src/**/!(*.test).js",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-rule-value-observable/package.json
+++ b/packages/jss-plugin-rule-value-observable/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-rule-value-observable]"
   },
   "files": [
+    "!*.test.js",
     "dist",
     "src",
     "LICENSE"

--- a/packages/jss-plugin-rule-value-observable/package.json
+++ b/packages/jss-plugin-rule-value-observable/package.json
@@ -19,8 +19,7 @@
   "files": [
     "dist",
     "src",
-    "!*.test.*",
-    "LICENSE"
+    "!*.test.*"
   ],
   "keywords": [
     "jss",

--- a/packages/jss-plugin-rule-value-observable/package.json
+++ b/packages/jss-plugin-rule-value-observable/package.json
@@ -18,7 +18,7 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test).js",
+    "src/**/!(*.test.*)",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-template/package.json
+++ b/packages/jss-plugin-template/package.json
@@ -17,9 +17,8 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-template]"
   },
   "files": [
-    "!*.test.js",
     "dist",
-    "src",
+    "src/**/!(*.test).js",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-template/package.json
+++ b/packages/jss-plugin-template/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test.*)",
+    "src",
+    "!*.test.*",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-template/package.json
+++ b/packages/jss-plugin-template/package.json
@@ -19,8 +19,7 @@
   "files": [
     "dist",
     "src",
-    "!*.test.*",
-    "LICENSE"
+    "!*.test.*"
   ],
   "keywords": [
     "cssinjs",

--- a/packages/jss-plugin-template/package.json
+++ b/packages/jss-plugin-template/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-template]"
   },
   "files": [
+    "!*.test.js",
     "dist",
     "src",
     "LICENSE"

--- a/packages/jss-plugin-template/package.json
+++ b/packages/jss-plugin-template/package.json
@@ -18,7 +18,7 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test).js",
+    "src/**/!(*.test.*)",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-vendor-prefixer/package.json
+++ b/packages/jss-plugin-vendor-prefixer/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test.*)",
+    "src",
+    "!*.test.*",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-vendor-prefixer/package.json
+++ b/packages/jss-plugin-vendor-prefixer/package.json
@@ -17,9 +17,8 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-vendor-prefixer]"
   },
   "files": [
-    "!*.test.js",
     "dist",
-    "src",
+    "src/**/!(*.test).js",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-plugin-vendor-prefixer/package.json
+++ b/packages/jss-plugin-vendor-prefixer/package.json
@@ -19,8 +19,7 @@
   "files": [
     "dist",
     "src",
-    "!*.test.*",
-    "LICENSE"
+    "!*.test.*"
   ],
   "keywords": [
     "cssinjs",

--- a/packages/jss-plugin-vendor-prefixer/package.json
+++ b/packages/jss-plugin-vendor-prefixer/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-vendor-prefixer]"
   },
   "files": [
+    "!*.test.js",
     "dist",
     "src",
     "LICENSE"

--- a/packages/jss-plugin-vendor-prefixer/package.json
+++ b/packages/jss-plugin-vendor-prefixer/package.json
@@ -18,7 +18,7 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test).js",
+    "src/**/!(*.test.*)",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-preset-default/package.json
+++ b/packages/jss-preset-default/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test.*)",
+    "src",
+    "!*.test.*",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-preset-default/package.json
+++ b/packages/jss-preset-default/package.json
@@ -17,9 +17,8 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-preset-default]"
   },
   "files": [
-    "!*.test.js",
     "dist",
-    "src",
+    "src/**/!(*.test).js",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-preset-default/package.json
+++ b/packages/jss-preset-default/package.json
@@ -19,8 +19,7 @@
   "files": [
     "dist",
     "src",
-    "!*.test.*",
-    "LICENSE"
+    "!*.test.*"
   ],
   "keywords": [
     "jss",

--- a/packages/jss-preset-default/package.json
+++ b/packages/jss-preset-default/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-preset-default]"
   },
   "files": [
+    "!*.test.js",
     "dist",
     "src",
     "LICENSE"

--- a/packages/jss-preset-default/package.json
+++ b/packages/jss-preset-default/package.json
@@ -18,7 +18,7 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test).js",
+    "src/**/!(*.test.*)",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-starter-kit/package.json
+++ b/packages/jss-starter-kit/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test.*)",
+    "src",
+    "!*.test.*",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-starter-kit/package.json
+++ b/packages/jss-starter-kit/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/cssinjs/jss/issues/new"
   },
   "files": [
+    "!*.test.js",
     "dist",
     "src",
     "LICENSE"

--- a/packages/jss-starter-kit/package.json
+++ b/packages/jss-starter-kit/package.json
@@ -19,8 +19,7 @@
   "files": [
     "dist",
     "src",
-    "!*.test.*",
-    "LICENSE"
+    "!*.test.*"
   ],
   "keywords": [
     "jss",

--- a/packages/jss-starter-kit/package.json
+++ b/packages/jss-starter-kit/package.json
@@ -17,9 +17,8 @@
     "url": "https://github.com/cssinjs/jss/issues/new"
   },
   "files": [
-    "!*.test.js",
     "dist",
-    "src",
+    "src/**/!(*.test).js",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss-starter-kit/package.json
+++ b/packages/jss-starter-kit/package.json
@@ -18,7 +18,7 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test).js",
+    "src/**/!(*.test.*)",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss/package.json
+++ b/packages/jss/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test.*)",
+    "src",
+    "!*.test.*",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss/package.json
+++ b/packages/jss/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/cssinjs/jss/issues/new"
   },
   "files": [
+    "!*.test.js",
     "dist",
     "src",
     "LICENSE"

--- a/packages/jss/package.json
+++ b/packages/jss/package.json
@@ -19,8 +19,7 @@
   "files": [
     "dist",
     "src",
-    "!*.test.*",
-    "LICENSE"
+    "!*.test.*"
   ],
   "keywords": [
     "jss",

--- a/packages/jss/package.json
+++ b/packages/jss/package.json
@@ -17,9 +17,8 @@
     "url": "https://github.com/cssinjs/jss/issues/new"
   },
   "files": [
-    "!*.test.js",
     "dist",
-    "src",
+    "src/**/!(*.test).js",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/jss/package.json
+++ b/packages/jss/package.json
@@ -18,7 +18,7 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test).js",
+    "src/**/!(*.test.*)",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/react-jss/package.json
+++ b/packages/react-jss/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test.*)",
+    "src",
+    "!*.test.*",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/react-jss/package.json
+++ b/packages/react-jss/package.json
@@ -17,9 +17,8 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[react-jss]"
   },
   "files": [
-    "!*.test.js",
     "dist",
-    "src",
+    "src/**/!(*.test).js",
     "LICENSE"
   ],
   "keywords": [

--- a/packages/react-jss/package.json
+++ b/packages/react-jss/package.json
@@ -19,8 +19,7 @@
   "files": [
     "dist",
     "src",
-    "!*.test.*",
-    "LICENSE"
+    "!*.test.*"
   ],
   "keywords": [
     "react",

--- a/packages/react-jss/package.json
+++ b/packages/react-jss/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/cssinjs/jss/issues/new?title=[react-jss]"
   },
   "files": [
+    "!*.test.js",
     "dist",
     "src",
     "LICENSE"

--- a/packages/react-jss/package.json
+++ b/packages/react-jss/package.json
@@ -18,7 +18,7 @@
   },
   "files": [
     "dist",
-    "src/**/!(*.test).js",
+    "src/**/!(*.test.*)",
     "LICENSE"
   ],
   "keywords": [


### PR DESCRIPTION
## Corresponding issue (if exists):
https://github.com/cssinjs/jss/issues/979
## What would you like to add/fix?
Prevent the test files from being published to NPM.

I'm not super comfortable with how lerna works, but I believe this is what's needed.

## Todo

- [X] Add tests if possible (N/A)
- [X] Add changelog if users should know about the change (N/A)
- [X] Add documentation (N/A)
