### PR TITLE
[default-unit] Fix missing default unit for 0ms and 0%

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@ Since you are interested in what happens next, in case, you work for a for-profi
 ### Bug fixes
 
 - [jss] Restores TypeScript support for Observable styles [1402](https://github.com/cssinjs/jss/pull/1402)
-- [jss-plugin-default-unit] Fix missing default unit bug for 0ms and 0% [1413](https://github.com/cssinjs/jss/pull/1413)
+- [jss-plugin-default-unit] Fix missing default unit for 0ms and 0% [1413](https://github.com/cssinjs/jss/pull/1413)
 
 ---
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Since you are interested in what happens next, in case, you work for a for-profi
 ### Bug fixes
 
 - [jss] Restores TypeScript support for Observable styles [1402](https://github.com/cssinjs/jss/pull/1402)
+- [jss-plugin-default-unit] Fix missing default unit bug for 0ms and 0% [1413](https://github.com/cssinjs/jss/pull/1413)
 
 ---
 

--- a/docs/react-jss.md
+++ b/docs/react-jss.md
@@ -177,22 +177,27 @@ and
   font-style: italic;
 }
 ```
+
 ## Prefix classname
+
 ```javascript
 import React from 'react'
 import {createUseStyles} from 'react-jss'
 
-const useStyles = createUseStyles({
-  myButton: {
-    padding: props => props.spacing
+const useStyles = createUseStyles(
+  {
+    myButton: {
+      padding: props => props.spacing
+    },
+    myLabel: props => ({
+      display: 'block',
+      color: props.labelColor,
+      fontWeight: props.fontWeight,
+      fontStyle: props.fontStyle
+    })
   },
-  myLabel: props => ({
-    display: 'block',
-    color: props.labelColor,
-    fontWeight: props.fontWeight,
-    fontStyle: props.fontStyle
-  })
-}, {name: 'Button'})
+  {name: 'Button'}
+)
 
 const Button = ({children, ...props}) => {
   const classes = useStyles(props)

--- a/packages/css-jss/.size-snapshot.json
+++ b/packages/css-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/css-jss.js": {
-    "bundled": 59599,
-    "minified": 21252,
-    "gzipped": 7233
+    "bundled": 59713,
+    "minified": 21273,
+    "gzipped": 7244
   },
   "dist/css-jss.min.js": {
-    "bundled": 58524,
-    "minified": 20657,
-    "gzipped": 6968
+    "bundled": 58638,
+    "minified": 20678,
+    "gzipped": 6979
   },
   "dist/css-jss.cjs.js": {
     "bundled": 2968,

--- a/packages/css-jss/.size-snapshot.json
+++ b/packages/css-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/css-jss.js": {
-    "bundled": 59713,
-    "minified": 21273,
-    "gzipped": 7244
+    "bundled": 59705,
+    "minified": 21271,
+    "gzipped": 7242
   },
   "dist/css-jss.min.js": {
-    "bundled": 58638,
-    "minified": 20678,
-    "gzipped": 6979
+    "bundled": 58630,
+    "minified": 20676,
+    "gzipped": 6978
   },
   "dist/css-jss.cjs.js": {
     "bundled": 2968,

--- a/packages/jss-plugin-default-unit/.size-snapshot.json
+++ b/packages/jss-plugin-default-unit/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/jss-plugin-default-unit.js": {
-    "bundled": 5644,
-    "minified": 2727,
-    "gzipped": 1055
+    "bundled": 5758,
+    "minified": 2748,
+    "gzipped": 1070
   },
   "dist/jss-plugin-default-unit.min.js": {
-    "bundled": 5644,
-    "minified": 2727,
-    "gzipped": 1055
+    "bundled": 5758,
+    "minified": 2748,
+    "gzipped": 1070
   },
   "dist/jss-plugin-default-unit.cjs.js": {
-    "bundled": 4948,
-    "minified": 2816,
-    "gzipped": 1021
+    "bundled": 5062,
+    "minified": 2838,
+    "gzipped": 1035
   },
   "dist/jss-plugin-default-unit.esm.js": {
-    "bundled": 4868,
-    "minified": 2750,
-    "gzipped": 965,
+    "bundled": 4982,
+    "minified": 2772,
+    "gzipped": 981,
     "treeshaked": {
       "rollup": {
         "code": 1865,

--- a/packages/jss-plugin-default-unit/.size-snapshot.json
+++ b/packages/jss-plugin-default-unit/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/jss-plugin-default-unit.js": {
-    "bundled": 5758,
-    "minified": 2748,
-    "gzipped": 1070
+    "bundled": 5750,
+    "minified": 2746,
+    "gzipped": 1068
   },
   "dist/jss-plugin-default-unit.min.js": {
-    "bundled": 5758,
-    "minified": 2748,
-    "gzipped": 1070
+    "bundled": 5750,
+    "minified": 2746,
+    "gzipped": 1068
   },
   "dist/jss-plugin-default-unit.cjs.js": {
-    "bundled": 5062,
-    "minified": 2838,
+    "bundled": 5054,
+    "minified": 2836,
     "gzipped": 1035
   },
   "dist/jss-plugin-default-unit.esm.js": {
-    "bundled": 4982,
-    "minified": 2772,
-    "gzipped": 981,
+    "bundled": 4974,
+    "minified": 2770,
+    "gzipped": 979,
     "treeshaked": {
       "rollup": {
         "code": 1865,

--- a/packages/jss-plugin-default-unit/src/defaultUnits.js
+++ b/packages/jss-plugin-default-unit/src/defaultUnits.js
@@ -2,9 +2,9 @@
 
 import {hasCSSTOMSupport} from 'jss'
 
-const px = hasCSSTOMSupport && CSS ? CSS.px : 'px'
-const ms = hasCSSTOMSupport && CSS ? CSS.ms : 'ms'
-const percent = hasCSSTOMSupport && CSS ? CSS.percent : '%'
+export const px = hasCSSTOMSupport && CSS ? CSS.px : 'px'
+export const ms = hasCSSTOMSupport && CSS ? CSS.ms : 'ms'
+export const percent = hasCSSTOMSupport && CSS ? CSS.percent : '%'
 
 /**
  * Generated jss-plugin-default-unit CSS property units

--- a/packages/jss-plugin-default-unit/src/index.js
+++ b/packages/jss-plugin-default-unit/src/index.js
@@ -24,7 +24,7 @@ const units = addCamelCasedVersion(defaultUnits)
  * Recursive deep style passing function
  */
 function iterate(prop: string, value: any, options: Options) {
-  if (!value && value !== 0) return value
+  if (value == null) return value
 
   if (Array.isArray(value)) {
     for (let i = 0; i < value.length; i++) {

--- a/packages/jss-plugin-default-unit/src/index.js
+++ b/packages/jss-plugin-default-unit/src/index.js
@@ -1,6 +1,6 @@
 // @flow
 import type {Plugin} from 'jss'
-import defaultUnits from './defaultUnits'
+import defaultUnits, {px} from './defaultUnits'
 
 export type Options = {[key: string]: string | ((val: number) => string)}
 
@@ -24,7 +24,7 @@ const units = addCamelCasedVersion(defaultUnits)
  * Recursive deep style passing function
  */
 function iterate(prop: string, value: any, options: Options) {
-  if (!value) return value
+  if (!value && value !== 0) return value
 
   if (Array.isArray(value)) {
     for (let i = 0; i < value.length; i++) {
@@ -43,7 +43,8 @@ function iterate(prop: string, value: any, options: Options) {
   } else if (typeof value === 'number') {
     const unit = options[prop] || units[prop]
 
-    if (unit) {
+    // Add the unit if available, except for the special case of 0px.
+    if (unit && !(value === 0 && unit === px)) {
       return typeof unit === 'function' ? unit(value).toString() : `${value}${unit}`
     }
 

--- a/packages/jss-plugin-default-unit/src/index.test.js
+++ b/packages/jss-plugin-default-unit/src/index.test.js
@@ -99,6 +99,44 @@ describe('jss-plugin-default-unit', () => {
     })
   })
 
+  describe('0 values', () => {
+    it('should generate 0 when value is unitless', () => {
+      const sheet = jss.createStyleSheet({
+        a: {
+          zoom: 0
+        }
+      })
+      expect(sheet.toString()).to.be('.a-id {\n  zoom: 0;\n}')
+    })
+
+    it('should generate 0 instead of 0px when default unit is px', () => {
+      const sheet = jss.createStyleSheet({
+        a: {
+          width: 0
+        }
+      })
+      expect(sheet.toString()).to.be('.a-id {\n  width: 0;\n}')
+    })
+
+    it('should generate 0ms when default unit is ms', () => {
+      const sheet = jss.createStyleSheet({
+        a: {
+          'animation-duration': 0
+        }
+      })
+      expect(sheet.toString()).to.be('.a-id {\n  animation-duration: 0ms;\n}')
+    })
+
+    it('should generate 0% when default unit is %', () => {
+      const sheet = jss.createStyleSheet({
+        a: {
+          'transform-origin-x': 0
+        }
+      })
+      expect(sheet.toString()).to.be('.a-id {\n  transform-origin-x: 0%;\n}')
+    })
+  })
+
   describe('leave non-regular rules unchanged', () => {
     let sheet
 

--- a/packages/jss-preset-default/.size-snapshot.json
+++ b/packages/jss-preset-default/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/jss-preset-default.js": {
-    "bundled": 56906,
-    "minified": 20499,
-    "gzipped": 6895
+    "bundled": 56898,
+    "minified": 20497,
+    "gzipped": 6893
   },
   "dist/jss-preset-default.min.js": {
-    "bundled": 55831,
-    "minified": 19904,
-    "gzipped": 6627
+    "bundled": 55823,
+    "minified": 19902,
+    "gzipped": 6626
   },
   "dist/jss-preset-default.cjs.js": {
     "bundled": 1329,

--- a/packages/jss-preset-default/.size-snapshot.json
+++ b/packages/jss-preset-default/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/jss-preset-default.js": {
-    "bundled": 56792,
-    "minified": 20478,
-    "gzipped": 6885
+    "bundled": 56906,
+    "minified": 20499,
+    "gzipped": 6895
   },
   "dist/jss-preset-default.min.js": {
-    "bundled": 55717,
-    "minified": 19883,
-    "gzipped": 6616
+    "bundled": 55831,
+    "minified": 19904,
+    "gzipped": 6627
   },
   "dist/jss-preset-default.cjs.js": {
     "bundled": 1329,

--- a/packages/jss-starter-kit/.size-snapshot.json
+++ b/packages/jss-starter-kit/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/jss-starter-kit.js": {
-    "bundled": 72696,
-    "minified": 30693,
-    "gzipped": 9533
+    "bundled": 72688,
+    "minified": 30691,
+    "gzipped": 9531
   },
   "dist/jss-starter-kit.min.js": {
-    "bundled": 71621,
-    "minified": 30097,
-    "gzipped": 9277
+    "bundled": 71613,
+    "minified": 30095,
+    "gzipped": 9275
   },
   "dist/jss-starter-kit.cjs.js": {
     "bundled": 2790,

--- a/packages/jss-starter-kit/.size-snapshot.json
+++ b/packages/jss-starter-kit/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/jss-starter-kit.js": {
-    "bundled": 72582,
-    "minified": 30672,
-    "gzipped": 9522
+    "bundled": 72696,
+    "minified": 30693,
+    "gzipped": 9533
   },
   "dist/jss-starter-kit.min.js": {
-    "bundled": 71507,
-    "minified": 30076,
-    "gzipped": 9267
+    "bundled": 71621,
+    "minified": 30097,
+    "gzipped": 9277
   },
   "dist/jss-starter-kit.cjs.js": {
     "bundled": 2790,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/react-jss.js": {
-    "bundled": 170267,
-    "minified": 59072,
-    "gzipped": 19374
+    "bundled": 170259,
+    "minified": 59070,
+    "gzipped": 19371
   },
   "dist/react-jss.min.js": {
-    "bundled": 113244,
-    "minified": 42331,
-    "gzipped": 14394
+    "bundled": 113236,
+    "minified": 42329,
+    "gzipped": 14393
   },
   "dist/react-jss.cjs.js": {
     "bundled": 26358,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/react-jss.js": {
-    "bundled": 170153,
-    "minified": 59050,
-    "gzipped": 19361
+    "bundled": 170267,
+    "minified": 59072,
+    "gzipped": 19374
   },
   "dist/react-jss.min.js": {
-    "bundled": 113130,
-    "minified": 42309,
-    "gzipped": 14382
+    "bundled": 113244,
+    "minified": 42331,
+    "gzipped": 14394
   },
   "dist/react-jss.cjs.js": {
     "bundled": 26358,


### PR DESCRIPTION
## Corresponding issue (if exists):

Fixes https://github.com/cssinjs/jss/issues/1363.

## What would you like to add/fix?

Currently, no default units are applied to a zero value. While the CSS spec allows this for length units like `px` (see https://www.w3.org/TR/css-values-3/#lengths), this causes incorrect CSS to be generated for other units like `ms`, which the browser then ignores.

An example of this bug is provided in the linked issue (https://github.com/cssinjs/jss/issues/1363):

<img width="379" alt="Screen Shot 2020-07-16 at 10 02 16 AM" src="https://user-images.githubusercontent.com/3311523/87680611-a43a9a00-c74b-11ea-8ede-e8a34e2584fc.png">

This PR makes two changes to the logic in `packages/jss-plugin-default-unit/src/index.js`:
* It prevents a value of `0` from being returned early in the initial falsy value check.
* It adds a default unit (if available) to all numeric values, except for the special case of `0px`.

While generating `0px` instead of `0` would also be acceptable when the default unit is `px`, it may deviate from what developers are used to, so we omit it in this PR.

In order to pass the pre-commit checks, this PR also fixes a `yarn format:ci` failure in `docs/react-jss.md`.

## Todo

- [X] Add tests if possible
- [x] Add changelog if users should know about the change
- [ ] Add documentation
