### PR TITLE
fix: jssStyle type

### DIFF
--- a/packages/jss/src/index.d.ts
+++ b/packages/jss/src/index.d.ts
@@ -15,13 +15,17 @@ type NormalCssValues<K> = K extends keyof NormalCssProperties
   ? NormalCssProperties[K] | JssValue
   : JssValue
 
-export type JssStyle = {
-  [K in keyof NormalCssProperties | string]:
-    | NormalCssValues<K>
-    | JssStyle
-    | Func<NormalCssValues<K> | JssStyle | undefined>
-    | Observable<NormalCssValues<K> | JssStyle | undefined>
-}
+export type JssStyle =
+  | {
+      [K in keyof NormalCssProperties]:
+        | NormalCssValues<K>
+        | JssStyle
+        | Func<NormalCssValues<K> | JssStyle | undefined>
+        | Observable<NormalCssValues<K> | JssStyle | undefined>
+    }
+  | {
+      [K: string]: JssStyle | Func<JssStyle> | Observable<JssStyle | undefined>
+    }
 
 export type Styles<Name extends string | number | symbol = string> = Record<
   Name,

--- a/packages/jss/src/index.d.ts
+++ b/packages/jss/src/index.d.ts
@@ -24,7 +24,11 @@ export type JssStyle =
         | Observable<NormalCssValues<K> | JssStyle | undefined>
     }
   | {
-      [K: string]: JssStyle | Func<JssStyle> | Observable<JssStyle | undefined>
+      [K: string]:
+        | JssValue
+        | JssStyle
+        | Func<JssValue | JssStyle | undefined>
+        | Observable<JssValue | JssStyle | undefined>
     }
 
 export type Styles<Name extends string | number | symbol = string> = Record<


### PR DESCRIPTION
typescript can't work with   [K in keyof NormalCssProperties | string]

## Corresponding issue (if exists):

## What would you like to add/fix?
type definition
## Todo

- [ ] Add tests if possible
- [ ] Add changelog if users should know about the change
- [ ] Add documentation
