### PR TITLE
make rule-value-function and global work together

### DIFF
--- a/packages/jss-plugin-rule-value-function/.size-snapshot.json
+++ b/packages/jss-plugin-rule-value-function/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "jss-plugin-rule-value-function.js": {
-    "bundled": 2958,
-    "minified": 1046,
-    "gzipped": 579
+    "bundled": 3816,
+    "minified": 1409,
+    "gzipped": 750
   },
   "jss-plugin-rule-value-function.min.js": {
-    "bundled": 2379,
-    "minified": 795,
-    "gzipped": 455
+    "bundled": 3237,
+    "minified": 1158,
+    "gzipped": 631
   },
   "jss-plugin-rule-value-function.cjs.js": {
-    "bundled": 2526,
-    "minified": 1058,
-    "gzipped": 551
+    "bundled": 3100,
+    "minified": 1341,
+    "gzipped": 674
   },
   "jss-plugin-rule-value-function.esm.js": {
-    "bundled": 2240,
-    "minified": 835,
-    "gzipped": 452,
+    "bundled": 2731,
+    "minified": 1062,
+    "gzipped": 569,
     "treeshaked": {
       "rollup": {
-        "code": 33,
-        "import_statements": 33
+        "code": 76,
+        "import_statements": 76
       },
       "webpack": {
-        "code": 1071
+        "code": 1147
       }
     }
   }

--- a/packages/jss/.size-snapshot.json
+++ b/packages/jss/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "jss.js": {
-    "bundled": 63033,
-    "minified": 23299,
-    "gzipped": 7090
+    "bundled": 63305,
+    "minified": 23353,
+    "gzipped": 7113
   },
   "jss.min.js": {
-    "bundled": 61636,
-    "minified": 22531,
-    "gzipped": 6743
+    "bundled": 61908,
+    "minified": 22585,
+    "gzipped": 6766
   },
   "jss.cjs.js": {
-    "bundled": 58745,
-    "minified": 26132,
-    "gzipped": 7181
+    "bundled": 59011,
+    "minified": 26186,
+    "gzipped": 7209
   },
   "jss.esm.js": {
-    "bundled": 57127,
-    "minified": 24833,
-    "gzipped": 7000,
+    "bundled": 57393,
+    "minified": 24887,
+    "gzipped": 7028,
     "treeshaked": {
       "rollup": {
-        "code": 20291,
+        "code": 20345,
         "import_statements": 345
       },
       "webpack": {
-        "code": 21773
+        "code": 21827
       }
     }
   }

--- a/packages/jss/src/RuleList.js
+++ b/packages/jss/src/RuleList.js
@@ -200,8 +200,13 @@ export default class RuleList {
       sheet
     } = this.options
 
+    // updateFun is a workaround to use together
+    // jss-plugin-rule-value-function and jss-plugin-global
+    const hasUpdateFun = typeof rule.updateFun == 'function'
+
     // It is a rules container like for e.g. ConditionalRule.
-    if (rule.rules instanceof RuleList) {
+    // Ignore if there is an updateFun
+    if (!hasUpdateFun && rule.rules instanceof RuleList) {
       rule.rules.update(data, options)
       return
     }
@@ -209,7 +214,8 @@ export default class RuleList {
     const styleRule: StyleRule = (rule: any)
     const {style} = styleRule
 
-    plugins.onUpdate(data, rule, sheet, options)
+    if (hasUpdateFun) rule.updateFun(data)
+    else plugins.onUpdate(data, rule, sheet, options)
 
     // We rely on a new `style` ref in case it was mutated during onUpdate hook.
     if (options.process && style && style !== styleRule.style) {


### PR DESCRIPTION
Fix #1335 
## Implementation details

I attach an attribute `updateFun` to rules with type `'global'` that have a function as declation (i.e. rules that match both plugins).

I already had to modify `RuleList.js` to prevent the special case `rule.rules instanceof RuleList` from skipping the update, so I included the code that executes `updateFun` in `RuleList.js`. An important choice (that is easily modifiable) is that `plugins.onUpdate` will not be launched on the global rule that is updated with a function: **other plugins will not run on the updated properties**.

Another meaningful possibility would be to include the call to `updateFun` in the `onUpdate` method of the `rule-value-function`. This would allow us to call `plugins.onUpdate` from `RuleList.js`, so have other plugins run on the rule after update. I was not sure what interactions this could create with other plugins so I didn't handle it this way. 

It is my first contribution to a JS project, so please feel free to give me advice to improve my coding style :smiley:

## Example

```js
import jss, {SheetsRegistry} from 'jss'
import funplugin from 'jss-plugin-rule-value-function'
import globplugin from 'jss-plugin-global'

const jss_ = jss.default

jss_.use(funplugin.default(), globplugin.default())

const sheet = jss_.createStyleSheet({
  '@global': (data) => ({
    button: {
      width: 100,
      height: 100
    },
    '#sntch_block': {
      display: data.display
    }
  }),

  a: {
    display: 'inline',
    color: (data) => data.color
  },

  div: (data) => ({
    color: data.color
  })
})

const sheets = new SheetsRegistry()
sheets.add(sheet)
var str = sheets.toString()
console.log(str)

console.log('\n-----\n')

sheet.update({color: 'red', display: 'none'})

str = sheets.toString()
console.log(str)

console.log('\n-----\n')

sheet.update({color: 'blue', display: 'none'})

str = sheets.toString()
console.log(str)
```

gives 

```
.a-0-0-1 {
  display: inline;
}

-----

button {
  width: 100;
  height: 100;
}
#sntch_block {
  display: none;
}
.a-0-0-1 {
  display: inline;
  color: red;
}
.div-0-0-2 {
  color: red;
}

-----

button {
  width: 100;
  height: 100;
}
#sntch_block {
  display: none;
}
.a-0-0-1 {
  display: inline;
  color: blue;
}
.div-0-0-2 {
  color: blue;
}
```