### PR TITLE
fix: allow partial `classes` prop in withStyles

### DIFF
--- a/packages/react-jss/src/index.d.ts
+++ b/packages/react-jss/src/index.d.ts
@@ -37,8 +37,12 @@ declare const JssContext: Context<{
   disableStylesGeneration: boolean
 }>
 
+type ClassesForStyles<S extends Styles | ((theme: any) => Styles)> = Classes<
+  S extends (theme: any) => Styles ? keyof ReturnType<S> : keyof S
+>
+
 interface WithStylesProps<S extends Styles | ((theme: any) => Styles)> {
-  classes: Classes<S extends (theme: any) => Styles ? keyof ReturnType<S> : keyof S>
+  classes: ClassesForStyles<S>
 }
 /**
  * @deprecated Please use `WithStylesProps` instead
@@ -79,8 +83,10 @@ declare function withStyles<
 ) => ComponentType<
   JSX.LibraryManagedAttributes<
     C,
-    Omit<GetProps<C>, 'classes'> &
-      Partial<WithStylesProps<S>> & {innerRef?: RefObject<any> | ((instance: any) => void)}
+    Omit<GetProps<C>, 'classes'> & {
+      classes?: Partial<ClassesForStyles<S>>
+      innerRef?: RefObject<any> | ((instance: any) => void)
+    }
   >
 >
 


### PR DESCRIPTION
The `classes` prop created by the `withStyles` function is meant to be an optional parameter where you can provide some or all of the style classes.

Imagine a somewhat contrived snippet like:
```typescript
import React from "react";
import withStyles, { WithStylesProps } from "react-jss";
import clsx from "clsx";

const styles = {
  root: { display: "block" },
  blue: { color: "blue" },
};

type Props = { blue?: boolean } & WithStylesProps<typeof styles>;
const Component = ({ blue = false, classes }: Props) => (
  <div className={clsx(classes.root, { [classes.blue]: blue })}>
    Hello, world!
  </div>
);

const StyledComponent = withStyles(styles)(Component);
```

You'd expect to be able to use it in any of the following ways:
```tsx
<StyledComponent />
<StyledComponent blue />
<StyledComponent classes={{ root: "myClass" }} />
```

The last use case was broken in TypeScript because, while `classes` was an optional prop, each key within class was _required_. So you'd get an error like:

> Property 'blue' is missing in type '{ root: string; }' but required in type 'Record<"blue" | "root", string>'.ts(2741)

This changes makes sure that the `classes` property is still optional, but that each key within it is optional, too. I abstracted a field out so that I could use it in two places. There's probably about a dozen ways to set something like this up, though, so if you'd prefer it formatted in a different way let me know.