### PR TITLE
Allow project to be in a directory that contains spaces

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -8,7 +8,7 @@ shell.cp(path.join(__dirname, '..', 'LICENSE'), './')
 createReadme()
 
 const rollup = path.join(__dirname, '../node_modules/.bin/rollup')
-const {code} = shell.exec(`${rollup} --config "../../rollup.config.js"`)
+const {code} = shell.exec(`"${rollup}" --config "../../rollup.config.js"`)
 
 if (code !== 0) {
   shell.exit(code)

--- a/scripts/match-snapshot.js
+++ b/scripts/match-snapshot.js
@@ -4,7 +4,7 @@ const path = require('path')
 const crossEnv = path.join(__dirname, '../node_modules/.bin/cross-env')
 const rollup = path.join(__dirname, '../node_modules/.bin/rollup')
 const {code} = shell.exec(
-  `${crossEnv} MATCH_SNAPSHOT=true ${rollup} --config "../../rollup.config.js"`
+  `"${crossEnv}" MATCH_SNAPSHOT=true "${rollup}" --config "../../rollup.config.js"`
 )
 
 if (code !== 0) {


### PR DESCRIPTION
Just ran into issue while trying to run `yarn build` and `yarn check:snapshots`, because `shell.exec` calls didn't expect project directory to contain spaces.