### PR TITLE
feat: add px as default unit for row-gap property

### DIFF
--- a/packages/css-jss/.size-snapshot.json
+++ b/packages/css-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "css-jss.js": {
-    "bundled": 61053,
-    "minified": 21882,
+    "bundled": 61072,
+    "minified": 21894,
     "gzipped": 7360
   },
   "css-jss.min.js": {
-    "bundled": 59978,
-    "minified": 21259,
-    "gzipped": 7080
+    "bundled": 59997,
+    "minified": 21271,
+    "gzipped": 7079
   },
   "css-jss.cjs.js": {
     "bundled": 3034,

--- a/packages/jss-plugin-default-unit/.size-snapshot.json
+++ b/packages/jss-plugin-default-unit/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "jss-plugin-default-unit.js": {
-    "bundled": 6838,
-    "minified": 3577,
-    "gzipped": 1218
+    "bundled": 6857,
+    "minified": 3589,
+    "gzipped": 1219
   },
   "jss-plugin-default-unit.min.js": {
-    "bundled": 6838,
-    "minified": 3577,
-    "gzipped": 1218
+    "bundled": 6857,
+    "minified": 3589,
+    "gzipped": 1219
   },
   "jss-plugin-default-unit.cjs.js": {
-    "bundled": 6021,
-    "minified": 3659,
-    "gzipped": 1167
+    "bundled": 6038,
+    "minified": 3672,
+    "gzipped": 1169
   },
   "jss-plugin-default-unit.esm.js": {
-    "bundled": 5941,
-    "minified": 3593,
-    "gzipped": 1112,
+    "bundled": 5958,
+    "minified": 3606,
+    "gzipped": 1113,
     "treeshaked": {
       "rollup": {
-        "code": 2652,
+        "code": 2664,
         "import_statements": 39
       },
       "webpack": {
-        "code": 3673
+        "code": 3685
       }
     }
   }

--- a/packages/jss-plugin-default-unit/src/defaultUnits.js
+++ b/packages/jss-plugin-default-unit/src/defaultUnits.js
@@ -162,6 +162,7 @@ export default {
   // Grid properties
   grid: px,
   'grid-gap': px,
+  'row-gap': px,
   'grid-row-gap': px,
   'grid-column-gap': px,
   'grid-template-rows': px,

--- a/packages/jss-preset-default/.size-snapshot.json
+++ b/packages/jss-preset-default/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "jss-preset-default.js": {
-    "bundled": 58253,
-    "minified": 21106,
-    "gzipped": 7012
+    "bundled": 58272,
+    "minified": 21118,
+    "gzipped": 7011
   },
   "jss-preset-default.min.js": {
-    "bundled": 57178,
-    "minified": 20483,
-    "gzipped": 6732
+    "bundled": 57197,
+    "minified": 20495,
+    "gzipped": 6731
   },
   "jss-preset-default.cjs.js": {
     "bundled": 2222,

--- a/packages/jss-starter-kit/.size-snapshot.json
+++ b/packages/jss-starter-kit/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "jss-starter-kit.js": {
-    "bundled": 74396,
-    "minified": 31557,
-    "gzipped": 9647
+    "bundled": 74415,
+    "minified": 31569,
+    "gzipped": 9645
   },
   "jss-starter-kit.min.js": {
-    "bundled": 73321,
-    "minified": 31369,
-    "gzipped": 9423
+    "bundled": 73340,
+    "minified": 31381,
+    "gzipped": 9422
   },
   "jss-starter-kit.cjs.js": {
     "bundled": 5647,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "react-jss.js": {
-    "bundled": 169637,
-    "minified": 59521,
-    "gzipped": 19549
+    "bundled": 169656,
+    "minified": 59534,
+    "gzipped": 19547
   },
   "react-jss.min.js": {
-    "bundled": 112277,
-    "minified": 42721,
-    "gzipped": 14503
+    "bundled": 112296,
+    "minified": 42734,
+    "gzipped": 14502
   },
   "react-jss.cjs.js": {
     "bundled": 27701,


### PR DESCRIPTION
## Corresponding issue (if exists):
https://github.com/cssinjs/jss/issues/1435

## What would you like to add/fix?
Adds default unit as `px` for `row-gap` css property

## Todo

- [ ] Add tests if possible
- [ ] Add changelog if users should know about the change
- [ ] Add documentation
