### PR TITLE
feat: add px as default unit for text-decoration-thickness property

### DIFF
--- a/packages/jss-plugin-default-unit/src/defaultUnits.js
+++ b/packages/jss-plugin-default-unit/src/defaultUnits.js
@@ -121,6 +121,7 @@ export default {
   'font-size': px,
   'font-size-delta': px,
   'letter-spacing': px,
+  'text-decoration-thickness': px,
   'text-indent': px,
   'text-stroke': px,
   'text-stroke-width': px,


### PR DESCRIPTION
## Corresponding issue (if exists):
https://github.com/cssinjs/jss/issues/1437

## What would you like to add/fix?

## Todo

- [ ] Add tests if possible
- [ ] Add changelog if users should know about the change
- [ ] Add documentation
