### PR TITLE
Fix crash Chrome 88

### DIFF
--- a/packages/css-jss/.size-snapshot.json
+++ b/packages/css-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "css-jss.js": {
-    "bundled": 61109,
-    "minified": 21924,
-    "gzipped": 7375
+    "bundled": 61133,
+    "minified": 21942,
+    "gzipped": 7382
   },
   "css-jss.min.js": {
-    "bundled": 60034,
-    "minified": 21301,
-    "gzipped": 7094
+    "bundled": 60058,
+    "minified": 21319,
+    "gzipped": 7102
   },
   "css-jss.cjs.js": {
     "bundled": 3034,

--- a/packages/jss-plugin-default-unit/.size-snapshot.json
+++ b/packages/jss-plugin-default-unit/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "jss-plugin-default-unit.js": {
-    "bundled": 6894,
-    "minified": 3619,
-    "gzipped": 1234
+    "bundled": 6918,
+    "minified": 3637,
+    "gzipped": 1245
   },
   "jss-plugin-default-unit.min.js": {
-    "bundled": 6894,
-    "minified": 3619,
-    "gzipped": 1234
+    "bundled": 6918,
+    "minified": 3637,
+    "gzipped": 1245
   },
   "jss-plugin-default-unit.cjs.js": {
-    "bundled": 6073,
-    "minified": 3703,
-    "gzipped": 1183
+    "bundled": 6097,
+    "minified": 3721,
+    "gzipped": 1194
   },
   "jss-plugin-default-unit.esm.js": {
-    "bundled": 5993,
-    "minified": 3637,
-    "gzipped": 1127,
+    "bundled": 6017,
+    "minified": 3655,
+    "gzipped": 1137,
     "treeshaked": {
       "rollup": {
         "code": 2694,

--- a/packages/jss-plugin-default-unit/src/index.js
+++ b/packages/jss-plugin-default-unit/src/index.js
@@ -40,7 +40,7 @@ function iterate(prop: string, value: any, options: Options) {
         value[innerProp] = iterate(`${prop}-${innerProp}`, value[innerProp], options)
       }
     }
-  } else if (typeof value === 'number') {
+  } else if (typeof value === 'number' && !Number.isNaN(value)) {
     const unit = options[prop] || units[prop]
 
     // Add the unit if available, except for the special case of 0px.

--- a/packages/jss-plugin-default-unit/src/index.test.js
+++ b/packages/jss-plugin-default-unit/src/index.test.js
@@ -255,7 +255,9 @@ describe('jss-plugin-default-unit', () => {
       sheet = jss.createStyleSheet({
         a: {
           padding: 10,
-          margin: null
+          margin: null,
+          width: undefined,
+          height: NaN
         }
       })
     })
@@ -265,7 +267,7 @@ describe('jss-plugin-default-unit', () => {
     })
 
     it('should generate correct CSS', () => {
-      expect(sheet.toString()).to.be('.a-id {\n  padding: 10px;\n}')
+      expect(sheet.toString()).to.be('.a-id {\n  padding: 10px;\n  height: NaN;\n}')
     })
   })
 

--- a/packages/jss-preset-default/.size-snapshot.json
+++ b/packages/jss-preset-default/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "jss-preset-default.js": {
-    "bundled": 58309,
-    "minified": 21148,
-    "gzipped": 7027
+    "bundled": 58333,
+    "minified": 21166,
+    "gzipped": 7034
   },
   "jss-preset-default.min.js": {
-    "bundled": 57234,
-    "minified": 20525,
-    "gzipped": 6746
+    "bundled": 57258,
+    "minified": 20543,
+    "gzipped": 6755
   },
   "jss-preset-default.cjs.js": {
     "bundled": 2222,

--- a/packages/jss-starter-kit/.size-snapshot.json
+++ b/packages/jss-starter-kit/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "jss-starter-kit.js": {
-    "bundled": 74452,
-    "minified": 31599,
-    "gzipped": 9657
+    "bundled": 74476,
+    "minified": 31617,
+    "gzipped": 9666
   },
   "jss-starter-kit.min.js": {
-    "bundled": 73377,
-    "minified": 31411,
-    "gzipped": 9434
+    "bundled": 73401,
+    "minified": 31429,
+    "gzipped": 9442
   },
   "jss-starter-kit.cjs.js": {
     "bundled": 5647,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "react-jss.js": {
-    "bundled": 169693,
-    "minified": 59565,
-    "gzipped": 19559
+    "bundled": 169717,
+    "minified": 59583,
+    "gzipped": 19570
   },
   "react-jss.min.js": {
-    "bundled": 112333,
-    "minified": 42765,
-    "gzipped": 14514
+    "bundled": 112357,
+    "minified": 42783,
+    "gzipped": 14523
   },
   "react-jss.cjs.js": {
     "bundled": 27701,


### PR DESCRIPTION
Fixes #1445. The new test case fails without the fix (locally, not in the cloud as it's using an old version of Chrome).

I think that this bug will require a release sooner rather than later @kof.