### PR TITLE
chore: edit globalThis.js to first check for `globalThis`

### DIFF
--- a/packages/jss/.size-snapshot.json
+++ b/packages/jss/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "jss.js": {
-    "bundled": 63283,
-    "minified": 23316,
-    "gzipped": 7096
+    "bundled": 63344,
+    "minified": 23360,
+    "gzipped": 7098
   },
   "jss.min.js": {
-    "bundled": 61886,
-    "minified": 22548,
-    "gzipped": 6745
+    "bundled": 61947,
+    "minified": 22592,
+    "gzipped": 6748
   },
   "jss.cjs.js": {
-    "bundled": 58995,
-    "minified": 26159,
-    "gzipped": 7190
+    "bundled": 59056,
+    "minified": 26211,
+    "gzipped": 7200
   },
   "jss.esm.js": {
-    "bundled": 57387,
-    "minified": 24870,
-    "gzipped": 7016,
+    "bundled": 57448,
+    "minified": 24922,
+    "gzipped": 7027,
     "treeshaked": {
       "rollup": {
-        "code": 20305,
+        "code": 20349,
         "import_statements": 345
       },
       "webpack": {
-        "code": 21790
+        "code": 21834
       }
     }
   }

--- a/packages/jss/src/utils/globalThis.js
+++ b/packages/jss/src/utils/globalThis.js
@@ -1,5 +1,17 @@
 /* eslint-disable */
-// https://github.com/zloirock/core-js/issues/86#issuecomment-115759028
+
+/**
+ * Now that `globalThis` is available on most platforms
+ * (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis#browser_compatibility)
+ * we check for `globalThis` first. `globalThis` is necessary for jss
+ * to run in Agoric's secure version of JavaScript (SES). Under SES,
+ * `globalThis` exists, but `window`, `self`, and `Function('return
+ * this')()` are all undefined for security reasons.
+ *
+ * https://github.com/zloirock/core-js/issues/86#issuecomment-115759028
+ */
+
+//
 export default (typeof globalThis !== 'undefined'
   ? globalThis
   : typeof window !== 'undefined' && window.Math === Math

--- a/packages/jss/src/utils/globalThis.js
+++ b/packages/jss/src/utils/globalThis.js
@@ -1,7 +1,9 @@
 /* eslint-disable */
 // https://github.com/zloirock/core-js/issues/86#issuecomment-115759028
-export default (typeof window != 'undefined' && window.Math == Math
-  ? window
-  : typeof self != 'undefined' && self.Math == Math
-    ? self
-    : Function('return this')())
+export default (typeof globalThis !== 'undefined'
+  ? globalThis
+  : typeof window !== 'undefined' && window.Math === Math
+    ? window
+    : typeof self !== 'undefined' && self.Math === Math
+      ? self
+      : Function('return this')())


### PR DESCRIPTION
## Corresponding issue (if exists): 

N/A, but can create if that would be helpful. 

## What would you like to add/fix?

Now that [`globalThis` is generally available on all the latest platforms](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis#browser_compatibility), `globalThis.js` can be improved by first checking for the presence of `globalThis`. 

My motivation: At Agoric, we have a secure version of JavaScript called SES. Under SES, `globalThis` exists, but `window`, `self`, and `Function('return this')()` are all undefined for security reasons. So, `jss` was failing for us, but by including `globalThis`, it will safely succeed even under our security requirements. 

## Todo

- [ ] Add test that verifies the modified behavior

I would be happy to add a test, but I wasn't sure what to test and where to put it. It looks like there are no unit tests for `globalThis`. I'm testing locally that `jss` works for me under SES with this change.

- [ ] ~~Add documentation if it changes public API~~
