### PR TITLE
support global typescript theme definition

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -26,9 +26,9 @@ yarn build
 To lint, format, and type check the project run the following commands:
 
 ```bash
-yarn lint
+yarn check:lint
 yarn format
-yarn typecheck
+yarn check:ts
 ```
 
 ## Run tests

--- a/packages/react-jss/src/index.d.ts
+++ b/packages/react-jss/src/index.d.ts
@@ -45,7 +45,14 @@ interface WithStylesProps<S extends Styles | ((theme: any) => Styles)> {
  */
 type WithStyles<S extends Styles | ((theme: any) => Styles)> = WithStylesProps<S>
 
-export interface DefaultTheme {}
+declare global {
+  namespace Jss {
+    /** You can use the global `Jss.Theme` interface to define a project-wide default theme. */
+    export interface Theme {}
+  }
+}
+
+export type DefaultTheme = Jss.Theme
 
 interface BaseOptions<Theme = DefaultTheme> extends StyleSheetFactoryOptions {
   index?: number

--- a/packages/react-jss/src/index.test.tsx
+++ b/packages/react-jss/src/index.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
+import WithStyles, {createUseStyles} from '.'
 
-import WithStyles from '.'
+const expectType = <T extends any>(x: T): T => x
 
 interface Props {
   testProp: string
@@ -40,6 +41,42 @@ function testRender() {
       <TestComponentWitStyles />
       <TestComponentWitStyles innerRef={ref} />
       <TestComponentWitStyles innerRef={refFunction} />
+    </>
+  )
+}
+
+declare global {
+  namespace Jss {
+    export interface Theme {
+      themeColour: string
+      defaultFontSize: number
+    }
+  }
+}
+
+const useStyles = createUseStyles(theme => {
+  expectType<string>(theme.themeColour)
+  expectType<number>(theme.defaultFontSize)
+
+  return {
+    myDiv: {
+      color: theme.themeColour,
+      // @ts-expect-error typescript should error here since the theme property doesn't exist
+      border: theme.aPropertyThatDoesntExist
+    }
+  }
+})
+
+export function Component() {
+  const classes = useStyles()
+
+  expectType<string>(classes.myDiv)
+
+  return (
+    <>
+      <div className={classes.myDiv} />
+      {/* @ts-expect-error typescript should error here since the class is invalid */}
+      <div className={classes.thisClassDoesntExist} />
     </>
   )
 }


### PR DESCRIPTION

This PR fixes a number of things that make react-jss's `createUseStyles` less convenient for TypeScript users.

#### The problems:

1. Defining `createUseStyles` is tedious because you need to pass the theme as a type argument every time, which has to be imported from somewhere (`createUseStyles<MyTheme>(theme => { ... })`)
2. If you supply a type argument, then you lose one of the most important type safety features - the typecheck of the class names:
  ![a](https://user-images.githubusercontent.com/16009897/107865305-d969bf00-6ec9-11eb-90ff-e2fb32cb15bf.png)
   This is because, if you supply a type argument, the union type (`"myHeader" | "myFooter"` in the screenshot) just becomes `string`.
   &shy;
   To fix this, you have to duplicate every class name, and now the code looks horrendous:
   ```js
   createUseStyles<MyTheme, "myHeader" | "myFooter">(theme => ({ 
     myHeader: { margin: 0 },
     myFooter: { padding: 0 },
   }))
   ```
3. For JavaScript users, or [mixed TS/JS users](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html), there is no way to get auto-complete (intellisense) for the theme. Because the `createUseStyles<MyTheme>()` syntax is not possible in JS files.

#### This PR fixes these 3 issues.

Anyone (TypeScript **and** JavaScript users) can create a file called `global.d.ts` anywhere in their project. It is not imported by anything; TypeScript and/or VSCode's TSServer finds it automatically. It could like this:

```ts
declare global {
  namespace Jss {
    export interface Theme {
      themeColour: string;
    }
  }
}

export {};
```

Now, when call `createUseStyles()` you don't need to provide any type arguments to get type definitions for the theme, and the class names (see screenshot above) are automatically inferred by typescript without defining them separately.

I have added tests to confirm that this works and that TypeScript produces errors if you make a typo in the `classes` object or the `theme` object.
## Todo

- [x] Add test that verifies the modified behaviour
- [ ] Add documentation if it changes public API
