### PR TITLE
make auto-complete of createUseStyles value work

### DIFF
--- a/packages/jss/src/index.d.ts
+++ b/packages/jss/src/index.d.ts
@@ -50,8 +50,8 @@ export type CreateGenerateId = (options?: CreateGenerateIdOptions) => GenerateId
 export type GenerateId = (rule: Rule, sheet?: StyleSheet<string>) => string
 
 export type JssValue =
-  | string
-  | number
+  | (string & {})
+  | (number & {})
   | Array<string | number | Array<string | number> | '!important'>
   | null
   | false


### PR DESCRIPTION
## Corresponding issue (if exists):

Closes #1439, Closes #1452, Closes #806, possibly fixes #776

## What would you like to add/fix?

Make auto-complete work for Typescript and/or VSCode users like in this screenshot:

![image](https://user-images.githubusercontent.com/16009897/108145726-cb69a780-7130-11eb-80c4-493da9c0e2c6.png)



This is **not** a breaking change. In the example above, folks can still type `display: "dhgjdkfhg"` and TS will accept it. This PR only makes auto-complete work. It deliberately doesn't add type-safety because that needs to wait for a semver-major release.

## Todo

- [ ] Add test that verifies the modified behaviour - **Not possible unfortunately** 
- [ ] Add documentation if it changes public API - not needed
