### PR TITLE
fix: type import from csstype

### DIFF
--- a/packages/jss/src/index.d.ts
+++ b/packages/jss/src/index.d.ts
@@ -12,7 +12,7 @@ type Func<R> = ((data: any) => R)
 
 type NormalCssProperties = CSSProperties<string | number>
 type NormalCssValues<K> = K extends keyof NormalCssProperties
-  ? NormalCssProperties[K] | JssValue
+  ? NormalCssProperties[K]
   : JssValue
 
 export type JssStyle =

--- a/packages/jss/src/index.d.ts
+++ b/packages/jss/src/index.d.ts
@@ -1,4 +1,4 @@
-import * as css from 'csstype'
+import {Properties as CSSProperties} from 'csstype'
 
 // Observable support is included as a plugin.  Including it here allows
 // TypeScript users to use Observables, which could be confusing if a user
@@ -10,7 +10,7 @@ import {Observable} from 'indefinite-observable'
 // TODO: Type data better, currently typed as any for allowing to override it
 type Func<R> = ((data: any) => R)
 
-type NormalCssProperties = css.Properties<string | number>
+type NormalCssProperties = CSSProperties<string | number>
 type NormalCssValues<K> = K extends keyof NormalCssProperties
   ? NormalCssProperties[K] | JssValue
   : JssValue


### PR DESCRIPTION
## Corresponding issue (if exists):
Typescript not working I changed import from `csstype` and now that working
## What would you like to add/fix?

## Todo

- [ ] Add test that verifies the modified behavior
- [ ] Add documentation if it changes public API
