### PR TITLE
Improve Types for Hooks

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ flow-typed/
 packages/**/dist/
 examples/**/static/
 *.ts
+*.tsx

--- a/packages/jss/src/index.d.ts
+++ b/packages/jss/src/index.d.ts
@@ -7,35 +7,36 @@ import {Properties as CSSProperties} from 'csstype'
 // TODO: refactor to only include Observable types if plugin is installed.
 import {Observable} from 'indefinite-observable'
 
-// TODO: Type data better, currently typed as any for allowing to override it
-type Func<R> = ((data: any) => R)
+type Func<P, T, R> = T extends undefined ? ((data: P) => R) : ((data: P & {theme: T}) => R)
 
 type NormalCssProperties = CSSProperties<string | number>
-type NormalCssValues<K> = K extends keyof NormalCssProperties
-  ? NormalCssProperties[K]
-  : JssValue
+type NormalCssValues<K> = K extends keyof NormalCssProperties ? NormalCssProperties[K] : JssValue
 
-export type JssStyle =
+export type JssStyle<Props = any, Theme = undefined> =
   | {
       [K in keyof NormalCssProperties]:
         | NormalCssValues<K>
-        | JssStyle
-        | Func<NormalCssValues<K> | JssStyle | undefined>
+        | JssStyle<Props, Theme>
+        | Func<Props, Theme, NormalCssValues<K> | JssStyle<undefined, undefined> | undefined>
         | Observable<NormalCssValues<K> | JssStyle | undefined>
     }
   | {
       [K: string]:
         | JssValue
-        | JssStyle
-        | Func<JssValue | JssStyle | undefined>
+        | JssStyle<Props, Theme>
+        | Func<Props, Theme, JssValue | JssStyle<undefined, undefined> | undefined>
         | Observable<JssValue | JssStyle | undefined>
     }
 
-export type Styles<Name extends string | number | symbol = string> = Record<
+export type Styles<
+  Name extends string | number | symbol = string,
+  Props = unknown,
+  Theme = undefined
+> = Record<
   Name,
-  | JssStyle
+  | JssStyle<Props, Theme>
   | string
-  | Func<JssStyle | string | null | undefined>
+  | Func<Props, Theme, JssStyle<undefined, undefined> | string | null | undefined>
   | Observable<JssStyle | string | null | undefined>
 >
 export type Classes<Name extends string | number | symbol = string> = Record<Name, string>
@@ -215,7 +216,10 @@ export interface StyleSheet<RuleName extends string | number | symbol = string |
    * Create and add rules.
    * Will render also after Style Sheet was rendered the first time.
    */
-  addRules(styles: Partial<Styles<RuleName>>, options?: Partial<RuleOptions>): Rule[]
+  addRules(
+    styles: Partial<Styles<RuleName, any, undefined>>,
+    options?: Partial<RuleOptions>
+  ): Rule[]
   /**
    * Get a rule by name.
    */
@@ -250,7 +254,7 @@ export interface JssOptions {
 
 export interface Jss {
   createStyleSheet<Name extends string | number | symbol>(
-    styles: Partial<Styles<Name>>,
+    styles: Partial<Styles<Name, any, undefined>>,
     options?: StyleSheetFactoryOptions
   ): StyleSheet<Name>
   removeStyleSheet(sheet: StyleSheet): this

--- a/packages/jss/tests/types/Styles.ts
+++ b/packages/jss/tests/types/Styles.ts
@@ -5,13 +5,18 @@ interface Props {
   flag?: boolean
 }
 
+interface Theme {
+  color: string
+}
+
 declare const color$: Observable<'cyan'>
 declare const style$: Observable<{
   backgroundColor: 'fuchsia'
   transform: 'translate(0px, 205px)'
 }>
 
-const styles: Styles = {
+// General Types Check
+const styles: Styles<string, Props> = {
   basic: {
     textAlign: 'center',
     display: 'flex',
@@ -22,7 +27,7 @@ const styles: Styles = {
     textAlign: 'center',
     display: 'flex',
     width: '100%',
-    justifyContent: (props: Props) => (props.flag ? 'center' : undefined)
+    justifyContent: props => (props.flag ? 'center' : undefined)
   },
   inner: {
     textAlign: 'center',
@@ -33,7 +38,7 @@ const styles: Styles = {
       fontSize: 12
     }
   },
-  func: (props: Props) => ({
+  func: props => ({
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'center',
@@ -43,8 +48,8 @@ const styles: Styles = {
     position: 'relative',
     pointerEvents: props.flag ? 'none' : null
   }),
-  funcNull: (props: Props) => null,
-  funcWithTerm: (props: Props) => ({
+  funcNull: props => null,
+  funcWithTerm: props => ({
     width: props.flag ? 377 : 272,
     height: props.flag ? 330 : 400,
     boxShadow: '0px 2px 20px rgba(0, 0, 0, 0.08)',
@@ -66,4 +71,31 @@ const styles: Styles = {
     from: {opacity: 0},
     to: {opacity: 1}
   }
+}
+
+// Test supplied Props and Theme
+// Verify that nested parameter declarations are banned
+const stylesPropsAndTheme: Styles<string, Props, Theme> = {
+  rootParamDeclaration: ({flag, theme}) => ({
+    fontWeight: 'bold',
+    // @ts-expect-error
+    nothingAllowed: ({flag, theme}) => ''
+  }),
+  anotherClass: {
+    color: 'red',
+    innerParamDeclaration1: ({flag, theme}) => '',
+    innerParamDeclaration2: ({flag, theme}) => ({
+      backgroundColor: 'blue',
+      // @ts-expect-error
+      nothingAllowed: ({flag, theme}) => ''
+    })
+  }
+}
+
+// Test the className types
+const stylesClassNames: Styles<number, unknown, unknown> = {
+  // @ts-expect-error
+  stringClassName: '',
+  [1]: '',
+  [2]: ''
 }

--- a/packages/react-jss/src/index.d.ts
+++ b/packages/react-jss/src/index.d.ts
@@ -37,17 +37,21 @@ declare const JssContext: Context<{
   disableStylesGeneration: boolean
 }>
 
-type ClassesForStyles<S extends Styles | ((theme: any) => Styles)> = Classes<
-  S extends (theme: any) => Styles ? keyof ReturnType<S> : keyof S
->
+type ClassesForStyles<
+  S extends Styles<any, any, any> | ((theme: any) => Styles<any, any, undefined>)
+> = Classes<S extends (theme: any) => Styles<any, any, undefined> ? keyof ReturnType<S> : keyof S>
 
-interface WithStylesProps<S extends Styles | ((theme: any) => Styles)> {
+interface WithStylesProps<
+  S extends Styles<any, any, any> | ((theme: any) => Styles<any, any, undefined>)
+> {
   classes: ClassesForStyles<S>
 }
 /**
  * @deprecated Please use `WithStylesProps` instead
  */
-type WithStyles<S extends Styles | ((theme: any) => Styles)> = WithStylesProps<S>
+type WithStyles<
+  S extends Styles<any, any, any> | ((theme: any) => Styles<any, any, undefined>)
+> = WithStylesProps<S>
 
 declare global {
   namespace Jss {
@@ -72,18 +76,17 @@ interface CreateUseStylesOptions<Theme = DefaultTheme> extends BaseOptions<Theme
   name?: string
 }
 
-declare function createUseStyles<Theme = DefaultTheme, C extends string = string>(
-  styles: Styles<C> | ((theme: Theme) => Styles<C>),
+declare function createUseStyles<C extends string = string, Props = unknown, Theme = DefaultTheme>(
+  styles: Styles<C, Props, Theme> | ((theme: Theme) => Styles<C, Props, undefined>),
   options?: CreateUseStylesOptions<Theme>
-): (data?: unknown) => Classes<C>
+): (data?: Props & {theme?: Theme}) => Classes<C>
 
 type GetProps<C> = C extends ComponentType<infer P> ? P : never
 
-declare function withStyles<
-  ClassNames extends string | number | symbol,
-  S extends Styles<ClassNames> | ((theme: any) => Styles<ClassNames>)
->(
-  styles: S,
+declare function withStyles<ClassNames extends string | number | symbol, Props, Theme>(
+  styles:
+    | Styles<ClassNames, Props, Theme>
+    | ((theme: Theme) => Styles<ClassNames, Props, undefined>),
   options?: WithStylesOptions
 ): <C>(
   comp: C
@@ -91,7 +94,7 @@ declare function withStyles<
   JSX.LibraryManagedAttributes<
     C,
     Omit<GetProps<C>, 'classes'> & {
-      classes?: Partial<ClassesForStyles<S>>
+      classes?: Partial<ClassesForStyles<typeof styles>>
       innerRef?: RefObject<any> | ((instance: any) => void)
     }
   >

--- a/packages/react-jss/tests/types/createUseStyles.ts
+++ b/packages/react-jss/tests/types/createUseStyles.ts
@@ -1,0 +1,238 @@
+import {createUseStyles} from '../../src'
+
+type DefaultTheme = Jss.Theme
+
+interface MyProps {
+  property: string
+}
+
+interface MyTheme {
+  color: 'red'
+}
+
+const expectedCustomProps = {property: ''}
+const expectedDefaultTheme: DefaultTheme = {defaultFontSize: 0, themeColour: ''}
+const expectedCustomTheme: MyTheme = {color: 'red'}
+
+/* -------------------- THEME ARGUMENT -------------------- */
+// Regular, static styles work fine
+const themeArg1 = createUseStyles(theme => ({
+  someClassName: '',
+  anotherClassName: {
+    fontWeight: 'bold'
+  }
+}))
+const themeArg1ClassesPass = themeArg1()
+
+// Theme type assumed to be the default
+// Nested theme declaration banned
+// @ts-expect-error
+const themeArg2 = createUseStyles(theme => ({
+  themeNotAllowed: ({theme: innerTheme}) => ({
+    fontWeight: 'bold'
+  })
+}))
+// @ts-expect-error
+const themeArg2ClassesFail = themeArg2({theme: {}})
+// @ts-expect-error
+const themeArg2ClassesFail2 = themeArg2({theme: expectedCustomTheme})
+const themeArg2ClassesPass = themeArg2({theme: expectedDefaultTheme})
+
+// Props declaration is allowed
+const themeArg3 = createUseStyles<string, MyProps>(theme => ({
+  onlyPropsAllowed: ({...props}) => ({
+    fontWeight: 'bold'
+  })
+}))
+// @ts-expect-error
+const themeArg3ClassesFail = themeArg3({property: 0})
+// @ts-expect-error
+const themeArg3ClassesFail2 = themeArg3({...expectedCustomProps, theme: expectedCustomTheme})
+const themeArg3ClassesPass = themeArg3(expectedCustomProps)
+const themeArg3ClassesPass2 = themeArg3({...expectedCustomProps, theme: expectedDefaultTheme})
+
+// Nested props declaration banned
+const themeArg4 = createUseStyles<string, MyProps>(theme => ({
+  onlyPropsAllowed: ({...props}) => ({
+    fontWeight: 'bold',
+    // @ts-expect-error
+    propsNotAllowed: ({...innerProps}) => ''
+  })
+}))
+
+// Supplied theme type is acknowledged
+const themeArg5 = createUseStyles<string, unknown, MyTheme>(theme => ({}))
+// @ts-expect-error
+const themeArg5ClassesFail = themeArg5({theme: {}})
+// @ts-expect-error
+const themeArg5ClassesFail2 = themeArg5({theme: expectedDefaultTheme})
+const themeArg5ClassesPass = themeArg5({theme: expectedCustomTheme})
+
+// Custom theme can be determined from argument
+const themeArg6 = createUseStyles((theme: MyTheme) => ({
+  someClassName: {
+    fontWeight: 'bold'
+  }
+}))
+// @ts-expect-error
+const themeArg6ClassesFail = themeArg6({theme: {}})
+// @ts-expect-error
+const themeArg6ClassesFail2 = themeArg6({theme: expectedDefaultTheme})
+const themeArg6ClassesPass = themeArg6({theme: expectedCustomTheme})
+
+// Props can be determined implicitly
+const themeArg7 = createUseStyles(theme => ({
+  checkbox: ({property}: MyProps) => ({
+    borderColor: property
+  })
+}))
+
+// @ts-expect-error invalid props
+const themeArg7ClassesFail = themeArg7({colour: 'green'})
+// @ts-expect-error extraneous props
+const themeArg7ClassesFail2 = themeArg7({...expectedCustomProps, someUnTypedProp: 1})
+const themeArg7ClassesPass = themeArg7(expectedCustomProps)
+
+// Classes check
+const themeArgClasses7String: string = themeArg7ClassesPass.checkbox
+// @ts-expect-error invalid className
+themeArg7ClassesPass.doesntExist
+
+/* -------------------- NO THEME ARGUMENT -------------------- */
+// Regular, static styles work fine
+const noThemeArg1 = createUseStyles({
+  someClassName: '',
+  anotherClassName: {
+    fontWeight: 'bold'
+  }
+})
+const noThemeArg1ClassesPass = noThemeArg1()
+
+// Theme declaration is allowed, but not nested theme declaration
+// Theme type assumed to be the default
+const noThemeArg2 = createUseStyles({
+  themeOnly: ({theme}) => ({
+    fontWeight: 'bold',
+    // @ts-expect-error
+    themeNotAllowed: ({theme: innerTheme}) => '',
+    '& > *': {
+      color: 'red',
+      // @ts-expect-error
+      themeNotAllowed: ({theme: innerMostTheme}) => ''
+    }
+  })
+})
+// @ts-expect-error
+const noThemeArg2ClassesFail = noThemeArg2({theme: {}})
+// @ts-expect-error
+const noThemeArg2ClassesFail2 = noThemeArg2({theme: expectedCustomTheme})
+const noThemeArg2ClassesPass = noThemeArg2({theme: expectedDefaultTheme})
+
+// Props declaration is allowed, but not nested props declaration
+const noThemeArg3 = createUseStyles<string, MyProps>({
+  propsAndTheme: ({property, theme}) => ({
+    fontWeight: 'bold',
+    // @ts-expect-error
+    nothingAllowed: ({property: innerProperty}) => '',
+    '& > *': {
+      color: 'red',
+      // @ts-expect-error
+      nothingAllowed: ({property: innerMostProperty}) => ''
+    }
+  })
+})
+// @ts-expect-error
+const noThemeArg3ClassesFail = noThemeArg3({property: 0})
+// @ts-expect-error
+const noThemeArg3ClassesFail2 = noThemeArg3({...expectedCustomProps, theme: expectedCustomTheme})
+const noThemeArg3ClassesPass = noThemeArg3(expectedCustomProps)
+const noThemeArg3ClassesPass2 = noThemeArg3({...expectedCustomProps, theme: expectedDefaultTheme})
+
+// Props and Theme types are properly acknowledged when supplied
+const noThemeArg4 = createUseStyles<string, MyProps, MyTheme>({
+  propsAndTheme: ({property, theme}) => ({
+    fontWeight: 'bold',
+    // @ts-expect-error
+    nothingAllowed: ({theme: innerTheme, ...innerProps}) => '',
+    '& > *': {
+      color: 'red',
+      // @ts-expect-error
+      nothingAllowed: ({theme: innerMostTheme, ...innerMostProps}) => ''
+    }
+  })
+})
+// @ts-expect-error
+const noThemeArg4ClassesFail = noThemeArg4({property: 0})
+// @ts-expect-error
+const noThemeArg4ClassesFail2 = noThemeArg4({...expectedCustomProps, theme: expectedDefaultTheme})
+const noThemeArg4ClassesPass = noThemeArg4(expectedCustomProps)
+const noThemeArg4ClassesPass2 = noThemeArg4({...expectedCustomProps, theme: expectedCustomTheme})
+
+// Nested declarations are banned (single nest test)
+const noThemeArg5 = createUseStyles<string, MyProps, MyTheme>({
+  singleNest: {
+    fontWeight: 'bold',
+    singleValue: ({property, theme}) => '',
+    nestOne: ({property, theme}) => ({
+      color: 'red',
+      // @ts-expect-error
+      nothingAllowed: ({theme: innerTheme, ...innerProps}) => ''
+    })
+  }
+})
+
+// Nested declarations are banned (double nest test)
+const noThemeArg6 = createUseStyles<string, MyProps, MyTheme>({
+  doubleNest: {
+    fontWeight: 'bold',
+    singleValue: ({property, theme}) => '',
+    firstNest: {
+      color: 'red',
+      innerSingleValue: ({property, theme}) => '',
+      secondNest: ({property, theme}) => ({
+        backgroundColor: 'blue',
+        // @ts-expect-error
+        nothingAllowed: ({theme: innerTheme, ...innerProps}) => ''
+      })
+    }
+  }
+})
+
+// Nested declarations are banned (triple nest test)
+const noThemeArg7 = createUseStyles<string, MyProps, MyTheme>({
+  tripleNest: {
+    fontWeight: 'bold',
+    singleValue: ({property, theme}) => '',
+    firstNest: {
+      color: 'red',
+      innerSingleValue: ({property, theme}) => '',
+      secondNest: {
+        backgroundColor: 'blue',
+        innerMostSingleValue: ({property, theme}) => '',
+        thirdNest: ({property, theme}) => ({
+          display: 'block',
+          // @ts-expect-error
+          nothingAllowed: ({theme: innerMostTheme, ...innerMostProps}) => ''
+        })
+      }
+    }
+  }
+})
+
+// Props can be determined implicitly
+const noThemeArg8 = createUseStyles({
+  checkbox: ({property}: MyProps) => ({
+    borderColor: property
+  })
+})
+
+// @ts-expect-error invalid props
+const noThemeArg8ClassesFail = noThemeArg8({colour: 'green'})
+// @ts-expect-error extraneous props
+const noThemeArg8ClassesFail2 = noThemeArg8({...expectedCustomProps, someUnTypedProp: 1})
+const noThemeArg8ClassesPass = noThemeArg8(expectedCustomProps)
+
+// Classes check
+const noThemeArg8ClassesString: string = noThemeArg8ClassesPass.checkbox
+// @ts-expect-error invalid className
+noThemeArg8ClassesPass.doesntExist

--- a/packages/react-jss/tests/types/withStyles.tsx
+++ b/packages/react-jss/tests/types/withStyles.tsx
@@ -1,0 +1,170 @@
+import React from 'react'
+import withStyles, {Styles} from '../../src'
+
+// Note: Styles type is thoroughly tested in `jss/tests/types/Styles` and `react-jss/tests/types/createUseStyles`.
+// This is simply a test to make sure `withStyles` accepts and rejects the correct arguments.
+
+// Note: Testing default theme vs. custom theme is unnecessary here since the user will
+// always have to specify the theme anyway.
+
+interface MyProps {
+  property: string
+}
+
+interface MyTheme {
+  color: 'red'
+}
+
+function SimpleComponent(props: MyProps) {
+  return <div>{props.property}</div>
+}
+
+// Intended to test the output of withStyles to make sure the props are still valid
+let ResultingComponent: React.ComponentType<MyProps>
+let ComponentTest: React.FC
+
+/* -------------------- Function Argument Passing Cases -------------------- */
+// Plain Object (no type supplied)
+function functionPlainObject(theme: MyTheme) {
+  return {
+    someClassName: '',
+    anotherClassName: {
+      fontWeight: 'bold'
+    }
+  }
+}
+ResultingComponent = withStyles(functionPlainObject)(SimpleComponent)
+ComponentTest = () => <ResultingComponent property="" />
+
+// Plain Styles
+function functionPlainStyles(theme: MyTheme): Styles {
+  return {
+    someClassName: '',
+    anotherClassName: {
+      fontWeight: 'bold'
+    }
+  }
+}
+ResultingComponent = withStyles(functionPlainStyles)(SimpleComponent)
+ComponentTest = () => <ResultingComponent property="" />
+
+// With Props
+function functionProps(theme: MyTheme): Styles<string, MyProps> {
+  return {
+    someClassName: ({property}) => '',
+    anotherClassName: {
+      fontWeight: 'bold'
+    }
+  }
+}
+ResultingComponent = withStyles(functionProps)(SimpleComponent)
+ComponentTest = () => <ResultingComponent property="" />
+
+// With Props and ClassName rules
+function functionPropsAndName(theme: MyTheme): Styles<number, MyProps, undefined> {
+  return {
+    [1]: ({property}) => '',
+    [2]: {
+      fontWeight: 'bold'
+    }
+  }
+}
+ResultingComponent = withStyles(functionPropsAndName)(SimpleComponent)
+ComponentTest = () => <ResultingComponent property="" />
+
+/* -------------------- Regular Object Passing Cases -------------------- */
+
+// Plain Object (no type supplied)
+const plainObject = {
+  someClassName: '',
+  anotherClassName: {
+    fontWeight: 'bold'
+  }
+}
+ResultingComponent = withStyles(plainObject)(SimpleComponent)
+ComponentTest = () => <ResultingComponent property="" />
+
+// Plain Styles
+const stylesPlain: Styles = {
+  someClassName: '',
+  anotherClassName: {
+    fontWeight: 'bold'
+  }
+}
+ResultingComponent = withStyles(stylesPlain)(SimpleComponent)
+ComponentTest = () => <ResultingComponent property="" />
+
+// With Props
+const stylesProps: Styles<string, MyProps> = {
+  someClassName: ({property}) => '',
+  anotherClassName: {
+    fontWeight: 'bold'
+  }
+}
+ResultingComponent = withStyles(stylesProps)(SimpleComponent)
+ComponentTest = () => <ResultingComponent property="" />
+
+// With Theme
+const stylesTheme: Styles<string, unknown, MyTheme> = {
+  someClassName: ({theme}) => '',
+  anotherClassName: {
+    fontWeight: 'bold'
+  }
+}
+ResultingComponent = withStyles(stylesTheme)(SimpleComponent)
+ComponentTest = () => <ResultingComponent property="" />
+
+// With Props and Theme
+const stylesPropsAndTheme: Styles<string, MyProps, MyTheme> = {
+  someClassName: ({property, theme}) => '',
+  anotherClassName: {
+    fontWeight: 'bold'
+  }
+}
+ResultingComponent = withStyles(stylesPropsAndTheme)(SimpleComponent)
+ComponentTest = () => <ResultingComponent property="" />
+
+// With Props and Theme and ClassName rules
+const stylesPropsAndThemeAndName: Styles<number, MyProps, MyTheme> = {
+  [1]: ({property, theme}) => '',
+  [2]: {
+    fontWeight: 'bold'
+  }
+}
+ResultingComponent = withStyles(stylesPropsAndThemeAndName)(SimpleComponent)
+ComponentTest = () => <ResultingComponent property="" />
+
+/* -------------------- Failing Cases -------------------- */
+
+// A function argument cannot provide another defined theme type conflicting with `undefined`
+function failingFunctionRedefineTheme(theme: MyTheme): Styles<string, unknown, any> {
+  return {
+    someClassName: '',
+    anotherClassName: {
+      fontWeight: 'bold'
+    }
+  }
+}
+
+function passingFunctionUnknownTheme(theme: MyTheme): Styles<string, unknown, unknown> {
+  return {
+    someClassName: '',
+    anotherClassName: {
+      fontWeight: 'bold'
+    }
+  }
+}
+
+function passingFunctionNullTheme(theme: MyTheme): Styles<string, unknown, null> {
+  return {
+    someClassName: '',
+    anotherClassName: {
+      fontWeight: 'bold'
+    }
+  }
+}
+
+// @ts-expect-error
+withStyles(failingFunctionRedefineTheme)(SimpleComponent)
+withStyles(passingFunctionUnknownTheme)(SimpleComponent)
+withStyles(passingFunctionNullTheme)(SimpleComponent)


### PR DESCRIPTION
## What Would You Like to Fix/Add?
This PR aims to ensure that the `createUseStyles` hook has accurate TS intellisense for `props` and `theme`s. The details of the work can be found in the commit message. Note that as a result of cascading effects, this PR also improves the types for the deprecated `withStyles` HOC. This should satisfy #1273 and #1431.

These are TypeScript changes **only**, as only these changes will be visible to the TypeScript users. These are the minimal changes necessary to improve the user experience for TS devs. Flow is separate and unrelated to the user, and I'm not so familiar with it, so it's simplest to add flow changes in a separate commit (if that's acceptable). (If someone else familiar with Flow could apply the changes, that would be helpful. I've already supplied the TS types, so it should be easy.)

## Goals
- The types should be accurate for **both** kinds of arguments supplied to `createUseStyles`/`withStyles` (ie. the object argument and the function argument).
- The type definitions should ban the declaration of [React-JSS-related] types that have already been defined in the surrounding scope. This prevents confusion that could be caused from unnecessary shadowing (which many eslint configs would oppose anyway). It also discourages users from attempting to define nested functions (which JSS seems to warn against already).
  - As an example: A function of `props` and `theme` that returns a style object will not give type inference to nested functions.
- The generic types should be ordered according to what users are most likely to need or use. For instance, `Props` is typically more necessary than `Theme`.
- A `withStyles` "lazy migration" in TS should be "sufficiently easy" ("not too complicated") to write given these changes. If not, these new types may need to be revisited. (This requires closely examining how well the HOC is defined, not just how well these new types are defined.)
  - On that note, I intend to send out a PR for this in the future, pending this PR. See #1459.

## Caveats
- Supplying **any** generic type parameters causes all defaults to be used by TS. This means you risk losing the implicit definitions of class names whenever you specify `props`/`data`.
  - This is a TS problem, and it will hopefully get resolved in the near future. See microsoft/TypeScript#26349.
- No breaking changes for JS. But for TS (mainly React), if anyone is using the old `createUseStyles<Theme>` syntax, they will have to update their types. This is unfortunate, but not hard. And since TS has better intellisense when `Name` is not specified, this shouldn't be a common concern.

## Unknowns / Concerns
- **Resolved**: Use default `any`. ~~In `jss/src/index.d.ts`, should all _default_ usages of `JssStyle` be updated to use `JssStyle<any>` in the context of these proposed changes?~~

## Extra Notes
- `createStyleSheet` uses `any` for the `Data`/`Props` type because the data can be dynamically changed at any point. `any` is safest.

## Todo
- [x] Add tests that verify the modified behavior
- [x] Add documentation if it changes the public API
  - N/A (no TS documentation currently exists...yet)
