### PR TITLE
Improve Contributing Docs (Flow)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage
 lerna-debug.log
 yarn-error.log
 .idea
+.vscode

--- a/contributing.md
+++ b/contributing.md
@@ -40,3 +40,17 @@ Using karma (real browsers will get launched).
 ```bash
 yarn test
 ```
+
+## IDEs
+
+If you are using VS Code, you'll need to do 2 things to get Flow type support:
+
+1. Install the [Flow Language Support extension](https://marketplace.visualstudio.com/items?itemName=flowtype.flow-for-vscode).
+2. If necessary, update your _local_ settings to disable JS file validation:
+
+```JSON
+// <PROJECT_ROOT>/.vscode/settings.json
+{
+  "javascript.validate.enable": false
+}
+```


### PR DESCRIPTION
## What Would You Like to Add/Fix?
This is a PR to improve the contribution docs by explaining how to setup VS Code with Flow support. (It also adds `.vscode` to the `.gitignore` so that different users can maintain their own settings).

I burned an unnecessary amount of time darting around trying to figure out how to get Flow support. Theoretically, users could just do their own research. But if the docs add a quick comment about how to get started, it will help contributors get to work faster (and reduce the number of people who give up because the mere setup seems too difficult).