### PR TITLE
Add Documentation for Using Hooks with TypeScript

### DIFF
--- a/docs/react-jss-ts.md
+++ b/docs/react-jss-ts.md
@@ -1,0 +1,120 @@
+# Using TypeScript with React-JSS
+
+React-JSS enables you to supply types for your `ruleNames`, `props`/`data`, and `theme` both explicitly and implicitly.
+
+## Explicit Typing
+
+```tsx
+// Define Component
+type RuleNames = 'myButton' | 'myLabel'
+
+interface ButtonProps {
+  children?: React.ReactNode
+  spacing?: number
+  fontWeight?: string
+  labelColor?: string
+}
+
+interface CustomTheme {
+  background: string
+}
+
+const useStyles = createUseStyles<RuleNames, ButtonProps, CustomTheme>({
+  myButton: {
+    padding: ({spacing}) => spacing || 10
+  },
+  myLabel: ({theme, ...props}) => ({
+    display: 'block',
+    color: props.labelColor || 'red',
+    fontWeight: props.fontWeight || 'bold',
+    backgroundColor: theme.background || 'gray'
+  })
+})
+
+function Button({children, ...props}: ButtonProps): React.ReactElement {
+  const theme = useTheme<CustomTheme>()
+  const classes = useStyles({...props, theme})
+
+  return (
+    <button className={classes.myButton}>
+      <span className={classes.myLabel}>{children}</span>
+    </button>
+  )
+}
+
+// Create App
+const theme = {background: 'black'}
+
+function App(): React.ReactElement {
+  return (
+    <ThemeProvider theme={theme}>
+      <Button fontWeight="bold">Submit</Button>
+    </ThemeProvider>
+  )
+}
+```
+
+You only need to supply as much type information as you need. For instance, if you aren't using a `Theme`, then you don't need to supply a type for it. You'll notice that if you want to supply types for `Props` or `Theme`, you'll have to supply the type for `RuleNames` first. This means that if you want autocomplete for the `classes` that come from `useStyles`, you'll need to explicitly provide the strings you'll be using. This restriction is due to a limitation in TypeScript [that will hopefully get resolved soon](https://github.com/microsoft/TypeScript/pull/26349). However, you can see the next section for a workaround.
+
+## Implicit Typing
+
+If you want to provide `Props` and/or `Theme` types without having to supply the `RuleNames` type, you can make TypeScript infer the types implicitly. The primary benefit of doing this is that you'll get autocomplete on `classes` _in addition to_ your props/theme without having to duplicate your rule names. There are two approaches:
+
+Using the functional variant...
+
+```tsx
+const useStyles = createUseStyles((theme: CustomTheme) => ({
+  myButton: {
+    padding: (props: ButtonProps) => props.spacing || 10
+  },
+  myLabel: props => ({
+    display: 'block',
+    color: props.labelColor || 'red',
+    fontWeight: props.fontWeight || 'bold',
+    backgroundColor: theme.background || 'gray'
+  })
+}))
+```
+
+Or using the object variant...
+
+```tsx
+const useStyles = createUseStyles({
+  myLabel: ({theme, ...props}: ButtonProps & {theme: CustomTheme}) => ({
+    display: 'block',
+    color: props.labelColor || 'red',
+    fontWeight: props.fontWeight || 'bold',
+    backgroundColor: theme.background || 'gray'
+  }),
+  myButton: {
+    padding: props => props.spacing || 10
+  }
+})
+```
+
+Note that because of how TS implicitly determines types, there are some restrictions here:
+
+- For the functional variant, the `Theme` type _must_ be supplied with the `theme` argument to register its type. The `Props` type can be specified at any level in the object tree, but the first occurence of a data function _must_ provide the prop types.
+- For the object variant, both the `Theme` type _and_ the `Props` type _must_ be provided in the first occurence of a data function. Additionally, this data function must be defined at the rule name level of the object. Due to both of these restrictions, you'll notice that the `myLabel` definition was moved above `myButton` in the object variant example.
+
+In both cases, the types only need to be supplied _once_ for TS to infer everything, as shown in the examples above. And again, you only need to define the types you choose to use.
+
+## Defining a Global Default Theme
+
+If `CustomTheme` is the same across your entire application, you can define a default theme for React-JSS to use by creating a file called `global.d.ts` anywhere in the project:
+
+```typescript
+// global.d.ts
+
+declare global {
+  namespace Jss {
+    export interface Thme {
+      background: string
+    }
+  }
+}
+
+export {}
+```
+
+This enables React-JSS to rely on a default `Theme` type, removing the need to explicitly provide a type to `createUseStyles`. This file does not need to be imported anywhere; it is automatically acknowledged by TypeScript and/or VSCode's TypeScript Server.

--- a/docs/react-jss.md
+++ b/docs/react-jss.md
@@ -30,7 +30,7 @@ Try it out in the [playground](https://codesandbox.io/s/j3l06yyqpw).
 - [Custom setup](#custom-setup)
 - [Multi-tree setup](#multi-tree-setup)
 - [Injection order](#injection-order)
-- [TypeScript](#typescript)
+- [Usage with TypeScript](#usage-with-typescript)
 
 ## Install
 
@@ -585,6 +585,6 @@ const Button = () => {
 }
 ```
 
-## TypeScript
+## Usage with TypeScript
 
-TODO hooks support
+For help using TypeScript with React-JSS, go [here](react-jss-ts.md).

--- a/packages/react-jss/tests/types/docs.tsx
+++ b/packages/react-jss/tests/types/docs.tsx
@@ -1,0 +1,80 @@
+import React from 'react'
+import {createUseStyles, useTheme, ThemeProvider} from 'react-jss'
+
+/* -------------------- EXPLICIT EXAMPLE -------------------- */
+// Define Component
+type RuleNames = 'myButton' | 'myLabel'
+
+interface ButtonProps {
+  children?: React.ReactNode
+  spacing?: number
+  fontWeight?: string
+  labelColor?: string
+}
+
+interface CustomTheme {
+  background: string
+}
+
+const useStyles = createUseStyles<RuleNames, ButtonProps, CustomTheme>({
+  myButton: {
+    padding: ({spacing}) => spacing || 10
+  },
+  myLabel: ({theme, ...props}) => ({
+    display: 'block',
+    color: props.labelColor || 'red',
+    fontWeight: props.fontWeight || 'bold',
+    backgroundColor: theme.background || 'gray'
+  })
+})
+
+function Button({children, ...props}: ButtonProps): React.ReactElement {
+  const theme = useTheme<CustomTheme>()
+  const classes = useStyles({...props, theme})
+
+  return (
+    <button className={classes.myButton}>
+      <span className={classes.myLabel}>{children}</span>
+    </button>
+  )
+}
+
+// Create App
+const theme = {background: 'black'}
+
+function App(): React.ReactElement {
+  return (
+    <ThemeProvider theme={theme}>
+      <Button fontWeight="bold">Submit</Button>
+    </ThemeProvider>
+  )
+}
+
+/* -------------------- IMPLICIT EXAMPLES -------------------- */
+// Note: `Theme` must be typed by the `theme` argument. And the
+// first occurence of a data function must provide `Props`.
+const useStylesImplicitFunc = createUseStyles((theme: CustomTheme) => ({
+  myButton: {
+    padding: (props: ButtonProps) => props.spacing || 10
+  },
+  myLabel: props => ({
+    display: 'block',
+    color: props.labelColor || 'red',
+    fontWeight: props.fontWeight || 'bold',
+    backgroundColor: theme.background || 'gray'
+  })
+}))
+
+// Note: First occurence of data function must provide `Props` and `Theme`.
+// It must also be defined at the `RuleNames` level.
+const useStylesImplicitObj = createUseStyles({
+  myLabel: ({theme, ...props}: ButtonProps & {theme: CustomTheme}) => ({
+    display: 'block',
+    color: props.labelColor || 'red',
+    fontWeight: props.fontWeight || 'bold',
+    backgroundColor: theme.background || 'gray'
+  }),
+  myButton: {
+    padding: props => props.spacing || 10
+  }
+})


### PR DESCRIPTION
## What Would You Like to Add/Fix?
This is a PR to add documentation for using hooks with TypeScript. I didn't expect 10.6.0 to get released this fast. But since it's out there, I think getting these docs out as soon as possible is optimal. It will help people who've been waiting for better TS support, and it will also give better ideas on how to migrate older code.

Tests are added under a `docs.tsx` file. If the examples are simple, then any TS code that gets added to the documentation should probably have something like this. Implicit types are complicated, so it's important to know they work as expected before suggesting the change to other users.