### PR TITLE
cover undef possibility on getHead

### DIFF
--- a/packages/jss/src/DomRenderer.js
+++ b/packages/jss/src/DomRenderer.js
@@ -246,7 +246,7 @@ function insertStyle(style: HTMLElement, options: PriorityOptions) {
     return
   }
 
-  getHead().appendChild(style)
+  getHead()?.appendChild(style)
 }
 
 /**


### PR DESCRIPTION
## Corresponding issue (if exists):
    TypeError: Cannot read property 'appendChild' of undefined

## Changelog
I just added a condiitonal access operator becuase it was failing on my jest test suites
at DomRenderer.js (Line: 249)

![image](https://user-images.githubusercontent.com/52932948/111673072-f9561080-87f0-11eb-9c90-73baed8011ac.png)
