### PR TITLE
Add Slight Improvements to PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,22 @@
-## Corresponding issue (if exists):
+## Corresponding Issue(s): <!-- (if relevant) -->
 
-## What would you like to add/fix?
+## What Would You Like to Add/Fix?
 
 ## Todo
 
-- [ ] Add test that verifies the modified behavior
+- [ ] Add test(s) that verify the modified behavior
 - [ ] Add documentation if it changes public API
 
-## Expectations on changes
+## Expectations on Changes
 
+<!--
 1. Please don't do code changes and move code around in the same PR, even if you are making code better. Make sure the reviewer can see just the changes which fix the problem. This can make your Code Review much more accessible in complex situations; otherwise, it might never get merged even if it is correct because it's impossible to review without reimplementing every change.
 2. Often, submitting a failing test is more critical than the fix. Fixing the problem can be challenging and has many ways. Offering an excellent failing test is often 80% of the solution.
 3. Please review your PR before submitting it as if you are the reviewer. This way, you show respect for the maintainer's time.
+-->
 
 ## Changelog
 
+<!--
 Please summarize the changes in a way that makes sense inside the changelog. Feel free to add migration tips or examples if necessary.
+-->


### PR DESCRIPTION
## What Would You Like to Add/Fix?
This is a simple PR to provide slight enhancements to the PR template. Commenting out text that doesn't belong in the submitted PR helps clarify what the contributor is (or isn't) expected to provide. Additionally, it reduces visual overloading for reviewers when the contributor forgets to remove/replace the template text.
