### PR TITLE
fix(jss): Fix the dynamic expanded style update bug.

### DIFF
--- a/packages/jss/src/RuleList.js
+++ b/packages/jss/src/RuleList.js
@@ -216,17 +216,6 @@ export default class RuleList {
       // We need to run the plugins in case new `style` relies on syntax plugins.
       plugins.onProcessStyle(styleRule.style, styleRule, sheet)
 
-      // Update and add props.
-      for (const prop in styleRule.style) {
-        const nextValue = styleRule.style[prop]
-        const prevValue = style[prop]
-        // We need to use `force: true` because `rule.style` has been updated during onUpdate hook, so `rule.prop()` will not update the CSSOM rule.
-        // We do this comparison to avoid unneeded `rule.prop()` calls, since we have the old `style` object here.
-        if (nextValue !== prevValue) {
-          styleRule.prop(prop, nextValue, forceUpdateOptions)
-        }
-      }
-
       // Remove props.
       for (const prop in style) {
         const nextValue = styleRule.style[prop]
@@ -235,6 +224,17 @@ export default class RuleList {
         // We do this comparison to avoid unneeded `rule.prop()` calls, since we have the old `style` object here.
         if (nextValue == null && nextValue !== prevValue) {
           styleRule.prop(prop, null, forceUpdateOptions)
+        }
+      }
+
+      // Update and add props.
+      for (const prop in styleRule.style) {
+        const nextValue = styleRule.style[prop]
+        const prevValue = style[prop]
+        // We need to use `force: true` because `rule.style` has been updated during onUpdate hook, so `rule.prop()` will not update the CSSOM rule.
+        // We do this comparison to avoid unneeded `rule.prop()` calls, since we have the old `style` object here.
+        if (nextValue !== prevValue) {
+          styleRule.prop(prop, nextValue, forceUpdateOptions)
         }
       }
     }

--- a/packages/jss/src/plugins/styleRule.js
+++ b/packages/jss/src/plugins/styleRule.js
@@ -62,14 +62,12 @@ export class BaseStyleRule implements BaseRule {
     if (isEmpty && !isDefined && !force) return this
 
     // We are going to remove this value.
-    const remove = isEmpty && isDefined
-
-    if (remove) delete this.style[name]
+    if (isEmpty) delete this.style[name]
     else this.style[name] = newValue
 
     // Renderable is defined if StyleSheet option `link` is true.
     if (this.renderable && this.renderer) {
-      if (remove) this.renderer.removeProperty(this.renderable, name)
+      if (isEmpty) this.renderer.removeProperty(this.renderable, name)
       else this.renderer.setProperty(this.renderable, name, newValue)
       return this
     }


### PR DESCRIPTION
## Corresponding Issue(s): <!-- (if relevant) -->

Fixes #1051

## What Would You Like to Add/Fix?

- Adjust the style processing order, the invalid props will remove before add/update.

https://github.com/cssinjs/jss/blob/6f151d497383f557fb69ee8bc2825373e75d63fe/packages/jss/src/RuleList.js#L219-L238

Currently, the props was update/add before remove, for example:

Before styles:
```
{
  "margin-top": "1px",
}
```

Updated styles 
```
{
  "margin": "2px",
}
```
The jss processing order is: 
> setProperty('margin', '1px');
> removeProperty('margin-top');

The problem is `setProperty('margin')` behavior will set `margin-top` `margin-left` `margin-right` `margin-bottom` to same values,  after the `removeProperty` remove `margin-top` property, the finally style will lost `margin-top`.

- Fix `style[prop]` remove bug

https://github.com/cssinjs/jss/blob/6f151d497383f557fb69ee8bc2825373e75d63fe/packages/jss/src/plugins/styleRule.js#L59-L65

Because `this.style` was updated by *RuleList*, so `const isDefined = name in this.style ` always be `false`. the `remove` flag was same to.


## Todo

- [ ] Add test(s) that verify the modified behavior

## Expectations on Changes

<!--
1. Please don't do code changes and move code around in the same PR, even if you are making code better. Make sure the reviewer can see just the changes which fix the problem. This can make your Code Review much more accessible in complex situations; otherwise, it might never get merged even if it is correct because it's impossible to review without reimplementing every change.
2. Often, submitting a failing test is more critical than the fix. Fixing the problem can be challenging and has many ways. Offering an excellent failing test is often 80% of the solution.
3. Please review your PR before submitting it as if you are the reviewer. This way, you show respect for the maintainer's time.
-->

## Changelog

<!--
Please summarize the changes in a way that makes sense inside the changelog. Feel free to add migration tips or examples if necessary.
-->
