### PR TITLE
add forgotten type for getPropertyValue

### DIFF
--- a/packages/jss/src/DomRenderer.js
+++ b/packages/jss/src/DomRenderer.js
@@ -38,7 +38,7 @@ type GetPropertyValue = (HTMLElementWithStyleMap | CSSStyleRule | CSSKeyframeRul
 /**
  * Get a style property value.
  */
-const getPropertyValue = (cssRule, prop) => {
+const getPropertyValue: GetPropertyValue = (cssRule, prop) => {
   try {
     // Support CSSTOM.
     if (cssRule.attributeStyleMap) {


### PR DESCRIPTION
We have `GetPropertyValue` but `getPropertyValue` not used it