### PR TITLE
simplify findHigherSheet in dom renderer

### DIFF
--- a/packages/jss/.size-snapshot.json
+++ b/packages/jss/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "jss.js": {
-    "bundled": 63809,
-    "minified": 23360,
-    "gzipped": 7098
+    "bundled": 63736,
+    "minified": 23340,
+    "gzipped": 7113
   },
   "jss.min.js": {
-    "bundled": 62412,
-    "minified": 22592,
-    "gzipped": 6748
+    "bundled": 62339,
+    "minified": 22572,
+    "gzipped": 6763
   },
   "jss.cjs.js": {
-    "bundled": 59503,
-    "minified": 26211,
-    "gzipped": 7200
+    "bundled": 59438,
+    "minified": 26191,
+    "gzipped": 7216
   },
   "jss.esm.js": {
-    "bundled": 57895,
-    "minified": 24922,
-    "gzipped": 7027,
+    "bundled": 57830,
+    "minified": 24902,
+    "gzipped": 7043,
     "treeshaked": {
       "rollup": {
-        "code": 20349,
+        "code": 20329,
         "import_statements": 345
       },
       "webpack": {
-        "code": 21834
+        "code": 21814
       }
     }
   }

--- a/packages/jss/src/DomRenderer.js
+++ b/packages/jss/src/DomRenderer.js
@@ -130,17 +130,14 @@ const getHead = memoize((): HTMLElement => (document.querySelector('head'): any)
  * Find attached sheet with an index higher than the passed one.
  */
 function findHigherSheet(registry: Array<StyleSheet>, options: PriorityOptions): StyleSheet | null {
-  for (let i = 0; i < registry.length; i++) {
-    const sheet = registry[i]
-    if (
-      sheet.attached &&
-      sheet.options.index > options.index &&
-      sheet.options.insertionPoint === options.insertionPoint
-    ) {
-      return sheet
-    }
-  }
-  return null
+  return (
+    registry.find(
+      sheet =>
+        sheet.attached &&
+        sheet.options.index > options.index &&
+        sheet.options.insertionPoint === options.insertionPoint
+    ) || null
+  )
 }
 
 /**


### PR DESCRIPTION
Used `find` instead of `for` to simplify and reduce the size