### PR TITLE
remove repetition type definition in createGenerateId

### DIFF
--- a/packages/jss/.size-snapshot.json
+++ b/packages/jss/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "jss.js": {
-    "bundled": 63809,
+    "bundled": 63854,
     "minified": 23360,
     "gzipped": 7098
   },
   "jss.min.js": {
-    "bundled": 62412,
+    "bundled": 62457,
     "minified": 22592,
     "gzipped": 6748
   },
   "jss.cjs.js": {
-    "bundled": 59503,
+    "bundled": 59546,
     "minified": 26211,
     "gzipped": 7200
   },
   "jss.esm.js": {
-    "bundled": 57895,
+    "bundled": 57938,
     "minified": 24922,
     "gzipped": 7027,
     "treeshaked": {

--- a/packages/jss/src/utils/createGenerateId.js
+++ b/packages/jss/src/utils/createGenerateId.js
@@ -21,7 +21,7 @@ export type CreateGenerateId = (options?: CreateGenerateIdOptions) => GenerateId
 const createGenerateId: CreateGenerateId = (options = {}) => {
   let ruleCounter = 0
 
-  return (rule: Rule, sheet?: StyleSheet): string => {
+  const generateId: GenerateId = (rule, sheet) => {
     ruleCounter += 1
 
     if (ruleCounter > maxRules) {
@@ -47,6 +47,8 @@ const createGenerateId: CreateGenerateId = (options = {}) => {
 
     return `${prefix + rule.key}-${moduleId}${jssId ? `-${jssId}` : ''}-${ruleCounter}`
   }
+
+  return generateId
 }
 
 export default createGenerateId


### PR DESCRIPTION
I used `GenerateId` type inside of `createGenerateId`