### PR TITLE
Ship memoize to utils

### DIFF
--- a/packages/jss/src/DomRenderer.js
+++ b/packages/jss/src/DomRenderer.js
@@ -3,6 +3,7 @@ import warning from 'tiny-warning'
 import StyleSheet from './StyleSheet'
 import sheets from './sheets'
 import toCssValue from './utils/toCssValue'
+import memoize from './utils/memoize'
 import type {
   CSSStyleRule,
   CSSMediaRule,
@@ -20,17 +21,6 @@ import type {
 type PriorityOptions = {
   index: number,
   insertionPoint?: InsertionPoint
-}
-
-/**
- * Cache the value from the first time a function is called.
- */
-const memoize = <Value>(fn: () => Value): (() => Value) => {
-  let value
-  return () => {
-    if (!value) value = fn()
-    return value
-  }
 }
 
 type GetPropertyValue = (HTMLElementWithStyleMap | CSSStyleRule | CSSKeyframeRule, string) => string

--- a/packages/jss/src/utils/memoize.js
+++ b/packages/jss/src/utils/memoize.js
@@ -1,0 +1,12 @@
+/**
+ * Cache the value from the first time a function is called.
+ */
+const memoize = <Value>(fn: () => Value): (() => Value) => {
+  let value
+  return () => {
+    if (!value) value = fn()
+    return value
+  }
+}
+
+export default memoize


### PR DESCRIPTION
`memoize` can use in other `Renderer` class such as `AtomicDomRenderer`, so I shipped to utils for use in future