### PR TITLE
Add minimal type to reduce dependency graph

### DIFF
--- a/packages/jss/package.json
+++ b/packages/jss/package.json
@@ -40,7 +40,6 @@
   "dependencies": {
     "@babel/runtime": "^7.3.1",
     "csstype": "^3.0.2",
-    "indefinite-observable": "^2.0.1",
     "is-in-browser": "^1.1.3",
     "tiny-warning": "^1.0.2"
   },

--- a/packages/jss/src/index.d.ts
+++ b/packages/jss/src/index.d.ts
@@ -5,7 +5,11 @@ import {Properties as CSSProperties} from 'csstype'
 // hasn't installed that plugin.
 //
 // TODO: refactor to only include Observable types if plugin is installed.
-import {Observable} from 'indefinite-observable'
+export interface MinimalObservable<T> {
+  subscribe(
+    nextOrObserver: ((value: T) => void) | {next: (value: T) => void}
+  ): {unsubscribe: () => void}
+}
 
 type Func<P, T, R> = T extends undefined ? ((data: P) => R) : ((data: P & {theme: T}) => R)
 
@@ -18,14 +22,14 @@ export type JssStyle<Props = any, Theme = undefined> =
         | NormalCssValues<K>
         | JssStyle<Props, Theme>
         | Func<Props, Theme, NormalCssValues<K> | JssStyle<undefined, undefined> | undefined>
-        | Observable<NormalCssValues<K> | JssStyle | undefined>
+        | MinimalObservable<NormalCssValues<K> | JssStyle | undefined>
     }
   | {
       [K: string]:
         | JssValue
         | JssStyle<Props, Theme>
         | Func<Props, Theme, JssValue | JssStyle<undefined, undefined> | undefined>
-        | Observable<JssValue | JssStyle | undefined>
+        | MinimalObservable<JssValue | JssStyle | undefined>
     }
 
 export type Styles<
@@ -37,7 +41,7 @@ export type Styles<
   | JssStyle<Props, Theme>
   | string
   | Func<Props, Theme, JssStyle<undefined, undefined> | string | null | undefined>
-  | Observable<JssStyle | string | null | undefined>
+  | MinimalObservable<JssStyle | string | null | undefined>
 >
 export type Classes<Name extends string | number | symbol = string> = Record<Name, string>
 export type Keyframes<Name extends string = string> = Record<Name, string>

--- a/packages/jss/tests/jss-tests.ts
+++ b/packages/jss/tests/jss-tests.ts
@@ -5,9 +5,9 @@ import {
   createGenerateId,
   JssStyle,
   SheetsRegistry,
-  default as sharedInstance
+  default as sharedInstance,
+  MinimalObservable
 } from 'jss'
-import {NextChannel} from 'indefinite-observable'
 
 const jss = createJSS().setup({createGenerateId})
 jss.use({}, {})
@@ -15,7 +15,7 @@ jss.use({}, {})
 const styleSheet = jss.createStyleSheet<string>(
   {
     ruleWithMockObservable: {
-      subscribe: (observer: {next: NextChannel<JssStyle | string | null | undefined>}) => {
+      subscribe: observer => {
         const next = typeof observer === 'function' ? observer : observer.next
         next({background: 'blue', display: 'flex'})
 
@@ -23,7 +23,7 @@ const styleSheet = jss.createStyleSheet<string>(
           unsubscribe() {}
         }
       }
-    },
+    } as MinimalObservable<JssStyle | string | null | undefined>,
     rule: {
       color: (data: {color: string}) => data.color,
 

--- a/packages/jss/tests/types/Styles.ts
+++ b/packages/jss/tests/types/Styles.ts
@@ -1,5 +1,4 @@
-import {Styles} from '../../src'
-import {Observable} from 'indefinite-observable'
+import {MinimalObservable, Styles} from '../../src'
 
 interface Props {
   flag?: boolean
@@ -9,8 +8,8 @@ interface Theme {
   color: string
 }
 
-declare const color$: Observable<'cyan'>
-declare const style$: Observable<{
+declare const color$: MinimalObservable<'cyan'>
+declare const style$: MinimalObservable<{
   backgroundColor: 'fuchsia'
   transform: 'translate(0px, 205px)'
 }>


### PR DESCRIPTION

## Corresponding Issue(s): <!-- (if relevant) -->

None.

## What Would You Like to Add/Fix?

I came here looking to see how this project was using observables, and I figured out it was only using one of the dependencies for the observable type itself. I've simplified that and reduced the dependencies, since there was not really a run-time dependency at all, only build time.


## Todo

- [ ] ~~Add test(s) that verify the modified behavior~~
- [ ] ~~Add documentation if it changes public API~~
- [x] This was a refactor of typings with no changes to tests or documentation.
 
## Expectations on Changes

This was a refactor to reduce the number of dependencies and simplify things a bit. Just making sure you have defined the interface you expect for observables. There was no attempt to change functionality at all.

## Changelog

Eliminated the dependency on an external run-time project for the basic observable contract that was only used for TypeScript.

(attn @appsforartists)
