### PR TITLE
feat(jss): Add format option to SheetsRegistry.toString()

### DIFF
--- a/packages/jss/.size-snapshot.json
+++ b/packages/jss/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "jss.js": {
-    "bundled": 64250,
-    "minified": 23478,
-    "gzipped": 7181
+    "bundled": 65018,
+    "minified": 23583,
+    "gzipped": 7215
   },
   "jss.min.js": {
-    "bundled": 62853,
-    "minified": 22710,
-    "gzipped": 6831
+    "bundled": 63621,
+    "minified": 22814,
+    "gzipped": 6864
   },
   "jss.cjs.js": {
-    "bundled": 59928,
-    "minified": 26329,
-    "gzipped": 7283
+    "bundled": 60654,
+    "minified": 26563,
+    "gzipped": 7334
   },
   "jss.esm.js": {
-    "bundled": 58320,
-    "minified": 25040,
-    "gzipped": 7106,
+    "bundled": 59046,
+    "minified": 25274,
+    "gzipped": 7159,
     "treeshaked": {
       "rollup": {
-        "code": 20467,
+        "code": 20570,
         "import_statements": 345
       },
       "webpack": {
-        "code": 21952
+        "code": 22057
       }
     }
   }

--- a/packages/jss/.size-snapshot.json
+++ b/packages/jss/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "jss.js": {
-    "bundled": 63839,
-    "minified": 23351,
-    "gzipped": 7097
+    "bundled": 64250,
+    "minified": 23478,
+    "gzipped": 7181
   },
   "jss.min.js": {
-    "bundled": 62442,
-    "minified": 22583,
-    "gzipped": 6747
+    "bundled": 62853,
+    "minified": 22710,
+    "gzipped": 6831
   },
   "jss.cjs.js": {
-    "bundled": 59531,
-    "minified": 26202,
-    "gzipped": 7199
+    "bundled": 59928,
+    "minified": 26329,
+    "gzipped": 7283
   },
   "jss.esm.js": {
-    "bundled": 57923,
-    "minified": 24913,
-    "gzipped": 7026,
+    "bundled": 58320,
+    "minified": 25040,
+    "gzipped": 7106,
     "treeshaked": {
       "rollup": {
-        "code": 20340,
+        "code": 20467,
         "import_statements": 345
       },
       "webpack": {
-        "code": 21825
+        "code": 21952
       }
     }
   }

--- a/packages/jss/src/RuleList.js
+++ b/packages/jss/src/RuleList.js
@@ -247,6 +247,7 @@ export default class RuleList {
     let str = ''
     const {sheet} = this.options
     const link = sheet ? sheet.options.link : false
+    const uglify = options ? options.uglify : false
 
     for (let index = 0; index < this.index.length; index++) {
       const rule = this.index[index]
@@ -255,7 +256,7 @@ export default class RuleList {
       // No need to render an empty rule.
       if (!css && !link) continue
 
-      if (str) str += '\n'
+      if (!uglify && str) str += '\n'
       str += css
     }
 

--- a/packages/jss/src/RuleList.js
+++ b/packages/jss/src/RuleList.js
@@ -13,6 +13,7 @@ import type {
   UpdateOptions
 } from './types'
 import escape from './utils/escape'
+import getWhitespaceSymbols from './utils/getWhitespaceSymbols'
 
 const defaultUpdateOptions = {
   process: true
@@ -247,7 +248,7 @@ export default class RuleList {
     let str = ''
     const {sheet} = this.options
     const link = sheet ? sheet.options.link : false
-    const uglify = options ? options.uglify : false
+    const {linebreak} = getWhitespaceSymbols(options)
 
     for (let index = 0; index < this.index.length; index++) {
       const rule = this.index[index]
@@ -256,7 +257,7 @@ export default class RuleList {
       // No need to render an empty rule.
       if (!css && !link) continue
 
-      if (!uglify && str) str += '\n'
+      if (str) str += linebreak
       str += css
     }
 

--- a/packages/jss/src/SheetsRegistry.js
+++ b/packages/jss/src/SheetsRegistry.js
@@ -1,6 +1,7 @@
 // @flow
 import type {ToCssOptions} from './types'
 import type StyleSheet from './StyleSheet'
+import getWhitespaceSymbols from './utils/getWhitespaceSymbols'
 
 /**
  * Sheets registry to access them all at one place.
@@ -57,14 +58,14 @@ export default class SheetsRegistry {
    * Convert all attached sheets to a CSS string.
    */
   toString({attached, ...options}: {|attached?: boolean, ...ToCssOptions|} = {}): string {
-    const {uglify} = options
+    const {linebreak} = getWhitespaceSymbols(options)
     let css = ''
     for (let i = 0; i < this.registry.length; i++) {
       const sheet = this.registry[i]
       if (attached != null && sheet.attached !== attached) {
         continue
       }
-      if (!uglify && css) css += '\n'
+      if (css) css += linebreak
       css += sheet.toString(options)
     }
     return css

--- a/packages/jss/src/SheetsRegistry.js
+++ b/packages/jss/src/SheetsRegistry.js
@@ -57,13 +57,14 @@ export default class SheetsRegistry {
    * Convert all attached sheets to a CSS string.
    */
   toString({attached, ...options}: {|attached?: boolean, ...ToCssOptions|} = {}): string {
+    const {uglify} = options
     let css = ''
     for (let i = 0; i < this.registry.length; i++) {
       const sheet = this.registry[i]
       if (attached != null && sheet.attached !== attached) {
         continue
       }
-      if (css) css += '\n'
+      if (!uglify && css) css += '\n'
       css += sheet.toString(options)
     }
     return css

--- a/packages/jss/src/index.d.ts
+++ b/packages/jss/src/index.d.ts
@@ -71,7 +71,7 @@ export interface UpdateOptions {
 
 export interface ToCssOptions {
   indent?: number
-  uglify?: boolean
+  format?: boolean
   allowEmpty?: boolean
 }
 

--- a/packages/jss/src/index.d.ts
+++ b/packages/jss/src/index.d.ts
@@ -71,6 +71,7 @@ export interface UpdateOptions {
 
 export interface ToCssOptions {
   indent?: number
+  uglify?: boolean
   allowEmpty?: boolean
 }
 

--- a/packages/jss/src/plugins/conditionalRule.js
+++ b/packages/jss/src/plugins/conditionalRule.js
@@ -79,7 +79,8 @@ export class ConditionalRule implements ContainerRule {
       return `${this.query} {}`
     }
     const children = this.rules.toString(options)
-    return children ? `${this.query} {\n${children}\n}` : ''
+    const lineBreak = options.uglify ? '' : '\n'
+    return children ? `${this.query} {${lineBreak}${children}${lineBreak}}` : ''
   }
 }
 

--- a/packages/jss/src/plugins/conditionalRule.js
+++ b/packages/jss/src/plugins/conditionalRule.js
@@ -1,6 +1,7 @@
 // @flow
 import RuleList from '../RuleList'
 import type {CSSMediaRule, Rule, RuleOptions, ToCssOptions, JssStyle, ContainerRule} from '../types'
+import getWhitespaceSymbols from '../utils/getWhitespaceSymbols'
 
 const defaultToStringOptions = {
   indent: 1,
@@ -73,14 +74,14 @@ export class ConditionalRule implements ContainerRule {
    * Generates a CSS string.
    */
   toString(options?: ToCssOptions = defaultToStringOptions): string {
+    const {linebreak} = getWhitespaceSymbols(options)
     if (options.indent == null) options.indent = defaultToStringOptions.indent
     if (options.children == null) options.children = defaultToStringOptions.children
     if (options.children === false) {
       return `${this.query} {}`
     }
     const children = this.rules.toString(options)
-    const lineBreak = options.uglify ? '' : '\n'
-    return children ? `${this.query} {${lineBreak}${children}${lineBreak}}` : ''
+    return children ? `${this.query} {${linebreak}${children}${linebreak}}` : ''
   }
 }
 

--- a/packages/jss/src/plugins/fontFaceRule.js
+++ b/packages/jss/src/plugins/fontFaceRule.js
@@ -27,11 +27,12 @@ export class FontFaceRule implements BaseRule {
    * Generates a CSS string.
    */
   toString(options?: ToCssOptions): string {
+    const uglify = options ? options.uglify : false
     if (Array.isArray(this.style)) {
       let str = ''
       for (let index = 0; index < this.style.length; index++) {
         str += toCss(this.at, this.style[index])
-        if (this.style[index + 1]) str += '\n'
+        if (!uglify && this.style[index + 1]) str += '\n'
       }
       return str
     }

--- a/packages/jss/src/plugins/fontFaceRule.js
+++ b/packages/jss/src/plugins/fontFaceRule.js
@@ -1,6 +1,7 @@
 // @flow
 import toCss from '../utils/toCss'
 import type {CSSFontFaceRule, RuleOptions, JssStyle, ToCssOptions, BaseRule} from '../types'
+import getWhitespaceSymbols from '../utils/getWhitespaceSymbols'
 
 export class FontFaceRule implements BaseRule {
   type: string = 'font-face'
@@ -27,12 +28,12 @@ export class FontFaceRule implements BaseRule {
    * Generates a CSS string.
    */
   toString(options?: ToCssOptions): string {
-    const uglify = options ? options.uglify : false
+    const {linebreak} = getWhitespaceSymbols(options)
     if (Array.isArray(this.style)) {
       let str = ''
       for (let index = 0; index < this.style.length; index++) {
         str += toCss(this.at, this.style[index])
-        if (!uglify && this.style[index + 1]) str += '\n'
+        if (this.style[index + 1]) str += linebreak
       }
       return str
     }

--- a/packages/jss/src/plugins/keyframesRule.js
+++ b/packages/jss/src/plugins/keyframesRule.js
@@ -11,6 +11,7 @@ import type {
   Plugin
 } from '../types'
 import escape from '../utils/escape'
+import getWhitespaceSymbols from '../utils/getWhitespaceSymbols'
 
 const defaultToStringOptions = {
   indent: 1,
@@ -69,13 +70,14 @@ export class KeyframesRule implements ContainerRule {
    * Generates a CSS string.
    */
   toString(options?: ToCssOptions = defaultToStringOptions): string {
+    const {linebreak} = getWhitespaceSymbols(options)
     if (options.indent == null) options.indent = defaultToStringOptions.indent
     if (options.children == null) options.children = defaultToStringOptions.children
     if (options.children === false) {
       return `${this.at} ${this.id} {}`
     }
     let children = this.rules.toString(options)
-    if (!options.uglify && children) children = `\n${children}\n`
+    if (children) children = `${linebreak}${children}${linebreak}`
     return `${this.at} ${this.id} {${children}}`
   }
 }

--- a/packages/jss/src/plugins/keyframesRule.js
+++ b/packages/jss/src/plugins/keyframesRule.js
@@ -75,7 +75,7 @@ export class KeyframesRule implements ContainerRule {
       return `${this.at} ${this.id} {}`
     }
     let children = this.rules.toString(options)
-    if (children) children = `\n${children}\n`
+    if (!options.uglify && children) children = `\n${children}\n`
     return `${this.at} ${this.id} {${children}}`
   }
 }

--- a/packages/jss/src/types/jss.js
+++ b/packages/jss/src/types/jss.js
@@ -20,7 +20,7 @@ export type KeyframesMap = {[string]: string}
 
 export type ToCssOptions = {|
   indent?: number,
-  uglify?: boolean,
+  format?: boolean,
   allowEmpty?: boolean,
   children?: boolean
 |}

--- a/packages/jss/src/types/jss.js
+++ b/packages/jss/src/types/jss.js
@@ -20,6 +20,7 @@ export type KeyframesMap = {[string]: string}
 
 export type ToCssOptions = {|
   indent?: number,
+  uglify?: boolean,
   allowEmpty?: boolean,
   children?: boolean
 |}

--- a/packages/jss/src/utils/getWhitespaceSymbols.js
+++ b/packages/jss/src/utils/getWhitespaceSymbols.js
@@ -1,0 +1,20 @@
+import type {ToCssOptions} from '../types'
+
+type WhitespaceSymbols = {
+  linebreak: string,
+  space: string
+}
+
+export default function getWhitespaceSymbols(options?: ToCssOptions): WhitespaceSymbols {
+  if (options && options.format === false) {
+    return {
+      linebreak: '',
+      space: ''
+    }
+  }
+
+  return {
+    linebreak: '\n',
+    space: ' '
+  }
+}

--- a/packages/jss/src/utils/toCss.js
+++ b/packages/jss/src/utils/toCss.js
@@ -1,6 +1,7 @@
 // @flow
 import toCssValue from './toCssValue'
 import type {ToCssOptions, JssStyle} from '../types'
+import getWhitespaceSymbols from './getWhitespaceSymbols'
 
 /**
  * Indent a string.
@@ -24,11 +25,13 @@ export default function toCss(
 
   if (!style) return result
 
-  const {uglify} = options
   let {indent = 0} = options
   const {fallbacks} = style
 
-  if (uglify) indent = -Infinity
+  if (options.format === false) {
+    indent = -Infinity
+  }
+  const {linebreak, space} = getWhitespaceSymbols(options)
 
   if (selector) indent++
 
@@ -41,8 +44,8 @@ export default function toCss(
         for (const prop in fallback) {
           const value = fallback[prop]
           if (value != null) {
-            if (!uglify && result) result += '\n'
-            result += indentStr(`${prop}: ${toCssValue(value)};`, indent)
+            if (result) result += linebreak
+            result += indentStr(`${prop}:${space}${toCssValue(value)};`, indent)
           }
         }
       }
@@ -51,8 +54,8 @@ export default function toCss(
       for (const prop in fallbacks) {
         const value = fallbacks[prop]
         if (value != null) {
-          if (!uglify && result) result += '\n'
-          result += indentStr(`${prop}: ${toCssValue(value)};`, indent)
+          if (result) result += linebreak
+          result += indentStr(`${prop}:${space}${toCssValue(value)};`, indent)
         }
       }
     }
@@ -61,8 +64,8 @@ export default function toCss(
   for (const prop in style) {
     const value = style[prop]
     if (value != null && prop !== 'fallbacks') {
-      if (!uglify && result) result += '\n'
-      result += indentStr(`${prop}: ${toCssValue(value)};`, indent)
+      if (result) result += linebreak
+      result += indentStr(`${prop}:${space}${toCssValue(value)};`, indent)
     }
   }
 
@@ -74,7 +77,7 @@ export default function toCss(
 
   indent--
 
-  if (!uglify && result) result = `\n${result}\n`
+  if (result) result = `${linebreak}${result}${linebreak}`
 
-  return indentStr(`${selector} {${result}`, indent) + indentStr('}', indent)
+  return indentStr(`${selector}${space}{${result}`, indent) + indentStr('}', indent)
 }

--- a/packages/jss/src/utils/toCss.js
+++ b/packages/jss/src/utils/toCss.js
@@ -24,8 +24,11 @@ export default function toCss(
 
   if (!style) return result
 
+  const {uglify} = options
   let {indent = 0} = options
   const {fallbacks} = style
+
+  if (uglify) indent = -Infinity
 
   if (selector) indent++
 
@@ -38,7 +41,7 @@ export default function toCss(
         for (const prop in fallback) {
           const value = fallback[prop]
           if (value != null) {
-            if (result) result += '\n'
+            if (!uglify && result) result += '\n'
             result += indentStr(`${prop}: ${toCssValue(value)};`, indent)
           }
         }
@@ -48,7 +51,7 @@ export default function toCss(
       for (const prop in fallbacks) {
         const value = fallbacks[prop]
         if (value != null) {
-          if (result) result += '\n'
+          if (!uglify && result) result += '\n'
           result += indentStr(`${prop}: ${toCssValue(value)};`, indent)
         }
       }
@@ -58,7 +61,7 @@ export default function toCss(
   for (const prop in style) {
     const value = style[prop]
     if (value != null && prop !== 'fallbacks') {
-      if (result) result += '\n'
+      if (!uglify && result) result += '\n'
       result += indentStr(`${prop}: ${toCssValue(value)};`, indent)
     }
   }
@@ -71,7 +74,7 @@ export default function toCss(
 
   indent--
 
-  if (result) result = `\n${result}\n`
+  if (!uglify && result) result = `\n${result}\n`
 
   return indentStr(`${selector} {${result}`, indent) + indentStr('}', indent)
 }

--- a/packages/jss/tests/integration/rules.js
+++ b/packages/jss/tests/integration/rules.js
@@ -388,6 +388,11 @@ describe('Integration: rules', () => {
         `)
       })
     })
+
+    it('should uglify CSS', () => {
+      const rule = jss.createRule('a', {float: 'left', width: '1px'})
+      expect(rule.toString({uglify: true})).to.be('.a-id {float: left;width: 1px;}')
+    })
   })
 
   describe('rule.toJSON()', () => {

--- a/packages/jss/tests/integration/rules.js
+++ b/packages/jss/tests/integration/rules.js
@@ -389,9 +389,9 @@ describe('Integration: rules', () => {
       })
     })
 
-    it('should uglify CSS', () => {
+    it('should remove whitespaces', () => {
       const rule = jss.createRule('a', {float: 'left', width: '1px'})
-      expect(rule.toString({uglify: true})).to.be('.a-id {float: left;width: 1px;}')
+      expect(rule.toString({format: false})).to.be('.a-id{float:left;width:1px;}')
     })
   })
 

--- a/packages/jss/tests/integration/sheetsRegistry.js
+++ b/packages/jss/tests/integration/sheetsRegistry.js
@@ -94,6 +94,15 @@ describe('Integration: sheetsRegistry', () => {
         }
       `)
     })
+
+    it('should uglify all', () => {
+      const sheet1 = jss.createStyleSheet({a: {color: 'red'}})
+      const sheet2 = jss.createStyleSheet({a: {color: 'blue'}}).attach()
+      sheets.add(sheet1)
+      sheets.add(sheet2)
+      expect(sheets.toString({uglify: true})).to.be('.a-id {color: red;}.a-id {color: blue;}')
+    })
+
     it('should stringify detached sheets', () => {
       const sheet1 = jss.createStyleSheet({a: {color: 'red'}})
       const sheet2 = jss.createStyleSheet({a: {color: 'blue'}}).attach()

--- a/packages/jss/tests/integration/sheetsRegistry.js
+++ b/packages/jss/tests/integration/sheetsRegistry.js
@@ -95,12 +95,12 @@ describe('Integration: sheetsRegistry', () => {
       `)
     })
 
-    it('should uglify all', () => {
+    it('should remove whitespaces', () => {
       const sheet1 = jss.createStyleSheet({a: {color: 'red'}})
       const sheet2 = jss.createStyleSheet({a: {color: 'blue'}}).attach()
       sheets.add(sheet1)
       sheets.add(sheet2)
-      expect(sheets.toString({uglify: true})).to.be('.a-id {color: red;}.a-id {color: blue;}')
+      expect(sheets.toString({format: false})).to.be('.a-id{color:red;}.a-id{color:blue;}')
     })
 
     it('should stringify detached sheets', () => {


### PR DESCRIPTION
## What Would You Like to Add/Fix?

This PR adds a new option `format` to `SheetsRegistry.toString` so whitespaces are removed from stringified CSS.

```es6
jss.createRule('a', {float: 'left', width: '1px'})

// Default
rule.toString()
// outputs:
// .a-id {
//   float: left;
//   width: 1px;
// }

// With format:false
rule.toString({format: false}))
// outputs:
// .a-id{float:left;width:1px;}
```

## Todo

- [x] Add test(s) that verify the modified behavior
- [ ] Add documentation if it changes public API

## Expectations on Changes

Indentation and line breaks are removed when `format: false` is passed to `SheetsRegistry.toString` or `rule.toString` methods.

## Changelog

- Add a new option `format` for removing whitespaces in `SheetsRegistry.toString(options)`
