### PR TITLE
fix(jss-plugin-global): Support format option for @global rules

### DIFF
--- a/packages/css-jss/.size-snapshot.json
+++ b/packages/css-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "css-jss.js": {
-    "bundled": 59688,
-    "minified": 21828,
-    "gzipped": 7357
+    "bundled": 59702,
+    "minified": 21830,
+    "gzipped": 7354
   },
   "css-jss.min.js": {
-    "bundled": 58613,
-    "minified": 21205,
-    "gzipped": 7078
+    "bundled": 58627,
+    "minified": 21207,
+    "gzipped": 7075
   },
   "css-jss.cjs.js": {
     "bundled": 2949,

--- a/packages/jss-plugin-global/.size-snapshot.json
+++ b/packages/jss-plugin-global/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "jss-plugin-global.js": {
-    "bundled": 4988,
-    "minified": 2184,
-    "gzipped": 919
+    "bundled": 5002,
+    "minified": 2186,
+    "gzipped": 914
   },
   "jss-plugin-global.min.js": {
-    "bundled": 4988,
-    "minified": 2184,
-    "gzipped": 919
+    "bundled": 5002,
+    "minified": 2186,
+    "gzipped": 914
   },
   "jss-plugin-global.cjs.js": {
-    "bundled": 4263,
-    "minified": 2310,
-    "gzipped": 892
+    "bundled": 4277,
+    "minified": 2312,
+    "gzipped": 886
   },
   "jss-plugin-global.esm.js": {
-    "bundled": 3917,
-    "minified": 2036,
-    "gzipped": 788,
+    "bundled": 3931,
+    "minified": 2038,
+    "gzipped": 783,
     "treeshaked": {
       "rollup": {
         "code": 55,

--- a/packages/jss-plugin-global/src/index.js
+++ b/packages/jss-plugin-global/src/index.js
@@ -51,8 +51,8 @@ class GlobalContainerRule {
   /**
    * Generates a CSS string.
    */
-  toString() {
-    return this.rules.toString()
+  toString(options) {
+    return this.rules.toString(options)
   }
 }
 

--- a/packages/jss-plugin-global/src/index.test.js
+++ b/packages/jss-plugin-global/src/index.test.js
@@ -6,7 +6,7 @@ import nested from 'jss-plugin-nested'
 import global from './index'
 
 const settings = {
-  createGenerateId: () => (rule) => `${rule.key}-id`
+  createGenerateId: () => rule => `${rule.key}-id`
 }
 
 describe('jss-plugin-global', () => {
@@ -36,6 +36,10 @@ describe('jss-plugin-global', () => {
 
     it('should generate correct CSS', () => {
       expect(sheet.toString()).to.be('a {\n  color: red;\n}\nbody {\n  color: green;\n}')
+    })
+
+    it('should remove whitespaces', () => {
+      expect(sheet.toString({format: false})).to.be('a{color:red;}body{color:green;}')
     })
   })
 

--- a/packages/jss-preset-default/.size-snapshot.json
+++ b/packages/jss-preset-default/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "jss-preset-default.js": {
-    "bundled": 56975,
-    "minified": 21052,
-    "gzipped": 7009
+    "bundled": 56989,
+    "minified": 21054,
+    "gzipped": 7004
   },
   "jss-preset-default.min.js": {
-    "bundled": 55900,
-    "minified": 20429,
-    "gzipped": 6731
+    "bundled": 55914,
+    "minified": 20431,
+    "gzipped": 6726
   },
   "jss-preset-default.cjs.js": {
     "bundled": 2222,

--- a/packages/jss-starter-kit/.size-snapshot.json
+++ b/packages/jss-starter-kit/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "jss-starter-kit.js": {
-    "bundled": 73003,
-    "minified": 31503,
-    "gzipped": 9646
+    "bundled": 73017,
+    "minified": 31505,
+    "gzipped": 9640
   },
   "jss-starter-kit.min.js": {
-    "bundled": 71928,
-    "minified": 31315,
-    "gzipped": 9421
+    "bundled": 71942,
+    "minified": 31317,
+    "gzipped": 9415
   },
   "jss-starter-kit.cjs.js": {
     "bundled": 5647,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "react-jss.js": {
-    "bundled": 135303,
-    "minified": 49865,
-    "gzipped": 16671
+    "bundled": 135317,
+    "minified": 49867,
+    "gzipped": 16666
   },
   "react-jss.min.js": {
-    "bundled": 102253,
-    "minified": 39724,
-    "gzipped": 13794
+    "bundled": 102267,
+    "minified": 39726,
+    "gzipped": 13789
   },
   "react-jss.cjs.js": {
     "bundled": 21449,


### PR DESCRIPTION
## Corresponding Issue(s): #1566

## What Would You Like to Add/Fix?

In #1549, I've introduced the `format: false` option to remove whitespaces when generating CSS. However, I've forgotten to update `jss-plugin-global` to support it, so as a result, all `@global` CSS rules were not formatted.

This PR fixes the above issue by making sure the `format` option is passed to `jss-plugin-global rules`.

## Todo

- [x] Add test(s) that verify the modified behavior

## Expectations on Changes

Indentation and line breaks are removed for `@global` rules when `format: false` is passed to SheetsRegistry.toString or rule.toString methods.

## Changelog

- Fix whitespaces for `@global` rules
