### PR TITLE
Keep classes ref when sheet and dynamicRules have not any change

### DIFF
--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -10,21 +10,21 @@
     "gzipped": 13789
   },
   "react-jss.cjs.js": {
-    "bundled": 21449,
-    "minified": 9456,
-    "gzipped": 3166
+    "bundled": 21443,
+    "minified": 9467,
+    "gzipped": 3169
   },
   "react-jss.esm.js": {
-    "bundled": 19537,
-    "minified": 7962,
-    "gzipped": 2950,
+    "bundled": 19531,
+    "minified": 7973,
+    "gzipped": 2952,
     "treeshaked": {
       "rollup": {
         "code": 426,
         "import_statements": 368
       },
       "webpack": {
-        "code": 1945
+        "code": 2408
       }
     }
   }

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "react-jss.js": {
-    "bundled": 135317,
-    "minified": 49867,
-    "gzipped": 16666
+    "bundled": 135385,
+    "minified": 49908,
+    "gzipped": 16677
   },
   "react-jss.min.js": {
-    "bundled": 102267,
-    "minified": 39726,
-    "gzipped": 13789
+    "bundled": 102335,
+    "minified": 39767,
+    "gzipped": 13792
   },
   "react-jss.cjs.js": {
-    "bundled": 21443,
-    "minified": 9467,
-    "gzipped": 3169
+    "bundled": 21515,
+    "minified": 9469,
+    "gzipped": 3171
   },
   "react-jss.esm.js": {
-    "bundled": 19531,
-    "minified": 7973,
-    "gzipped": 2952,
+    "bundled": 19603,
+    "minified": 7975,
+    "gzipped": 2954,
     "treeshaked": {
       "rollup": {
         "code": 426,
         "import_statements": 368
       },
       "webpack": {
-        "code": 2408
+        "code": 1945
       }
     }
   }

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "react-jss.js": {
-    "bundled": 135420,
-    "minified": 49912,
-    "gzipped": 16679
+    "bundled": 124531,
+    "minified": 45499,
+    "gzipped": 15737
   },
   "react-jss.min.js": {
-    "bundled": 102370,
-    "minified": 39771,
-    "gzipped": 13795
+    "bundled": 97767,
+    "minified": 37402,
+    "gzipped": 13296
   },
   "react-jss.cjs.js": {
-    "bundled": 21548,
-    "minified": 9473,
-    "gzipped": 3171
+    "bundled": 21554,
+    "minified": 9502,
+    "gzipped": 3177
   },
   "react-jss.esm.js": {
     "bundled": 19636,
-    "minified": 7979,
-    "gzipped": 2958,
+    "minified": 8002,
+    "gzipped": 2959,
     "treeshaked": {
       "rollup": {
         "code": 426,

--- a/packages/react-jss/src/createUseStyles.test.js
+++ b/packages/react-jss/src/createUseStyles.test.js
@@ -11,18 +11,11 @@ import {createUseStyles, JssProvider, SheetsRegistry} from '.'
 
 const createStyledComponent = (styles, options) => {
   const useStyles = createUseStyles(styles, options)
-  const Comp = props => {
-    useStyles(props)
-    return null
-  }
-  return Comp
-}
-
-const createUnstyledComponent = () => {
-  const useStyles = createUseStyles()
-  const Comp = ({getClasses}) => {
-    const classes = useStyles()
-    getClasses(classes)
+  const Comp = ({getClasses, ...restProps}) => {
+    const classes = useStyles(restProps)
+    if (getClasses) {
+      getClasses(classes)
+    }
     return null
   }
   return Comp
@@ -56,7 +49,7 @@ describe('React-JSS: createUseStyles', () => {
 
   describe('multiple components that share same hook', () => {
     const useStyles = createUseStyles({
-      item: (props) => ({
+      item: props => ({
         color: props.active ? 'red' : 'blue',
         '&:hover': {
           fontSize: 60
@@ -191,7 +184,7 @@ describe('React-JSS: createUseStyles', () => {
 
   describe('undesirable re-render', () => {
     it("should return keep previous classes when sheet and dynamicRules haven't change", () => {
-      const MyComponent = createUnstyledComponent()
+      const MyComponent = createStyledComponent()
 
       const classes = []
 

--- a/packages/react-jss/src/createUseStyles.test.js
+++ b/packages/react-jss/src/createUseStyles.test.js
@@ -18,7 +18,7 @@ const createStyledComponent = (styles, options) => {
   return Comp
 }
 
-const createUnStyledComponent = () => {
+const createUnstyledComponent = () => {
   const useStyles = createUseStyles()
   const Comp = ({getClasses}) => {
     const classes = useStyles()
@@ -191,17 +191,12 @@ describe('React-JSS: createUseStyles', () => {
 
   describe('undesirable re-render', () => {
     it("should return keep previous classes when sheet and dynamicRules haven't change", () => {
-      const MyComponent = createUnStyledComponent()
+      const MyComponent = createUnstyledComponent()
 
-      let firstRenderClasses
-      let secondRenderClasses
+      const classes = []
 
-      const getClasses = classes => {
-        if (firstRenderClasses) {
-          secondRenderClasses = classes
-        } else {
-          firstRenderClasses = classes
-        }
+      const getClasses = currentClasses => {
+        classes.push(currentClasses)
       }
 
       let root
@@ -213,7 +208,7 @@ describe('React-JSS: createUseStyles', () => {
         root.update(<MyComponent getClasses={getClasses} />)
       })
 
-      expect(firstRenderClasses).to.be(secondRenderClasses)
+      expect(classes[0]).to.be(classes[1])
     })
   })
 })

--- a/packages/react-jss/src/createUseStyles.test.js
+++ b/packages/react-jss/src/createUseStyles.test.js
@@ -214,7 +214,7 @@ describe('React-JSS: createUseStyles', () => {
   })
 
   describe('undesirable re-render', () => {
-    it("should return keep previous classes when sheet and dynamicRules haven't change", () => {
+    it("should return previous classes when sheet and dynamicRules haven't change", () => {
       const MyComponent = createStyledComponent()
 
       const classes = []

--- a/packages/react-jss/src/utils/getSheetClasses.js
+++ b/packages/react-jss/src/utils/getSheetClasses.js
@@ -1,6 +1,7 @@
 import {getMeta} from './sheetsMeta'
+import memoize from './memoizeOne'
 
-const getSheetClasses = (sheet, dynamicRules) => {
+const getSheetClasses = memoize((sheet, dynamicRules) => {
   if (!dynamicRules) {
     return sheet.classes
   }
@@ -21,6 +22,6 @@ const getSheetClasses = (sheet, dynamicRules) => {
   }
 
   return classes
-}
+})
 
 export default getSheetClasses

--- a/packages/react-jss/src/utils/getSheetClasses.js
+++ b/packages/react-jss/src/utils/getSheetClasses.js
@@ -1,7 +1,6 @@
 import {getMeta} from './sheetsMeta'
-import memoize from './memoizeOne'
 
-const getSheetClasses = memoize((sheet, dynamicRules) => {
+const getSheetClasses = (sheet, dynamicRules) => {
   if (!dynamicRules) {
     return sheet.classes
   }
@@ -22,6 +21,6 @@ const getSheetClasses = memoize((sheet, dynamicRules) => {
   }
 
   return classes
-})
+}
 
 export default getSheetClasses


### PR DESCRIPTION
## What Would You Like to Add/Fix?
`getSheetClasses` always return new object even `sheet` and `dynamicRules` haven't any change

Also I wrote a small test to keep it in future

## Todo

- [x] Add test(s) that verify the modified behavior

## Expectations on Changes
So, I memoized it to prevent this behavior

## Changelog
Improve performance at `useStyle`
