### PR TITLE
fix: add missing index property

### DIFF
--- a/packages/jss/src/SheetsRegistry.js.flow
+++ b/packages/jss/src/SheetsRegistry.js.flow
@@ -3,6 +3,7 @@ import type {ToCssOptions} from './flow-types'
 import type StyleSheet from './StyleSheet'
 
 declare export default class SheetsRegistry {
+  index: number;
   registry: Array<StyleSheet>;
   add(sheet: StyleSheet): void;
   reset(): void;


### PR DESCRIPTION
## Corresponding Issue(s):  haven't checked. I've cloned the project and noticed a problem when was viewing the code.

## What Would You Like to Add/Fix?
I'd like to add a missing property on which my IDE complains.
![image](https://user-images.githubusercontent.com/13823215/139458496-bded3f50-365f-40b6-b9e3-cd8802c18908.png)

Index property itself is used at least here https://github.com/cssinjs/jss/blob/02cb79b345570f2495ce9650641593c8cec8b47f/packages/jss/src/Jss.js#L73.

## Todo

- [x] Add test(s) that verify the modified behavior. - Not relevant.
- [x] Add documentation if it changes public API. - Not relevant.

## Expectations on Changes
No warnings from IDE when the `index` property of sheets is used.

## Changelog

Just a single extra property.
