### PR TITLE
chore: add repository directory for all packages.json

### DIFF
--- a/packages/css-jss/package.json
+++ b/packages/css-jss/package.json
@@ -12,7 +12,8 @@
   "author": "JSS Team",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cssinjs/jss"
+    "url": "https://github.com/cssinjs/jss.git",
+    "directory": "packages/css-jss"
   },
   "bugs": {
     "url": "https://github.com/cssinjs/jss/issues/new"

--- a/packages/jss-plugin-cache/package.json
+++ b/packages/jss-plugin-cache/package.json
@@ -12,7 +12,8 @@
   "author": "JSS Team",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cssinjs/jss"
+    "url": "https://github.com/cssinjs/jss.git",
+    "directory": "packages/jss-plugin-cache"
   },
   "bugs": {
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-cache]"

--- a/packages/jss-plugin-camel-case/package.json
+++ b/packages/jss-plugin-camel-case/package.json
@@ -12,7 +12,8 @@
   "author": "JSS Team",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cssinjs/jss"
+    "url": "https://github.com/cssinjs/jss.git",
+    "directory": "packages/jss-plugin-camel-case"
   },
   "bugs": {
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-camel-case]"

--- a/packages/jss-plugin-compose/package.json
+++ b/packages/jss-plugin-compose/package.json
@@ -12,7 +12,8 @@
   "author": "JSS Team",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cssinjs/jss"
+    "url": "https://github.com/cssinjs/jss.git",
+    "directory": "packages/jss-plugin-compose"
   },
   "bugs": {
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-compose]"

--- a/packages/jss-plugin-default-unit/package.json
+++ b/packages/jss-plugin-default-unit/package.json
@@ -12,7 +12,8 @@
   "author": "JSS Team",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cssinjs/jss"
+    "url": "https://github.com/cssinjs/jss.git",
+    "directory": "packages/jss-plugin-default-unit"
   },
   "bugs": {
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-default-unit]"

--- a/packages/jss-plugin-expand/package.json
+++ b/packages/jss-plugin-expand/package.json
@@ -12,7 +12,8 @@
   "author": "JSS Team",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cssinjs/jss"
+    "url": "https://github.com/cssinjs/jss.git",
+    "directory": "packages/jss-plugin-expand"
   },
   "bugs": {
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-expand]"

--- a/packages/jss-plugin-extend/package.json
+++ b/packages/jss-plugin-extend/package.json
@@ -12,7 +12,8 @@
   "author": "JSS Team",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cssinjs/jss"
+    "url": "https://github.com/cssinjs/jss.git",
+    "directory": "packages/jss-plugin-extend"
   },
   "bugs": {
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-extend]"

--- a/packages/jss-plugin-global/package.json
+++ b/packages/jss-plugin-global/package.json
@@ -12,7 +12,8 @@
   "author": "JSS Team",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cssinjs/jss"
+    "url": "https://github.com/cssinjs/jss.git",
+    "directory": "packages/jss-plugin-global"
   },
   "bugs": {
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-global]"

--- a/packages/jss-plugin-isolate/package.json
+++ b/packages/jss-plugin-isolate/package.json
@@ -12,7 +12,8 @@
   "author": "JSS Team",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cssinjs/jss"
+    "url": "https://github.com/cssinjs/jss.git",
+    "directory": "packages/jss-plugin-isolate"
   },
   "bugs": {
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-isolate]"

--- a/packages/jss-plugin-nested/package.json
+++ b/packages/jss-plugin-nested/package.json
@@ -12,7 +12,8 @@
   "author": "JSS Team",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cssinjs/jss"
+    "url": "https://github.com/cssinjs/jss.git",
+    "directory": "packages/jss-plugin-nested"
   },
   "bugs": {
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-nested]"

--- a/packages/jss-plugin-props-sort/package.json
+++ b/packages/jss-plugin-props-sort/package.json
@@ -12,7 +12,8 @@
   "author": "JSS Team",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cssinjs/jss"
+    "url": "https://github.com/cssinjs/jss.git",
+    "directory": "packages/jss-plugin-props-sort"
   },
   "bugs": {
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-props-sort]"

--- a/packages/jss-plugin-rule-value-function/package.json
+++ b/packages/jss-plugin-rule-value-function/package.json
@@ -12,7 +12,8 @@
   "author": "JSS Team",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cssinjs/jss"
+    "url": "https://github.com/cssinjs/jss.git",
+    "directory": "packages/jss-plugin-rule-value-function"
   },
   "bugs": {
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-rule-value-function]"

--- a/packages/jss-plugin-rule-value-observable/package.json
+++ b/packages/jss-plugin-rule-value-observable/package.json
@@ -12,7 +12,8 @@
   "author": "JSS Team",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cssinjs/jss"
+    "url": "https://github.com/cssinjs/jss.git",
+    "directory": "packages/jss-plugin-rule-value-observable"
   },
   "bugs": {
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-rule-value-observable]"

--- a/packages/jss-plugin-template/package.json
+++ b/packages/jss-plugin-template/package.json
@@ -12,7 +12,8 @@
   "author": "JSS Team",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cssinjs/jss"
+    "url": "https://github.com/cssinjs/jss.git",
+    "directory": "packages/jss-plugin-template"
   },
   "bugs": {
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-template]"

--- a/packages/jss-plugin-vendor-prefixer/package.json
+++ b/packages/jss-plugin-vendor-prefixer/package.json
@@ -12,7 +12,8 @@
   "author": "JSS Team",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cssinjs/jss"
+    "url": "https://github.com/cssinjs/jss.git",
+    "directory": "packages/jss-plugin-vendor-prefixer"
   },
   "bugs": {
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-plugin-vendor-prefixer]"

--- a/packages/jss-preset-default/package.json
+++ b/packages/jss-preset-default/package.json
@@ -12,7 +12,8 @@
   "author": "JSS Team",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cssinjs/jss"
+    "url": "https://github.com/cssinjs/jss.git",
+    "directory": "packages/jss-preset-default"
   },
   "bugs": {
     "url": "https://github.com/cssinjs/jss/issues/new?title=[jss-preset-default]"

--- a/packages/jss-starter-kit/package.json
+++ b/packages/jss-starter-kit/package.json
@@ -12,7 +12,8 @@
   "author": "JSS Team",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cssinjs/jss"
+    "url": "https://github.com/cssinjs/jss.git",
+    "directory": "packages/jss-starter-kit"
   },
   "bugs": {
     "url": "https://github.com/cssinjs/jss/issues/new"

--- a/packages/jss/package.json
+++ b/packages/jss/package.json
@@ -12,7 +12,8 @@
   "author": "JSS Team",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cssinjs/jss"
+    "url": "https://github.com/cssinjs/jss.git",
+    "directory": "packages/jss"
   },
   "bugs": {
     "url": "https://github.com/cssinjs/jss/issues/new"

--- a/packages/react-jss/package.json
+++ b/packages/react-jss/package.json
@@ -12,7 +12,8 @@
   "author": "JSS Team",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cssinjs/jss"
+    "url": "https://github.com/cssinjs/jss.git",
+    "directory": "packages/react-jss"
   },
   "bugs": {
     "url": "https://github.com/cssinjs/jss/issues/new?title=[react-jss]"


### PR DESCRIPTION
> If the package.json for your package is not in the root directory (for example if it is part of a monorepo), you can specify the directory in which it lives:
> ```json
> "repository": {
>   "type" : "git",
>   "url" : "https://github.com/facebook/react.git",
>   "directory": "packages/react-dom"
> }
> ```
> — https://docs.npmjs.com/cli/v6/configuring-npm/package-json#repository

I use a lot https://njt.vercel.app/ to jump to different packages information,
and with this PR we can know exactly what package in what folder lives

Made the changes with a script to make it easier 🙂

https://gist.github.com/iamandrewluca/5cc85b56a595056f0099d04ed6dd8a79
