### PR TITLE
use useInsertionEffect if available

### DIFF
--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "react-jss.js": {
-    "bundled": 136030,
-    "minified": 50117,
-    "gzipped": 16723
+    "bundled": 136058,
+    "minified": 50139,
+    "gzipped": 16733
   },
   "react-jss.min.js": {
-    "bundled": 102980,
-    "minified": 39976,
-    "gzipped": 13837
+    "bundled": 103008,
+    "minified": 39998,
+    "gzipped": 13846
   },
   "react-jss.cjs.js": {
-    "bundled": 21554,
-    "minified": 9502,
-    "gzipped": 3177
+    "bundled": 21582,
+    "minified": 9528,
+    "gzipped": 3189
   },
   "react-jss.esm.js": {
-    "bundled": 19636,
-    "minified": 8002,
-    "gzipped": 2959,
+    "bundled": 19678,
+    "minified": 8041,
+    "gzipped": 2971,
     "treeshaked": {
       "rollup": {
         "code": 426,
         "import_statements": 368
       },
       "webpack": {
-        "code": 1945
+        "code": 1967
       }
     }
   }

--- a/packages/react-jss/src/createUseStyles.js
+++ b/packages/react-jss/src/createUseStyles.js
@@ -13,7 +13,9 @@ import getSheetIndex from './utils/getSheetIndex'
 import {manageSheet, unmanageSheet} from './utils/managers'
 import getSheetClasses from './utils/getSheetClasses'
 
-const useEffectOrLayoutEffect = isInBrowser ? React.useLayoutEffect : React.useEffect
+const useEffectOrLayoutEffect = isInBrowser
+  ? React.useInsertionEffect || React.useLayoutEffect
+  : React.useEffect
 
 const noTheme = {}
 


### PR DESCRIPTION
## Corresponding Issue(s): <!-- (if relevant) -->

## What Would You Like to Add/Fix?
Well, our React `peerDependencies` is `>=16.8.6` so some projects maybe use React 18 we can use `useInsertionEffect` if available, also change is just one line

```js
const useEffectOrLayoutEffect = isInBrowser ? React.useInsertionEffect || React.useLayoutEffect : React.useEffect
```

## Todo

- [ ] Add test(s) that verify the modified behavior
- [ ] Add documentation if it changes public API

## Expectations on Changes
Nothing

## Changelog
use `useInsertionEffect` if available
