### PR TITLE
fix(useStyles): manage sheet on create and then add dynamic styles

### DIFF
--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "react-jss.js": {
-    "bundled": 77728,
-    "minified": 28993,
-    "gzipped": 10122
+    "bundled": 125190,
+    "minified": 46445,
+    "gzipped": 15559
   },
   "react-jss.min.js": {
-    "bundled": 45475,
-    "minified": 19337,
-    "gzipped": 7396
+    "bundled": 92392,
+    "minified": 36456,
+    "gzipped": 12759
   },
   "react-jss.cjs.js": {
     "bundled": 21488,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "react-jss.js": {
-    "bundled": 125190,
-    "minified": 46445,
-    "gzipped": 15559
+    "bundled": 136040,
+    "minified": 50156,
+    "gzipped": 16725
   },
   "react-jss.min.js": {
-    "bundled": 92392,
-    "minified": 36456,
-    "gzipped": 12759
+    "bundled": 102990,
+    "minified": 40015,
+    "gzipped": 13844
   },
   "react-jss.cjs.js": {
-    "bundled": 21488,
-    "minified": 9523,
-    "gzipped": 3163
+    "bundled": 21566,
+    "minified": 9534,
+    "gzipped": 3176
   },
   "react-jss.esm.js": {
-    "bundled": 19604,
-    "minified": 8056,
-    "gzipped": 2958,
+    "bundled": 19682,
+    "minified": 8067,
+    "gzipped": 2971,
     "treeshaked": {
       "rollup": {
         "code": 426,

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "react-jss.js": {
-    "bundled": 136040,
-    "minified": 50156,
-    "gzipped": 16725
+    "bundled": 136053,
+    "minified": 50140,
+    "gzipped": 16739
   },
   "react-jss.min.js": {
-    "bundled": 102990,
-    "minified": 40015,
-    "gzipped": 13844
+    "bundled": 103003,
+    "minified": 39999,
+    "gzipped": 13855
   },
   "react-jss.cjs.js": {
-    "bundled": 21566,
-    "minified": 9534,
-    "gzipped": 3176
+    "bundled": 21581,
+    "minified": 9508,
+    "gzipped": 3183
   },
   "react-jss.esm.js": {
-    "bundled": 19682,
-    "minified": 8067,
-    "gzipped": 2971,
+    "bundled": 19703,
+    "minified": 8047,
+    "gzipped": 2975,
     "treeshaked": {
       "rollup": {
         "code": 426,

--- a/packages/react-jss/src/createUseStyles.js
+++ b/packages/react-jss/src/createUseStyles.js
@@ -63,6 +63,13 @@ const createUseStyles = (styles, options = {}) => {
 
     const dynamicRules = React.useMemo(() => (sheet ? addDynamicRules(sheet, data) : null), [sheet])
 
+    useInsertionEffect(() => {
+      // We only need to update the rules on a subsequent update and not in the first mount
+      if (sheet && dynamicRules && !isFirstMount.current) {
+        updateDynamicRules(data, sheet, dynamicRules)
+      }
+    }, [data])
+
     useInsertionEffect(
       () => () => {
         if (sheet) {
@@ -81,13 +88,6 @@ const createUseStyles = (styles, options = {}) => {
       },
       [sheet]
     )
-
-    useInsertionEffect(() => {
-      // We only need to update the rules on a subsequent update and not in the first mount
-      if (sheet && dynamicRules && !isFirstMount.current) {
-        updateDynamicRules(data, sheet, dynamicRules)
-      }
-    }, [data])
 
     const classes = React.useMemo(
       () => (sheet && dynamicRules ? getSheetClasses(sheet, dynamicRules) : emptyObject),

--- a/packages/react-jss/src/createUseStyles.js
+++ b/packages/react-jss/src/createUseStyles.js
@@ -39,30 +39,32 @@ const createUseStyles = (styles, options = {}) => {
     const context = React.useContext(JssContext)
     const theme = useTheme(data && data.theme)
 
-    const sheet = React.useMemo(
-      () =>
-        createStyleSheet({
-          context,
-          styles,
-          name,
-          theme,
+    const sheet = React.useMemo(() => {
+      const newSheet = createStyleSheet({
+        context,
+        styles,
+        name,
+        theme,
+        index,
+        sheetOptions
+      })
+
+      if (newSheet) {
+        manageSheet({
           index,
-          sheetOptions
-        }),
-      [context, theme]
-    )
+          context,
+          sheet: newSheet,
+          theme
+        })
+      }
+
+      return newSheet
+    }, [context, theme])
 
     const dynamicRules = React.useMemo(() => (sheet ? addDynamicRules(sheet, data) : null), [sheet])
 
-    useInsertionEffect(() => {
-      manageSheet({
-        index,
-        context,
-        sheet,
-        theme
-      })
-
-      return () => {
+    useInsertionEffect(
+      () => () => {
         if (sheet) {
           unmanageSheet({
             index,
@@ -76,8 +78,9 @@ const createUseStyles = (styles, options = {}) => {
             removeDynamicRules(sheet, dynamicRules)
           }
         }
-      }
-    }, [sheet])
+      },
+      [sheet]
+    )
 
     useInsertionEffect(() => {
       // We only need to update the rules on a subsequent update and not in the first mount

--- a/packages/react-jss/src/createUseStyles.js
+++ b/packages/react-jss/src/createUseStyles.js
@@ -39,7 +39,7 @@ const createUseStyles = (styles, options = {}) => {
     const context = React.useContext(JssContext)
     const theme = useTheme(data && data.theme)
 
-    const sheet = React.useMemo(() => {
+    const [sheet, dynamicRules] = React.useMemo(() => {
       const newSheet = createStyleSheet({
         context,
         styles,
@@ -58,10 +58,8 @@ const createUseStyles = (styles, options = {}) => {
         })
       }
 
-      return newSheet
+      return [newSheet, newSheet ? addDynamicRules(newSheet, data) : null]
     }, [context, theme])
-
-    const dynamicRules = React.useMemo(() => (sheet ? addDynamicRules(sheet, data) : null), [sheet])
 
     useInsertionEffect(() => {
       // We only need to update the rules on a subsequent update and not in the first mount


### PR DESCRIPTION
Fixes failing tests in #1604 by managing the sheet immediately after create, instead of doing so in a separate effect.