### PR TITLE
fix(useStyles): manageSheet must be in the same effect as unmanageSheet

### DIFF
--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "react-jss.js": {
-    "bundled": 136053,
-    "minified": 50140,
-    "gzipped": 16739
+    "bundled": 136353,
+    "minified": 50194,
+    "gzipped": 16748
   },
   "react-jss.min.js": {
-    "bundled": 103003,
-    "minified": 39999,
-    "gzipped": 13855
+    "bundled": 103303,
+    "minified": 40053,
+    "gzipped": 13866
   },
   "react-jss.cjs.js": {
-    "bundled": 21581,
-    "minified": 9508,
-    "gzipped": 3183
+    "bundled": 21885,
+    "minified": 9591,
+    "gzipped": 3192
   },
   "react-jss.esm.js": {
-    "bundled": 19703,
-    "minified": 8047,
-    "gzipped": 2975,
+    "bundled": 19987,
+    "minified": 8113,
+    "gzipped": 2982,
     "treeshaked": {
       "rollup": {
         "code": 426,

--- a/packages/react-jss/src/createUseStyles.js
+++ b/packages/react-jss/src/createUseStyles.js
@@ -48,6 +48,17 @@ const createUseStyles = (styles, options = {}) => {
         index,
         sheetOptions
       })
+
+      if (newSheet && !isInBrowser) {
+        // manage immediately during SSRs. browsers will manage the sheet through useInsertionEffect below
+        manageSheet({
+          index,
+          context,
+          sheet: newSheet,
+          theme
+        })
+      }
+
       return [newSheet, newSheet ? addDynamicRules(newSheet, data) : null]
     }, [context, theme])
 

--- a/packages/react-jss/src/createUseStyles.js
+++ b/packages/react-jss/src/createUseStyles.js
@@ -48,16 +48,6 @@ const createUseStyles = (styles, options = {}) => {
         index,
         sheetOptions
       })
-
-      if (newSheet) {
-        manageSheet({
-          index,
-          context,
-          sheet: newSheet,
-          theme
-        })
-      }
-
       return [newSheet, newSheet ? addDynamicRules(newSheet, data) : null]
     }, [context, theme])
 
@@ -68,8 +58,17 @@ const createUseStyles = (styles, options = {}) => {
       }
     }, [data])
 
-    useInsertionEffect(
-      () => () => {
+    useInsertionEffect(() => {
+      if (sheet) {
+        manageSheet({
+          index,
+          context,
+          sheet,
+          theme
+        })
+      }
+
+      return () => {
         if (sheet) {
           unmanageSheet({
             index,
@@ -83,9 +82,8 @@ const createUseStyles = (styles, options = {}) => {
             removeDynamicRules(sheet, dynamicRules)
           }
         }
-      },
-      [sheet]
-    )
+      }
+    }, [sheet])
 
     const classes = React.useMemo(
       () => (sheet && dynamicRules ? getSheetClasses(sheet, dynamicRules) : emptyObject),

--- a/packages/react-jss/src/createUseStyles.js
+++ b/packages/react-jss/src/createUseStyles.js
@@ -50,7 +50,7 @@ const createUseStyles = (styles, options = {}) => {
         sheetOptions
       })
 
-      if (newSheet && !isInBrowser) {
+      if (newSheet && context.isSSR) {
         // manage immediately during SSRs. browsers will manage the sheet through useInsertionEffect below
         manageSheet({
           index,


### PR DESCRIPTION
#1608 fixed the failing tests caused by #1604, but doing so reintroduced the original bug breaking React 18 support...

`manageSheet` **must** be in a separate `useEffect` because it can run more times than `useMemo` - like during fast-refresh or running in strict mode. Since `manageSheet` is currently in the `useMemo`, `unmanageSheet` from `useEffect` gets **called more times** than `manageSheet`, unmanaging the sheet while in use.

All `renderToString` tests broke with #1604 because `useEffect`s don't run during SSR. The fix is included [here](https://github.com/cssinjs/jss/pull/1609/commits/21f87aeafee581c08d11b4797e238924b8a04672); however, your tests are wrongly set up since `isInBrowser` will return `true` when using `renderToString`.

@kof I don't want to tingle with your tests setup, can you please make sure that `isInBrowser` is `false` when testing with `renderToString`? Doing so will pass all the tests.