### PR TITLE
remvoe is-in-browser dep

### DIFF
--- a/packages/jss/.size-snapshot.json
+++ b/packages/jss/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "jss.js": {
-    "bundled": 64937,
-    "minified": 23204,
-    "gzipped": 7190
+    "bundled": 64537,
+    "minified": 22895,
+    "gzipped": 7129
   },
   "jss.min.js": {
-    "bundled": 63541,
-    "minified": 22435,
-    "gzipped": 6848
+    "bundled": 63141,
+    "minified": 22127,
+    "gzipped": 6777
   },
   "jss.cjs.js": {
-    "bundled": 60615,
-    "minified": 26232,
-    "gzipped": 7308
+    "bundled": 60552,
+    "minified": 26185,
+    "gzipped": 7305
   },
   "jss.esm.js": {
-    "bundled": 58987,
-    "minified": 24926,
-    "gzipped": 7142,
+    "bundled": 59023,
+    "minified": 24950,
+    "gzipped": 7149,
     "treeshaked": {
       "rollup": {
-        "code": 20190,
-        "import_statements": 345
+        "code": 20214,
+        "import_statements": 316
       },
       "webpack": {
-        "code": 21680
+        "code": 21661
       }
     }
   }

--- a/packages/jss/package.json
+++ b/packages/jss/package.json
@@ -41,7 +41,6 @@
   "dependencies": {
     "@babel/runtime": "^7.3.1",
     "csstype": "^3.0.2",
-    "is-in-browser": "^1.1.3",
     "tiny-warning": "^1.0.2"
   },
   "funding": {

--- a/packages/jss/src/Jss.js
+++ b/packages/jss/src/Jss.js
@@ -1,4 +1,4 @@
-import isInBrowser from 'is-in-browser'
+import isInBrowser from './utils/isInBrowser'
 import StyleSheet from './StyleSheet'
 import PluginsRegistry from './PluginsRegistry'
 import sheets from './sheets'

--- a/packages/jss/src/utils/isInBrowser.js
+++ b/packages/jss/src/utils/isInBrowser.js
@@ -1,0 +1,3 @@
+const isInBrowser = typeof window !== 'undefined' && 'HTMLElement' in window
+
+export default isInBrowser

--- a/packages/jss/src/utils/isInBrowser.js.flow
+++ b/packages/jss/src/utils/isInBrowser.js.flow
@@ -1,0 +1,4 @@
+// @flow
+type isInBrowser = boolean
+
+declare export default isInBrowser

--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "react-jss.js": {
-    "bundled": 136548,
-    "minified": 50282,
-    "gzipped": 16780
+    "bundled": 136629,
+    "minified": 50340,
+    "gzipped": 16803
   },
   "react-jss.min.js": {
-    "bundled": 103498,
-    "minified": 40141,
-    "gzipped": 13896
+    "bundled": 103579,
+    "minified": 40200,
+    "gzipped": 13905
   },
   "react-jss.cjs.js": {
-    "bundled": 22044,
-    "minified": 9662,
-    "gzipped": 3225
+    "bundled": 21981,
+    "minified": 9615,
+    "gzipped": 3231
   },
   "react-jss.esm.js": {
-    "bundled": 20140,
-    "minified": 8175,
-    "gzipped": 3006,
+    "bundled": 20176,
+    "minified": 8199,
+    "gzipped": 3023,
     "treeshaked": {
       "rollup": {
-        "code": 442,
-        "import_statements": 375
+        "code": 464,
+        "import_statements": 346
       },
       "webpack": {
-        "code": 1922
+        "code": 1906
       }
     }
   }

--- a/packages/react-jss/package.json
+++ b/packages/react-jss/package.json
@@ -44,7 +44,6 @@
     "@emotion/is-prop-valid": "^0.7.3",
     "css-jss": "10.9.1-alpha.1",
     "hoist-non-react-statics": "^3.2.0",
-    "is-in-browser": "^1.1.3",
     "jss": "10.9.1-alpha.1",
     "jss-preset-default": "10.9.1-alpha.1",
     "prop-types": "^15.6.0",

--- a/packages/react-jss/src/JssContext.js
+++ b/packages/react-jss/src/JssContext.js
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import isInBrowser from 'is-in-browser'
+import isInBrowser from './utils/isInBrowser'
 
 export default React.createContext({
   classNamePrefix: '',

--- a/packages/react-jss/src/utils/isInBrowser.js
+++ b/packages/react-jss/src/utils/isInBrowser.js
@@ -1,0 +1,3 @@
+const isInBrowser = typeof window !== 'undefined' && 'HTMLElement' in window
+
+export default isInBrowser

--- a/packages/react-jss/src/utils/isInBrowser.js.flow
+++ b/packages/react-jss/src/utils/isInBrowser.js.flow
@@ -1,0 +1,4 @@
+// @flow
+type isInBrowser = boolean
+
+declare export default isInBrowser

--- a/yarn.lock
+++ b/yarn.lock
@@ -5792,7 +5792,7 @@ is-hexadecimal@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz#b6e710d7d07bb66b98cb8cece5c9b4921deeb835"
   integrity sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A==
 
-is-in-browser@^1.0.2, is-in-browser@^1.1.3:
+is-in-browser@^1.0.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-in-browser/-/is-in-browser-1.1.3.tgz#56ff4db683a078c6082eb95dad7dc62e1d04f835"
   integrity sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU=


### PR DESCRIPTION
## Corresponding Issue(s): <!-- (if relevant) -->

## What Would You Like to Add/Fix?
remove `is-in-browser` module

## Todo

- All tests passed
- This is not a public API changed

## Expectations on Changes

knowing the environment is so easy and we don't need a module for that

## Changelog

remove `is-in-browser` module
