### PR TITLE
fix import issue about useInsertionEffect on react 17

### DIFF
--- a/packages/react-jss/.size-snapshot.json
+++ b/packages/react-jss/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "react-jss.js": {
-    "bundled": 136548,
-    "minified": 50282,
+    "bundled": 136550,
+    "minified": 50290,
     "gzipped": 16780
   },
   "react-jss.min.js": {
-    "bundled": 103498,
-    "minified": 40141,
-    "gzipped": 13896
+    "bundled": 103500,
+    "minified": 40149,
+    "gzipped": 13899
   },
   "react-jss.cjs.js": {
-    "bundled": 22044,
-    "minified": 9662,
-    "gzipped": 3225
+    "bundled": 22110,
+    "minified": 9723,
+    "gzipped": 3237
   },
   "react-jss.esm.js": {
-    "bundled": 20140,
-    "minified": 8175,
-    "gzipped": 3006,
+    "bundled": 20115,
+    "minified": 8169,
+    "gzipped": 3014,
     "treeshaked": {
       "rollup": {
         "code": 442,

--- a/packages/react-jss/src/createUseStyles.js
+++ b/packages/react-jss/src/createUseStyles.js
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React, {useEffect, useLayoutEffect, useContext, useRef, useMemo, useDebugValue} from 'react'
 import {ThemeContext as DefaultThemeContext} from 'theming'
 
 import JssContext from './JssContext'
@@ -14,9 +14,9 @@ import getSheetClasses from './utils/getSheetClasses'
 
 function getUseInsertionEffect(isSSR) {
   return isSSR
-    ? React.useEffect
+    ? useEffect
     : React.useInsertionEffect || // React 18+ (https://github.com/reactwg/react-18/discussions/110)
-        React.useLayoutEffect
+        useLayoutEffect
 }
 
 const noTheme = {}
@@ -27,7 +27,7 @@ const createUseStyles = (styles, options = {}) => {
 
   const useTheme = (theme) => {
     if (typeof styles === 'function') {
-      return theme || React.useContext(ThemeContext) || noTheme
+      return theme || useContext(ThemeContext) || noTheme
     }
 
     return noTheme
@@ -36,11 +36,11 @@ const createUseStyles = (styles, options = {}) => {
   const emptyObject = {}
 
   return function useStyles(data) {
-    const isFirstMount = React.useRef(true)
-    const context = React.useContext(JssContext)
+    const isFirstMount = useRef(true)
+    const context = useContext(JssContext)
     const theme = useTheme(data && data.theme)
 
-    const [sheet, dynamicRules] = React.useMemo(() => {
+    const [sheet, dynamicRules] = useMemo(() => {
       const newSheet = createStyleSheet({
         context,
         styles,
@@ -97,16 +97,16 @@ const createUseStyles = (styles, options = {}) => {
       }
     }, [sheet])
 
-    const classes = React.useMemo(
+    const classes = useMemo(
       () => (sheet && dynamicRules ? getSheetClasses(sheet, dynamicRules) : emptyObject),
       [sheet, dynamicRules]
     )
 
-    React.useDebugValue(classes)
+    useDebugValue(classes)
 
-    React.useDebugValue(theme === noTheme ? 'No theme' : theme)
+    useDebugValue(theme === noTheme ? 'No theme' : theme)
 
-    React.useEffect(() => {
+    useEffect(() => {
       isFirstMount.current = false
     })
 


### PR DESCRIPTION
## Corresponding Issue(s): <!-- (if relevant) -->
https://github.com/cssinjs/jss/issues/1618

## What Would You Like to Add/Fix?
By this PR JSS consumers can use React 17 and 16


## Changelog
Fix `useInsertionEffect` import issue on react 16 and 17