### PR TITLE
Add meta name="csp-nonce" option to getNonce function

### DIFF
--- a/packages/jss/src/DomRenderer.js
+++ b/packages/jss/src/DomRenderer.js
@@ -217,7 +217,7 @@ function insertStyle(style, options) {
  * Read jss nonce setting from the page if the user has set it.
  */
 const getNonce = memoize(() => {
-  const node = document.querySelector('meta[property="csp-nonce"]')
+  const node = document.querySelector('meta[property="csp-nonce"], meta[name="csp-nonce"]')
   return node ? node.getAttribute('content') : null
 })
 


### PR DESCRIPTION
## Changelog

Adds the ability to detect `<meta name="csp-nonce" content="{nonce}">` to the getNonce function.
