### PR TITLE
Fix for @global name validation

### DIFF
--- a/packages/jss-plugin-global/src/index.js
+++ b/packages/jss-plugin-global/src/index.js
@@ -136,11 +136,13 @@ export default function jssGlobal() {
   function onCreateRule(name, styles, options) {
     if (!name) return null
 
-    if (name === at) {
+    // The original name is used for validation as the system name can be `@global-X` which will throw error
+    const originName = options?.name || name;
+    if (originName === at) {
       return new GlobalContainerRule(name, styles, options)
     }
 
-    if (name[0] === '@' && name.substr(0, atPrefix.length) === atPrefix) {
+    if (originName[0] === '@' && originName.substr(0, atPrefix.length) === atPrefix) {
       return new GlobalPrefixedRule(name, styles, options)
     }
 


### PR DESCRIPTION
If `@global` has dynamic rules, or multiple `@global` is used, this can cause an error, as `onCreateRule(name, styles, options)` function takes a non-original name (`@global`) but a system one (`@global-X`)