### PR TITLE
feat(jss-plugin-expand): Add support background  array of objects

### DIFF
--- a/packages/jss-plugin-expand/src/props.js
+++ b/packages/jss-plugin-expand/src/props.js
@@ -168,8 +168,8 @@ export const customPropObj = {
     color: 'border-right-color'
   },
   background: {
-    blendMode: "blend-mode-repeat",
-    "blend-mode": "blend-mode-repeat",
+    blendMode: "background-blend-mode",
+    "blend-mode": "background-blend-mode",
     color: "background-color",
   },
   font: {

--- a/packages/jss-plugin-expand/src/props.js
+++ b/packages/jss-plugin-expand/src/props.js
@@ -3,6 +3,7 @@
  * All properties listed below will be transformed to a string separated by space.
  */
 export const propArray = {
+  background: true,
   'background-size': true,
   'background-position': true,
   border: true,
@@ -51,11 +52,16 @@ export const propObj = {
     left: 0
   },
   background: {
-    attachment: null,
-    color: null,
     image: null,
     position: null,
-    repeat: null
+    size: null,
+    repeat: null,
+    attachment: null,
+    origin: null,
+    clip: null,
+    color: null,
+    'blend-mode': null,
+    blendMode: null,
   },
   border: {
     width: null,
@@ -162,8 +168,9 @@ export const customPropObj = {
     color: 'border-right-color'
   },
   background: {
-    size: 'background-size',
-    image: 'background-image'
+    blendMode: "blend-mode-repeat",
+    "blend-mode": "blend-mode-repeat",
+    color: "background-color",
   },
   font: {
     style: 'font-style',


### PR DESCRIPTION
## Corresponding Issue(s): https://github.com/cssinjs/jss/issues/711

## What Would You Like to Add/Fix?
Support for multiple backgrounds list, from array of objects. Example:

```js
[
  {
    "image": "url(...)",
    "position": ["50%", "50%"],
    "size": "cover",
    "repeat": "no-repeat"
  },
  {
    "image": "linear-gradient(....)"
  },
  {
    "image": "url(...)",
    "position": [0, 0],
    "size": "cover"
  },
]
```

## Expectations on Changes

<!--
1. Please don't do code changes and move code around in the same PR, even if you are making code better. Make sure the reviewer can see just the changes which fix the problem. This can make your Code Review much more accessible in complex situations; otherwise, it might never get merged even if it is correct because it's impossible to review without reimplementing every change.
2. Often, submitting a failing test is more critical than the fix. Fixing the problem can be challenging and has many ways. Offering an excellent failing test is often 80% of the solution.
3. Please review your PR before submitting it as if you are the reviewer. This way, you show respect for the maintainer's time.
-->

This changes only add support for arrays. Old code will still work without the need to make changes.