### PR TITLE
Add support for CSSStyleSheet instance in DomRenderer for CSP enabled applications without relying on nonce

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -118,6 +118,48 @@ jss.setup({
 })
 ```
 
+## Using a `CSSStyleSheet` instance for secure style injection
+
+For environments with strict Content Security Policy (CSP) settings, JSS now supports injecting styles into a `CSSStyleSheet` instance. This approach is particularly useful when inline styles are restricted and a nonce value is unavailable or not exposed.
+
+### Example
+
+Create a `CSSStyleSheet` instance and pass it to JSS during setup:
+
+```javascript
+import jss from 'jss'
+
+const sheet = new CSSStyleSheet()
+document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet]
+
+jss.setup({
+  insertionPoint: sheet // Pass the CSSStyleSheet instance
+})
+
+// Create your style.
+const style = {
+  myButton: {
+    color: 'green'
+  }
+}
+
+// Compile styles, apply plugins.
+const jssSheet = jss.createStyleSheet(style)
+
+// Inject styles directly into the provided CSSStyleSheet.
+jssSheet.attach()
+```
+
+### Benefits
+
+- Enables secure style injection into a `CSSStyleSheet` instance, avoiding inline styles.
+- Works seamlessly in CSP-enabled applications where the nonce attribute cannot be used or accessed.
+
+### Notes
+
+- This feature is an alternative to nonce-based CSP compliance. Both approaches are supported.
+- Ensure the provided `CSSStyleSheet` instance is valid and adopted by the document where styles need to be applied.
+
 ## Configuring Content Security Policy
 
 You might need to set the `style-src` CSP directive, but do not want to set it to `unsafe-inline`. See [these instructions for configuring CSP](csp.md).


### PR DESCRIPTION
### Summary 
This pull request introduces support for using a `CSSStyleSheet` instance provided by the user in the `DomRenderer` class. This enhancement is aimed at improving the flexibility and security of style injection in Content Security Policy (CSP) enabled applications. While maintaining support for nonce, it also provides an alternative for environments where the nonce value is not exposed.

### Problem
In CSP enabled applications, inline styles are often restricted, making it challenging to manage stylesheets securely. The current implementation of JSS supports nonce for CSP, but it does not support the direct use of a `CSSStyleSheet` instance created and managed outside of JSS. This limitation hinders the ability to inject styles into a secure `CSSStyleSheet`, especially in environments where the nonce value is not exposed.

### Solution
The proposed solution allows users to provide a `CSSStyleSheet` instance as the `insertionPoint` in the `DomRenderer` class. The changes include:

- Updating the constructor of `DomRenderer` to accept a `CSSStyleSheet` instance.
- Modifying the `insertStyle` method to handle `CSSStyleSheet` instances.
- Maintaining support for nonce while providing an alternative for environments where the nonce value is not exposed.

### Changes
- Updated `DomRenderer` constructor to check if `insertionPoint` is an instance of `CSSStyleSheet` and use it directly if true.
- Modified `insertStyle` method to insert rules into the provided `CSSStyleSheet` instance.
- Maintained the setting of nonce attribute while providing an alternative for environments where the nonce value is not exposed.

### Impact
This change enhances the security and flexibility of JSS by allowing styles to be injected into a `CSSStyleSheet` instance, which is particularly useful in CSP enabled environments. It ensures that JSS can be used in a wider range of applications with strict security policies, even when the nonce value is not exposed.

### Testing
The changes have been tested in a CSP enabled environment to ensure that styles are correctly injected into the provided `CSSStyleSheet` instance without violating CSP rules.



## Corresponding Issue(s): <!-- (if relevant) -->

## What Would You Like to Add/Fix?

## Todo

- [ ] Add test(s) that verify the modified behavior
- [x] Add documentation if it changes public API

## Expectations on Changes

<!--
1. Please don't do code changes and move code around in the same PR, even if you are making code better. Make sure the reviewer can see just the changes which fix the problem. This can make your Code Review much more accessible in complex situations; otherwise, it might never get merged even if it is correct because it's impossible to review without reimplementing every change.
2. Often, submitting a failing test is more critical than the fix. Fixing the problem can be challenging and has many ways. Offering an excellent failing test is often 80% of the solution.
3. Please review your PR before submitting it as if you are the reviewer. This way, you show respect for the maintainer's time.
-->

## Changelog

<!--
Please summarize the changes in a way that makes sense inside the changelog. Feel free to add migration tips or examples if necessary.
-->
